### PR TITLE
status check appliance backwards compatibility

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -442,7 +442,7 @@ func showPrepareUpgradeMessage(f string, appliance []openapi.Appliance, stats []
 					Online:         "Offline ⨯",
 				}
 
-				if stat.GetOnline() {
+				if appliancepkg.StatsIsOnline(stat) {
 					i.Online = "Online ✓"
 				}
 				data.Appliances = append(data.Appliances, i)

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -1970,3 +1970,121 @@ func TestActiveSitesInAppliances(t *testing.T) {
 		})
 	}
 }
+
+func TestStatsIsOnline(t *testing.T) {
+	type args struct {
+		s openapi.StatsAppliancesListAllOfData
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "pre 6.0 online",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Online: openapi.PtrBool(true),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "online nil value",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Online: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pre 6.0 offline",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Online: openapi.PtrBool(false),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "status nil",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Status: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "status offline",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Status: openapi.PtrString("offline"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "status healthy",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Status: openapi.PtrString("healthy"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "status warning",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Status: openapi.PtrString("warning"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "status busy",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Status: openapi.PtrString("busy"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "status error",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Status: openapi.PtrString("error"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "status not available",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Status: openapi.PtrString("n/a"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "status unknown",
+			args: args{
+				s: openapi.StatsAppliancesListAllOfData{
+					Status: openapi.PtrString("abc123"),
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StatsIsOnline(tt.args.s); got != tt.want {
+				t.Errorf("StatsIsOnline() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
in appliance >= 6, `'"online": true'`
https://github.com/appgate/sdp-api-specification/blob/version-16/dashboard.yml#L458
has been removed. We will use Status instead if available to check if a appliance is != online