### PR TITLE
[SA-0] Notify URL cannot be empty string

### DIFF
--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -129,7 +129,7 @@ func PerformBackup(opts *BackupOpts) error {
 				}
 				log.Debug(respBody)
 				log.Debug(err)
-				return fmt.Errorf("%w", err)
+				return err
 			}
 			backupID := res.GetId()
 


### PR DESCRIPTION
Run against v16 API renders a Validation failure because of the NotifyURL field being sent as an empty string if not set. This is only sets the value is it is not an empty string.