### PR TITLE
Use default timeout in defaultExponentialBackoff

### DIFF
--- a/cmd/appliance/upgrade/upgrade.go
+++ b/cmd/appliance/upgrade/upgrade.go
@@ -27,7 +27,7 @@ func NewUpgradeCmd(f *factory.Factory) *cobra.Command {
 	upgradeCmd.AddCommand(NewUpgradeCompleteCmd(f))
 
 	flags := upgradeCmd.PersistentFlags()
-	flags.DurationP("timeout", "t", 30*time.Minute, "Timeout for the upgrade operation. The timeout applies to each appliance which is being operated on.")
+	flags.DurationP("timeout", "t", DefaultTimeout, "Timeout for the upgrade operation. The timeout applies to each appliance which is being operated on.")
 
 	return upgradeCmd
 }

--- a/pkg/appliance/status.go
+++ b/pkg/appliance/status.go
@@ -13,6 +13,8 @@ import (
 	"github.com/vbauerster/mpb/v7"
 )
 
+const DefaultTimeout = time.Minute * 30
+
 type WaitForUpgradeStatus interface {
 	// Wait does expodential backoff retries on upgrade status and return nil if it reaches any of the desiredStatuses
 	Wait(ctx context.Context, appliance openapi.Appliance, desiredStatuses []string) error
@@ -31,7 +33,7 @@ var defaultExponentialBackOff = &backoff.ExponentialBackOff{
 	Multiplier:          2,
 	RandomizationFactor: 0.7,
 	MaxInterval:         10 * time.Second,
-	MaxElapsedTime:      10 * time.Minute,
+	MaxElapsedTime:      DefaultTimeout,
 	Stop:                backoff.Stop,
 	Clock:               backoff.SystemClock,
 }


### PR DESCRIPTION
Applies default timeout to defaultExpontentialBackoff to not have the backoff timeout before the context