### PR TITLE
Filter disk space warning

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -187,11 +187,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	}
 
 	if hasLowDiskSpace := appliancepkg.HasLowDiskSpace(initialStats.GetData()); len(hasLowDiskSpace) > 0 {
-		msg, err := appliancepkg.ShowDiskSpaceWarningMessage(hasLowDiskSpace)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(opts.Out, "\n%s\n", msg)
+		appliancepkg.PrintDiskSpaceWarningMessage(opts.Out, hasLowDiskSpace)
 		if !opts.NoInteractive {
 			if err := prompt.AskConfirmation(); err != nil {
 				return err

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -210,11 +210,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		return err
 	}
 	if hasLowDiskSpace := appliancepkg.HasLowDiskSpace(initialStats.GetData()); len(hasLowDiskSpace) > 0 {
-		msg, err := appliancepkg.ShowDiskSpaceWarningMessage(hasLowDiskSpace)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(opts.Out, "\n%s\n", msg)
+		appliancepkg.PrintDiskSpaceWarningMessage(opts.Out, hasLowDiskSpace)
 		if !opts.NoInteractive {
 			if err := prompt.AskConfirmation(); err != nil {
 				return err

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -3,6 +3,7 @@ package appliance
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"text/template"
@@ -11,31 +12,19 @@ import (
 	"github.com/appgate/sdpctl/pkg/util"
 )
 
-const showDiskSpaceWarning = `
-Some appliances have very little space available
-{{range .Stats}}
-  - {{ .Name }}  Disk usage: {{ .Disk -}}%
-{{- end}}
+func PrintDiskSpaceWarningMessage(out io.Writer, stats []openapi.StatsAppliancesListAllOfData) {
+	p := util.NewPrinter(out)
+	p.AddHeader("Name", "Disk Usage")
+	for _, a := range stats {
+		p.AddLine(a.GetName(), fmt.Sprintf("%v%%", a.GetDisk()))
+	}
 
+	fmt.Fprint(out, "\nWARNING: Some appliances have very little space available\n\n")
+	p.Print()
+	fmt.Fprintln(out, `
 Upgrading requires the upload and decompression of big images.
 To avoid problems during the upgrade process it's recommended to
-increase the space on those appliances.
-`
-
-func ShowDiskSpaceWarningMessage(stats []openapi.StatsAppliancesListAllOfData) (string, error) {
-	type stub struct {
-		Stats []openapi.StatsAppliancesListAllOfData
-	}
-	data := stub{
-		Stats: stats,
-	}
-	t := template.Must(template.New("").Parse(showDiskSpaceWarning))
-	var tpl bytes.Buffer
-	if err := t.Execute(&tpl, data); err != nil {
-		return "", err
-	}
-
-	return tpl.String(), nil
+increase the space on those appliances.`)
 }
 
 func HasLowDiskSpace(stats []openapi.StatsAppliancesListAllOfData) []openapi.StatsAppliancesListAllOfData {

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -1,6 +1,7 @@
 package appliance
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
@@ -8,15 +9,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestShowDiskSpaceWarningMessage(t *testing.T) {
+func TestPrintDiskSpaceWarningMessage(t *testing.T) {
 	type args struct {
 		stats []openapi.StatsAppliancesListAllOfData
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
+		name string
+		args args
+		want string
 	}{
 		{
 			name: "warning",
@@ -35,10 +35,12 @@ func TestShowDiskSpaceWarningMessage(t *testing.T) {
 				},
 			},
 			want: `
-Some appliances have very little space available
+WARNING: Some appliances have very little space available
 
-  - controller  Disk usage: 90%
-  - controller2  Disk usage: 75%
+Name         Disk Usage
+----         ----------
+controller   90%
+controller2  75%
 
 Upgrading requires the upload and decompression of big images.
 To avoid problems during the upgrade process it's recommended to
@@ -48,13 +50,10 @@ increase the space on those appliances.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ShowDiskSpaceWarningMessage(tt.args.stats)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ShowDiskSpaceWarningMessage() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !cmp.Equal(got, tt.want) {
-				t.Fatalf("\nGot: \n %q \n\n Want: \n %q \n", got, tt.want)
+			var b bytes.Buffer
+			PrintDiskSpaceWarningMessage(&b, tt.args.stats)
+			if res := b.String(); res != tt.want {
+				t.Errorf("ShowDiskSpaceWarning() - want: %s, got: %s", tt.want, res)
 			}
 		})
 	}


### PR DESCRIPTION
Disk space warning message does not filter out appliances that don't have low disk space. This makes the disk space warning message too crowded.

Disk space warning now prints only the appliances that has 75% disk usage or more in a table.

This addresses that by filtering out and showing only appliances that have low disk space when printing the warning message.

Fixes:
- SA-18493

Sample output:
```
WARNING: Some appliances have very little space available

Name         Disk Usage
----         ----------
controller   90%
controller2  75%

Upgrading requires the upload and decompression of big images.
To avoid problems during the upgrade process it's recommended to
increase the space on those appliances.
```