### PR TITLE
Add no-verify flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,7 @@ func NewCmdRoot() *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file")
 	rootCmd.PersistentFlags().BoolVar(&cfg.Debug, "debug", false, "Enable debug logging")
 	rootCmd.PersistentFlags().IntVar(&cfg.Version, "api-version", cfg.Version, "peer API version override")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Insecure, "no-verify", cfg.Insecure, "don't verify TLS on for this particular command, overriding settings from config file")
 	initConfig()
 
 	viper.Unmarshal(cfg)


### PR DESCRIPTION
Add global flag to override TLS verification from settings when running a particular command. Example usage:
```bash
# If insecure is set to false in configuration and a certificate is presented on the requests, this will error
$ appgatectl appliance list
Get "https://www.acmesdp.com/admin/appliances?orderBy=name": x509: certificate signed by unknown authority
```
```bash
# Using the --no-verify flag will override the settings from config file, but will not persist for the upcoming commands
$ appgatectl appliance list --no-verify
Name                                                          Hostname                       Site                Activated
controller-ba0f22b3-6a1f-4b8b-a31c-4430285f7b5e-site1         controller.devops              Default Site        true
```