### PR TITLE
Return backup prompt on upgrade complete

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -134,7 +134,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	// if backup is default value (false) and user hasn't explicitly stated the flag, ask if user wants to backup
 	flagIsChanged := cmd.Flags().Changed("backup")
 	toBackup := []openapi.Appliance{}
-	if !opts.backup && !flagIsChanged && !opts.NoInteractive {
+	if !flagIsChanged && !opts.NoInteractive {
 		performBackup := &survey.Confirm{
 			Message: "Do you want to backup before proceeding?",
 			Default: opts.backup,
@@ -295,12 +295,12 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 
 	msg := ""
 	if primaryControllerUpgradeStatus.GetStatus() == appliancepkg.UpgradeStatusReady {
-		msg, err = printCompleteSummary(opts.Out, primaryController, additionalControllers, chunks, offline, toBackup, newVersion)
+		msg, err = printCompleteSummary(opts.Out, primaryController, additionalControllers, chunks, offline, toBackup, opts.backupDestination, newVersion)
 		if err != nil {
 			return err
 		}
 	} else {
-		msg, err = printCompleteSummary(opts.Out, nil, additionalControllers, chunks, offline, toBackup, newVersion)
+		msg, err = printCompleteSummary(opts.Out, nil, additionalControllers, chunks, offline, toBackup, opts.backupDestination, newVersion)
 		if err != nil {
 			return err
 		}
@@ -629,13 +629,14 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	return nil
 }
 
-func printCompleteSummary(out io.Writer, primaryController *openapi.Appliance, additionalControllers []openapi.Appliance, chunks [][]openapi.Appliance, skipped, backup []openapi.Appliance, toVersion *version.Version) (string, error) {
+func printCompleteSummary(out io.Writer, primaryController *openapi.Appliance, additionalControllers []openapi.Appliance, chunks [][]openapi.Appliance, skipped, backup []openapi.Appliance, backupDestination string, toVersion *version.Version) (string, error) {
 	type tplStub struct {
 		PrimaryController     string
 		AdditionalControllers []string
 		Chunks                map[int][]string
 		Skipped               []string
 		Backup                []string
+		BackupDestination     string
 		Version               string
 	}
 	completeSummaryTpl := `
@@ -675,8 +676,9 @@ Appliances that will be skipped:{{ range . }}
 {{ end }}
 {{ with .Backup -}}
 Appliances that will be backed up before completing upgrade:{{ range . }}
-  - {{ . }}{{ end }}
-{{ end }}
+  - {{ . }}{{ end }}{{ end }}
+{{ if .Backup -}}Backup destination is: {{ .BackupDestination }}
+{{ end -}}
 `
 	additionalControllerNames := []string{}
 	for _, a := range additionalControllers {
@@ -704,6 +706,7 @@ Appliances that will be backed up before completing upgrade:{{ range . }}
 		Chunks:                upgradeChunks,
 		Skipped:               toSkip,
 		Backup:                toBackup,
+		BackupDestination:     backupDestination,
 	}
 	if primaryController != nil {
 		tplData.PrimaryController = primaryController.GetName()

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -390,6 +390,7 @@ func TestPrintCompleteSummary(t *testing.T) {
 		chunks                [][]openapi.Appliance
 		skipped               []openapi.Appliance
 		backup                []openapi.Appliance
+		backupDestination     string
 		toVersion             string
 		expect                string
 	}{
@@ -476,7 +477,8 @@ The following appliances will be upgraded to version 5.5.4:
 					Name: "primary-controller",
 				},
 			},
-			toVersion: "5.5.4",
+			backupDestination: "/tmp/appgate/backup",
+			toVersion:         "5.5.4",
 			expect: `
 UPGRADE COMPLETE SUMMARY
 
@@ -509,7 +511,7 @@ Appliances that will be skipped:
 
 Appliances that will be backed up before completing upgrade:
   - primary-controller
-
+Backup destination is: /tmp/appgate/backup
 `,
 		},
 	}
@@ -518,7 +520,7 @@ Appliances that will be backed up before completing upgrade:
 		t.Run(tt.name, func(t *testing.T) {
 			var b bytes.Buffer
 			version, _ := version.NewVersion(tt.toVersion)
-			res, err := printCompleteSummary(&b, tt.primaryController, tt.additionalControllers, tt.chunks, tt.skipped, tt.backup, version)
+			res, err := printCompleteSummary(&b, tt.primaryController, tt.additionalControllers, tt.chunks, tt.skipped, tt.backup, tt.backupDestination, version)
 			if err != nil {
 				t.Errorf("printCompleteSummary() error - %s", err)
 			}


### PR DESCRIPTION
This will make the backup prompt work again when completing an upgrade. Also includes backup destination in the upgrade complete summary.

Fixes:
- SA-19357