### PR TITLE
enabled cgo on macos builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ builds:
   - id: sdpctl_darwin
     main: ./main.go
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - darwin
     goarch:


### PR DESCRIPTION
cgo is needed for macos builds inorder to have working dns resolution, relevant golang bug:

https://github.com/golang/go/issues/12524
