### PR TITLE
Add spinner while waiting for server response

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -272,6 +272,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	}
 
 	// Step 1
+	p := mpb.New()
 	shouldUpload := false
 	fileStatusCtx, fileStatusCancel := context.WithTimeout(ctx, opts.timeout)
 	defer fileStatusCancel()
@@ -297,7 +298,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			return err
 		}
 		defer imageFile.Close()
-		if err := a.UploadFile(ctx, imageFile); err != nil {
+		if err := a.UploadFile(ctx, imageFile, p); err != nil {
 			return err
 		}
 
@@ -310,6 +311,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}
 		log.WithField("file", remoteFile.GetName()).Infof("Status %s", remoteFile.GetStatus())
 	}
+	p.Wait()
 
 	// Step 2
 	remoteFilePath := fmt.Sprintf("controller://%s/%s", primaryController.GetHostname(), opts.filename)


### PR DESCRIPTION
When preparing an image for upload, there's a long delay between finishing the file upload and the verification on the appliances. The delay occurs because the controller takes quite a while to respond back after the upload is finished. Currently this delay makes it appear as the script is stuck as there is nothing showing that's it's actually waiting.

This alleviates the long delay by queuing up a spinner after the upload progress bar. This spinner will keep spinning until the server actually responds. 