### PR TITLE
support HTTP_PROXY for the api client

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -52,6 +52,9 @@ APPGATECTL_CONFIG_DIR: the directory where appgatectl will store configuration f
 
 APPGATECTL_LOG_LEVEL: application log level, default to INFO
 
+HTTP_PROXY: HTTP Proxy for the client
+    Example:  HTTP_PROXY="http://proxyIp:proxyPort"
+
 `
 
 func NewHelpCmd(f *factory.Factory) *cobra.Command {

--- a/pkg/factory/http.go
+++ b/pkg/factory/http.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -66,7 +67,13 @@ func httpClientFunc(f *Factory) func() (*http.Client, error) {
 			}).Dial,
 			TLSHandshakeTimeout: timeoutDuration * time.Second,
 		}
-
+		if key, ok := os.LookupEnv("HTTP_PROXY"); ok {
+			proxyURL, err := url.Parse(key)
+			if err != nil {
+				return nil, err
+			}
+			tr.Proxy = http.ProxyURL(proxyURL)
+		}
 		c := &http.Client{
 			Transport: tr,
 			Timeout:   ((timeoutDuration * 2) * time.Second),


### PR DESCRIPTION
Support HTTP proxy for the client.
Usage:
    `HTTP_PROXY="http://proxyIp:proxyPort"`