### PR TITLE
upgrade cancel filter out offline appliances

### DIFF
--- a/cmd/appliance/upgrade/cancel_test.go
+++ b/cmd/appliance/upgrade/cancel_test.go
@@ -29,6 +29,10 @@ func TestUpgradeCancelCommand(t *testing.T) {
 			name: "test cancel multiple appliances",
 			httpStubs: []httpmock.Stub{
 				{
+					URL:       "/stats/appliances",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/stats_appliance.json"),
+				},
+				{
 					URL:       "/appliances",
 					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/appliance_list.json"),
 				},
@@ -50,6 +54,10 @@ func TestUpgradeCancelCommand(t *testing.T) {
 			name: "test cancel multiple appliances no acceptance",
 			httpStubs: []httpmock.Stub{
 				{
+					URL:       "/stats/appliances",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/stats_appliance.json"),
+				},
+				{
 					URL:       "/appliances",
 					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/appliance_list.json"),
 				},
@@ -70,6 +78,10 @@ func TestUpgradeCancelCommand(t *testing.T) {
 		{
 			name: "Test no appliance idle upgrade status",
 			httpStubs: []httpmock.Stub{
+				{
+					URL:       "/stats/appliances",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/stats_appliance.json"),
+				},
 				{
 					URL:       "/appliances",
 					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/appliance_list.json"),


### PR DESCRIPTION
upgrade cancel filter out offline appliances to avoid doing illegal http request on a appliance that is offline.