### PR TITLE
resolve img overflow

### DIFF
--- a/pkg/auth/flow.go
+++ b/pkg/auth/flow.go
@@ -37,6 +37,10 @@ p {
   padding: 24px;
   margin: 28px;
 }
+img {
+  height: auto;
+  max-width: 100%;
+}
 </style>
 <body>
   <div class="box">


### PR DESCRIPTION
Updated css to avoid img overflow.
In appliances >= 6.0 the barcode image size is bigger which caused the QR code to overflow the div.