### PR TITLE
Upgrade API to v17

### DIFF
--- a/cmd/appliance/backup/api.go
+++ b/cmd/appliance/backup/api.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"

--- a/cmd/appliance/backup/api_test.go
+++ b/cmd/appliance/backup/api_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/backup/backup_test.go
+++ b/cmd/appliance/backup/backup_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/list_test.go
+++ b/cmd/appliance/list_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/metric.go
+++ b/cmd/appliance/metric.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"

--- a/cmd/appliance/metric_test.go
+++ b/cmd/appliance/metric_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/resolve_name.go
+++ b/cmd/appliance/resolve_name.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"

--- a/cmd/appliance/resolve_name_status.go
+++ b/cmd/appliance/resolve_name_status.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"

--- a/cmd/appliance/resolve_name_status_test.go
+++ b/cmd/appliance/resolve_name_status_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/resolve_name_test.go
+++ b/cmd/appliance/resolve_name_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/stats.go
+++ b/cmd/appliance/stats.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"

--- a/cmd/appliance/stats_test.go
+++ b/cmd/appliance/stats_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/upgrade/cancel.go
+++ b/cmd/appliance/upgrade/cancel.go
@@ -9,7 +9,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"

--- a/cmd/appliance/upgrade/cancel_test.go
+++ b/cmd/appliance/upgrade/cancel_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -14,7 +14,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/cmdutil"
 	"github.com/appgate/sdpctl/pkg/configuration"

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2/core"
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/upgrade/status_test.go
+++ b/cmd/appliance/upgrade/status_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/token/list_test.go
+++ b/cmd/token/list_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/httpmock"

--- a/cmd/token/revoke.go
+++ b/cmd/token/revoke.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/spf13/cobra"

--- a/cmd/token/revoke_test.go
+++ b/cmd/token/revoke_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/httpmock"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.4
-	github.com/appgate/sdp-api-client-go v1.0.7-0.20211229102702-55d570847963
+	github.com/appgate/sdp-api-client-go v1.0.7-0.20220502093424-6e14652717a2
 	github.com/billgraziano/dpapi v0.4.0
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cheynewallace/tabby v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/appgate/sdp-api-client-go v1.0.7-0.20211229102702-55d570847963 h1:wpa8wqY3XrJbmbK0PvvNycExwKX2uNoNGa6g/h85yOI=
-github.com/appgate/sdp-api-client-go v1.0.7-0.20211229102702-55d570847963/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20220502093424-6e14652717a2 h1:BaMZXTkmDILzBqL/FrE1ycSipw2tJgMieLiqMGwT12M=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20220502093424-6e14652717a2/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/hashicorp/go-version"

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/prompt"

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/util"
 )
 

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/hashcode"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/hashicorp/go-multierror"

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/hashcode"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/pkg/appliance/status.go
+++ b/pkg/appliance/status.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"

--- a/pkg/auth/mfa.go
+++ b/pkg/auth/mfa.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 )
 

--- a/pkg/auth/mfa_test.go
+++ b/pkg/auth/mfa_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/httpmock"
 )
 

--- a/pkg/auth/signin.go
+++ b/pkg/auth/signin.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/pkg/auth/signin_test.go
+++ b/pkg/auth/signin_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/pkg/factory/http.go
+++ b/pkg/factory/http.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/appgate/sdpctl/pkg/token"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/util"

--- a/pkg/httpmock/http.go
+++ b/pkg/httpmock/http.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"testing/fstest"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/google/go-cmp/cmp"
 )

--- a/pkg/token/api.go
+++ b/pkg/token/api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 )
 


### PR DESCRIPTION
This upgrades the API version used by sdpctl to v17.

Manual testing:
- [x] `configure` and `configure signin`
- [x] `appliance backup`
- [x] `appliance upgrade`
- [x] `appliance list`

Manual testing also includes usage of most of the flas. No issues have been ancountered as a result of this update during testing.

Automatic test output:
```bash
go test ./... -count 1 -timeout 30s
?   	github.com/appgate/sdpctl	[no test files]
?   	github.com/appgate/sdpctl/cmd	[no test files]
ok  	github.com/appgate/sdpctl/cmd/appliance	0.014s
ok  	github.com/appgate/sdpctl/cmd/appliance/backup	1.091s
ok  	github.com/appgate/sdpctl/cmd/appliance/upgrade	1.604s
?   	github.com/appgate/sdpctl/cmd/configure	[no test files]
ok  	github.com/appgate/sdpctl/cmd/token	0.024s
?   	github.com/appgate/sdpctl/pkg/api	[no test files]
ok  	github.com/appgate/sdpctl/pkg/appliance	0.187s
ok  	github.com/appgate/sdpctl/pkg/auth	0.117s
?   	github.com/appgate/sdpctl/pkg/cmdutil	[no test files]
ok  	github.com/appgate/sdpctl/pkg/configuration	0.018s
?   	github.com/appgate/sdpctl/pkg/docs	[no test files]
ok  	github.com/appgate/sdpctl/pkg/factory	0.019s
ok  	github.com/appgate/sdpctl/pkg/filesystem	0.012s
ok  	github.com/appgate/sdpctl/pkg/hashcode	0.012s
?   	github.com/appgate/sdpctl/pkg/httpmock	[no test files]
ok  	github.com/appgate/sdpctl/pkg/keyring	0.003s
ok  	github.com/appgate/sdpctl/pkg/prompt	0.002s
ok  	github.com/appgate/sdpctl/pkg/queue	0.002s
?   	github.com/appgate/sdpctl/pkg/token	[no test files]
ok  	github.com/appgate/sdpctl/pkg/util	0.002s
go test ./... -race -covermode=atomic -coverprofile=cover.out -timeout 60s
?   	github.com/appgate/sdpctl	[no test files]
?   	github.com/appgate/sdpctl/cmd	[no test files]
ok  	github.com/appgate/sdpctl/cmd/appliance	0.081s	coverage: 74.0% of statements
ok  	github.com/appgate/sdpctl/cmd/appliance/backup	1.175s	coverage: 84.2% of statements
ok  	github.com/appgate/sdpctl/cmd/appliance/upgrade	2.009s	coverage: 69.0% of statements
?   	github.com/appgate/sdpctl/cmd/configure	[no test files]
ok  	github.com/appgate/sdpctl/cmd/token	0.094s	coverage: 69.7% of statements
?   	github.com/appgate/sdpctl/pkg/api	[no test files]
ok  	github.com/appgate/sdpctl/pkg/appliance	0.173s	coverage: 36.3% of statements
ok  	github.com/appgate/sdpctl/pkg/auth	0.221s	coverage: 64.7% of statements
?   	github.com/appgate/sdpctl/pkg/cmdutil	[no test files]
ok  	github.com/appgate/sdpctl/pkg/configuration	0.031s	coverage: 48.3% of statements
?   	github.com/appgate/sdpctl/pkg/docs	[no test files]
ok  	github.com/appgate/sdpctl/pkg/factory	0.210s	coverage: 51.5% of statements
ok  	github.com/appgate/sdpctl/pkg/filesystem	0.039s	coverage: 90.9% of statements
ok  	github.com/appgate/sdpctl/pkg/hashcode	0.046s	coverage: 50.0% of statements
?   	github.com/appgate/sdpctl/pkg/httpmock	[no test files]
ok  	github.com/appgate/sdpctl/pkg/keyring	0.029s	coverage: 70.0% of statements
ok  	github.com/appgate/sdpctl/pkg/prompt	0.021s	coverage: 57.5% of statements
ok  	github.com/appgate/sdpctl/pkg/queue	0.025s	coverage: 92.9% of statements
?   	github.com/appgate/sdpctl/pkg/token	[no test files]
ok  	github.com/appgate/sdpctl/pkg/util	0.026s	coverage: 15.7% of statements
```