### PR TITLE
new command: sdpctl configure get

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -44,6 +44,7 @@ SDPCTL_CONFIG_DIR=<path/to/config/dir sdpctl configure`,
 	cmd.Flags().StringVar(&opts.PEM, "pem", "", "Path to PEM file to use for request certificate validation")
 
 	cmd.AddCommand(NewSigninCmd(f))
+	cmd.AddCommand(NewConfigGetCmd(f))
 
 	return cmd
 }

--- a/cmd/configure/get.go
+++ b/cmd/configure/get.go
@@ -1,0 +1,47 @@
+package configure
+
+import (
+	"fmt"
+
+	"github.com/appgate/sdpctl/pkg/configuration"
+	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/appgate/sdpctl/pkg/hashcode"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// NewConfigGetCmd return a new config command
+func NewConfigGetCmd(f *factory.Factory) *cobra.Command {
+	return &cobra.Command{
+		Use: "get",
+		Annotations: map[string]string{
+			"skipAuthCheck": "true",
+		},
+		Short:  "Print current config to stdout",
+		Long:   "Show computed config based on environment variables and config file (username and password is excluded)",
+		Hidden: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			out := f.IOOutWriter
+			stderr := f.StdErr
+
+			fmt.Fprintf(out, "\nComputed Configuration:\n")
+			addr, err := configuration.NormalizeURL(f.Config.URL)
+			if err != nil {
+				fmt.Fprintf(stderr, "[ERROR] NormalizeURL %s", err)
+			}
+			fmt.Fprintf(out, "NormalizeURL: %s\n", addr)
+			for k, v := range viper.GetViper().AllSettings() {
+				fmt.Fprintf(out, "%s: %+v\n", k, v)
+			}
+
+			h, err := f.Config.GetHost()
+			if err != nil {
+				fmt.Fprintf(stderr, "[ERROR] GetHost %s", err)
+			}
+			fmt.Fprintf(out, "Host: %s\n", h)
+			fmt.Fprintf(out, "Host hashcode: %d\n", hashcode.String(h))
+
+			return nil
+		},
+	}
+}

--- a/pkg/factory/http.go
+++ b/pkg/factory/http.go
@@ -27,7 +27,7 @@ type Factory struct {
 	Config      *configuration.Config
 	IOOutWriter io.Writer
 	Stdin       io.Reader
-	StdErr      io.Reader
+	StdErr      io.Writer
 }
 
 func New(appVersion string, config *configuration.Config) *Factory {
@@ -39,6 +39,7 @@ func New(appVersion string, config *configuration.Config) *Factory {
 	f.Token = tokenFunc(f, appVersion)         // depends on config
 	f.IOOutWriter = os.Stdout
 	f.Stdin = os.Stdin
+	f.StdErr = os.Stderr
 	return f
 }
 


### PR DESCRIPTION
Print current config to stdout
Show computed config based on environment variables and config file (username and password is excluded), this command is hidden by default and wont show up during --help or list view (and autocomplete)