### PR TITLE
resolve non-interactive auth

### DIFF
--- a/cmd/configure/signin.go
+++ b/cmd/configure/signin.go
@@ -12,8 +12,7 @@ import (
 )
 
 type signinOptions struct {
-	f          *factory.Factory
-	noRemember bool
+	f *factory.Factory
 }
 
 // NewSigninCmd return a new signin command
@@ -35,10 +34,6 @@ func NewSigninCmd(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	flags := signinCmd.Flags()
-
-	flags.BoolVar(&opts.noRemember, "no-remember", false, "Do not remember sign in credentials when signin in")
-
 	return signinCmd
 }
 
@@ -47,7 +42,7 @@ func signinRun(cmd *cobra.Command, args []string, opts *signinOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := auth.Signin(opts.f, opts.noRemember, true, noInteractive); err != nil {
+	if err := auth.Signin(opts.f, true, noInteractive); err != nil {
 		return err
 	}
 	log.WithField("config file", viper.ConfigFileUsed()).Info("Sign in event")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -237,7 +237,7 @@ func rootPersistentPreRunEFunc(f *factory.Factory, cfg *configuration.Config) fu
 			if err != nil {
 				return err
 			}
-			if err := auth.Signin(f, false, false, noInteractive); err != nil {
+			if err := auth.Signin(f, false, noInteractive); err != nil {
 				var result error
 				result = multierror.Append(result, err)
 				return result

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -27,31 +27,6 @@ $ SDPCTL_USERNAME=<username> sdpctl configure signin
 ? Password: <password>
 ```
 
-On successful authentication, a token is retrieved and stored in the sdpctl configuration and will be used for all the consecutive commands executed until the token expires. By default, sdpctl will save your signin credentials for re-use. If you don't want sdpctl to remember the credentials, you can pass the `--no-remember` flag when using the `signin` command.
-
-```bash
-$ # Using default credentials prompt
-$ sdpctl configure signin
-? Username: <username>
-? Password: <password>
-? What credentials should be saved? [Use arrows to move, type to filter]
-> both
-  only username
-  only password
-  nothing
-
-$ # Using environment variables
-$ SDPCTL_USERNAME=<username> SDPCTL_PASSWORD=<password> sdpctl configure signin
-? What credentials should be saved? [Use arrows to move, type to filter]
-> both
-  only username
-  only password
-  nothing
-
-$ Do not save credentials when signing in
->sdpctl configure signin --no-remember
-? Username: <username>
-? Password: <password>
 ```
 
 ## Working with multiple appgate sdp collectives

--- a/pkg/auth/signin_test.go
+++ b/pkg/auth/signin_test.go
@@ -125,7 +125,6 @@ var (
 func TestSignin(t *testing.T) {
 	keyring.MockInit()
 	type args struct {
-		noRemember    bool
 		saveConfig    bool
 		noInteractive bool
 	}
@@ -140,7 +139,6 @@ func TestSignin(t *testing.T) {
 		{
 			name: "signin with environment variables",
 			args: args{
-				noRemember: true,
 				saveConfig: false,
 			},
 			environmentVariables: map[string]string{
@@ -164,7 +162,6 @@ func TestSignin(t *testing.T) {
 		{
 			name: "signin prompt username and password",
 			args: args{
-				noRemember: true,
 				saveConfig: false,
 			},
 
@@ -189,7 +186,6 @@ func TestSignin(t *testing.T) {
 		{
 			name: "signin prompt username and password and MFA token",
 			args: args{
-				noRemember: true,
 				saveConfig: false,
 			},
 
@@ -286,7 +282,6 @@ func TestSignin(t *testing.T) {
 		{
 			name: "no auth no-interactive",
 			args: args{
-				noRemember:    true,
 				saveConfig:    false,
 				noInteractive: true,
 			},
@@ -342,7 +337,7 @@ func TestSignin(t *testing.T) {
 			if tt.askStubs != nil {
 				tt.askStubs(stubber)
 			}
-			if err := Signin(f, tt.args.noRemember, tt.args.saveConfig, tt.args.noInteractive); (err != nil) != tt.wantErr {
+			if err := Signin(f, tt.args.saveConfig, tt.args.noInteractive); (err != nil) != tt.wantErr {
 				t.Errorf("Signin() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/docs/configure.go
+++ b/pkg/docs/configure.go
@@ -30,10 +30,6 @@ This will fetch a token on valid authentication which will be valid for 24 hours
 				Description: "default sign in command",
 				Command:     "sdpctl configure signin",
 			},
-			{
-				Description: "do not remember credentials on sign in",
-				Command:     "sdpctl configure signin --no-remember",
-			},
 		},
 	}
 )


### PR DESCRIPTION
removed no-remember flag and respect noInteractive flag

This PR resolves the issues for e2e; if the `--no-remember` flag is requested, we can add it later again when it has been thorughly tested.