### PR TITLE
Host on controller flag

### DIFF
--- a/cmd/appliance/upgrade/cancel.go
+++ b/cmd/appliance/upgrade/cancel.go
@@ -112,6 +112,7 @@ func upgradeCancelRun(cmd *cobra.Command, args []string, opts *upgradeCancelOpti
 		}
 	}
 
+	fmt.Fprint(opts.Out, "Cancelling prepared upgrades:\n")
 	cancel := func(ctx context.Context, appliances []openapi.Appliance) ([]openapi.Appliance, error) {
 		g, ctx := errgroup.WithContext(ctx)
 		cancelChan := make(chan openapi.Appliance, len(appliances))

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -425,7 +425,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 		fmt.Fprint(opts.Out, "\nUpgrading primary controller:\n")
 		primaryP := mpb.New(mpb.WithOutput(opts.Out))
 		statusReport := make(chan string)
-		a.UpgradeStatusWorker.Watch(pctx, primaryP, *primaryController, ctrlUpgradeState, statusReport)
+		a.UpgradeStatusWorker.Watch(pctx, primaryP, *primaryController, ctrlUpgradeState, appliancepkg.UpgradeStatusFailed, statusReport)
 		log.WithField("appliance", primaryController.GetName()).Info("Completing upgrade and switching partition")
 		if err := a.UpgradeComplete(pctx, primaryController.GetId(), true); err != nil {
 			close(statusReport)
@@ -461,7 +461,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				log.WithField("appliance", i.GetName()).Info("checking if ready")
 				statusReport := make(chan string)
 				defer close(statusReport)
-				a.UpgradeStatusWorker.Watch(bctx, p, i, finalState, statusReport)
+				a.UpgradeStatusWorker.Watch(bctx, p, i, finalState, appliancepkg.UpgradeStatusFailed, statusReport)
 				if err := a.UpgradeComplete(bctx, i.GetId(), SwitchPartition); err != nil {
 					close(statusReport)
 					return err
@@ -543,7 +543,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			}
 			statusReport := make(chan string)
 			defer close(statusReport)
-			a.UpgradeStatusWorker.Watch(ctx, ctrlP, ctrl, finalState, statusReport)
+			a.UpgradeStatusWorker.Watch(ctx, ctrlP, ctrl, finalState, appliancepkg.UpgradeStatusFailed, statusReport)
 			if err := a.UpgradeComplete(ctx, ctrl.GetId(), true); err != nil {
 				close(statusReport)
 				ctrlCancel()

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -32,7 +32,7 @@ func (u *mockUpgradeStatus) Wait(ctx context.Context, appliance openapi.Applianc
 	return nil
 }
 
-func (u *mockUpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, current <-chan string) {
+func (u *mockUpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, failState string, current <-chan string) {
 }
 
 type errorUpgradeStatus struct{}
@@ -41,7 +41,7 @@ func (u *errorUpgradeStatus) Wait(ctx context.Context, appliance openapi.Applian
 	return fmt.Errorf("gateway never reached %s, got failed", desiredStatus)
 }
 
-func (u *errorUpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, current <-chan string) {
+func (u *errorUpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, failState string, current <-chan string) {
 }
 
 func NewApplianceCmd(f *factory.Factory) *cobra.Command {

--- a/pkg/appliance/status.go
+++ b/pkg/appliance/status.go
@@ -15,7 +15,7 @@ import (
 
 type WaitForUpgradeStatus interface {
 	Wait(ctx context.Context, appliance openapi.Appliance, desiredStatus string, current chan<- string) error
-	Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, current <-chan string)
+	Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, failState string, current <-chan string)
 }
 
 type UpgradeStatus struct {
@@ -137,7 +137,7 @@ func (u *ApplianceStatus) WaitForState(ctx context.Context, appliance openapi.Ap
 	}, b)
 }
 
-func (u *UpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, current <-chan string) {
+func (u *UpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, failState string, current <-chan string) {
 	go func() {
 		log.WithField("appliance", appliance.GetName()).Info("Watching for appliance state")
 		endMsg := "completed"
@@ -158,7 +158,7 @@ func (u *UpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance op
 					"status":           status,
 					"spinnerCompleted": spinner.Completed(),
 				}).Debug("Completing spinner")
-			case UpgradeStatusFailed:
+			case failState:
 				spinner.Abort(false)
 				log.WithFields(log.Fields{
 					"appliance":      appliance.GetName(),


### PR DESCRIPTION
Implements a  `--host-on-controller` flag. With this flag, the upgrade image is first downloaded by the primary controller from the specified URL. The other appliances will then download the upgrade image from the primary controller instead of directly from the URL. This flag is ignored if the upgrade image is uploaded from the local file system.

Fixes:
- SA-18873