### PR TITLE
include OS and Arch in snapshot build name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,7 @@ builds:
       - darwin
     goarch:
       - amd64
+    binary: '{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}'
     ldflags:
     - -s -w -X "github.com/appgate/appgatectl/cmd.version={{ .Env.RELEASE_VERSION }}"
     - -X "github.com/appgate/appgatectl/cmd.commit={{ .Commit }}"


### PR DESCRIPTION
This will make it easier for our internal snapshot of main easier to distinguish what platform it is. And allow us to easier to integrate downstream with our other artifacts internally.

example

jq . dist/artifacts.json
```json
[
  {
    "name": "appgatectl_linux_amd64",
    "path": "/go/src/github.com/user/repo/dist/appgatectl_linux_amd64/appgatectl_linux_amd64",
    "goos": "linux",
    "goarch": "amd64",
    "type": "Binary",
    "extra": {
      "Binary": "appgatectl_linux_amd64",
      "Ext": "",
      "ID": "appgatectl"
    }
  },
  {
    "name": "appgatectl_darwin_amd64",
    "path": "/go/src/github.com/user/repo/dist/appgatectl_darwin_amd64/appgatectl_darwin_amd64",
    "goos": "darwin",
    "goarch": "amd64",
    "type": "Binary",
    "extra": {
      "Binary": "appgatectl_darwin_amd64",
      "Ext": "",
      "ID": "appgatectl"
    }
  },
  {
    "name": "appgatectl_windows_amd64.exe",
    "path": "/go/src/github.com/user/repo/dist/appgatectl_windows_amd64/appgatectl_windows_amd64.exe",
    "goos": "windows",
    "goarch": "amd64",
    "type": "Binary",
    "extra": {
      "Binary": "appgatectl_windows_amd64",
      "Ext": ".exe",
      "ID": "appgatectl"
    }
  }
]

```