### PR TITLE
updated to version from 1.16 to 1.18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,10 @@ jobs:
     name: "Static analysis"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: WillAbides/setup-go-faster@v1.5.0
+      - uses: WillAbides/setup-go-faster@v1.7.0
         with:
-          go-version: "1.16.x"
-      - run: "GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck"
+          go-version: "1.17.x"
+      - run: "GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.2.2"
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
@@ -22,4 +22,4 @@ jobs:
           restore-keys: |
             staticcheck-
       - run: "go vet ./..."
-      - run: "$(go env GOPATH)/bin/staticcheck -go 1.15 ./..."
+      - run: "$(go env GOPATH)/bin/staticcheck -go 1.18 ./..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.18
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.18
         id: go
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
to support new build tags

patch: update github action WillAbides/setup-go-faster

this resolves the latest build failure from main https://github.com/appgate/sdpctl/actions/runs/2056609875