### PR TITLE
handle queue failures even after downloading is finished

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -376,7 +376,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				appliancepkg.UpgradeStatusReady,
 			}
 			// prepareReady is used for the status bars to mark them as ready if everything is successful.
-			prepareReady = []string{appliancepkg.UpgradeStatusReady, appliancepkg.UpgradeStatusSuccess}
+			prepareReady = []string{appliancepkg.UpgradeStatusReady}
 		)
 
 		updateProgressBars := mpb.New(mpb.WithOutput(spinnerOut))
@@ -459,6 +459,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				return nil
 			})
 			if err != nil {
+				log.WithError(err).Error("failed during download stage")
 				queueContinue <- continueStruct{err: err}
 			}
 			close(queueContinue)
@@ -472,7 +473,8 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				continue
 			}
 			ctx, cancel := context.WithDeadline(context.Background(), qc.deadline)
-			if err := a.UpgradeStatusWorker.Wait(ctx, qc.appliance, []string{appliancepkg.UpgradeStatusReady, appliancepkg.UpgradeStatusFailed}); err != nil {
+			if err := a.UpgradeStatusWorker.Wait(ctx, qc.appliance, []string{appliancepkg.UpgradeStatusReady}); err != nil {
+				log.WithError(err).Error("failed during verifying stage")
 				errs = multierr.Append(errs, err)
 			}
 			cancel()


### PR DESCRIPTION
When preparing an upgrade and the prepare fails the verification, the command will now complete with a non-zero exit code.

After the download phase is completed and the next item is released onto the queue, this fix will make sure we still wait for each appliance to complete the upgrade image preparation, either by succeeding or failing. The timeout is also passed along between the phases.

Fixes:
- SA-19282