### PR TITLE
Pipeline mod and first tag

### DIFF
--- a/.github/workflows/release-flow.yml
+++ b/.github/workflows/release-flow.yml
@@ -2,17 +2,17 @@ name: Release Flow
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v*
 
 jobs:
   test:
+    if: ${{ github.event.base_ref == 'refs/heads/main' }}
     uses: ./.github/workflows/test.yml
   lint:
+    if: ${{ github.event.base_ref == 'refs/heads/main' }}
     uses: ./.github/workflows/lint.yml
   release:
-    if: ${{ github.ref_type == 'tag' }}
+    if: ${{ github.event.base_ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yml
     needs: [test, lint]


### PR DESCRIPTION
Modifies the github actions flow so that the release flow only runs on the main branch when tagging, otherwise it will skip.
