### PR TITLE
Cancel upgrades already prepared on condition

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -267,7 +267,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 		log.WithContext(ctx).WithError(err).Error("Failed to get upgrade status")
 		return err
 	}
-	newVersion, err := appliancepkg.NormalizeVersion(primaryControllerUpgradeStatus.GetDetails())
+	newVersion, err := appliancepkg.ParseVersionString(primaryControllerUpgradeStatus.GetDetails())
 	if err != nil {
 		log.WithContext(ctx).WithError(err).Error("Failed to determine upgrade version")
 	}

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -286,7 +286,7 @@ func ActiveSitesInAppliances(slice []openapi.Appliance) int {
 func GetApplianceVersion(appliance openapi.Appliance, stats openapi.StatsAppliancesList) (*version.Version, error) {
 	for _, s := range stats.GetData() {
 		if s.GetId() == appliance.GetId() {
-			return NormalizeVersion(s.GetVersion())
+			return ParseVersionString(s.GetVersion())
 		}
 	}
 	return nil, fmt.Errorf("could not determine appliance version %s", appliance.GetName())
@@ -590,13 +590,6 @@ func StatsIsOnline(s openapi.StatsAppliancesListAllOfData) bool {
 	}
 	// unkown or empty status will report appliance as offline.
 	return util.InSlice(s.GetStatus(), []string{statsHealthy, statsBusy, statsWarning, statsError})
-}
-
-func NormalizeVersion(s string) (*version.Version, error) {
-	regex := regexp.MustCompile(`\d+\.\d+\.\d+([-|\+]?\d+)?`)
-	match := regex.FindString(s)
-	vString := strings.ReplaceAll(match, "-", "+")
-	return version.NewVersion(vString)
 }
 
 func ShouldDisable(from, to *version.Version) bool {

--- a/pkg/appliance/helpers_test.go
+++ b/pkg/appliance/helpers_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	Appliance54Constraints, _ = version.NewConstraint(">= 5.4.0, < 5.5.0")
-	Appliance55Constraints, _ = version.NewConstraint(">= 5.5.0, < 5.6.0")
+	Appliance54Constraints, _ = version.NewConstraint(">= 5.4.0-*, < 5.5.0")
+	Appliance55Constraints, _ = version.NewConstraint(">= 5.5.0-*, < 5.6.0")
 )
 
 func TestGuessVersion(t *testing.T) {
@@ -49,13 +49,13 @@ func TestGuessVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GuessVersion(tt.args.f)
+			got, err := ParseVersionString(tt.args.f)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("GuessVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if (got != nil) && !tt.constraints.Check(got) {
-				t.Errorf("%s did not satisfies constraints %s", got, tt.constraints)
+				t.Errorf("%s does not satisfy constraints %s", got, tt.constraints)
 			}
 		})
 	}


### PR DESCRIPTION
This will cancel pending prepared upgrades when preparing another upgrade image given that the pending upgrades are the same version or older then the one being uploaded.

Parsing of version string and constraints is needed a bit of refinement for this.