### PR TITLE
SA-19399/Move and re-write spinner

### DIFF
--- a/cmd/appliance/upgrade/cancel.go
+++ b/cmd/appliance/upgrade/cancel.go
@@ -155,7 +155,7 @@ func upgradeCancelRun(cmd *cobra.Command, args []string, opts *upgradeCancelOpti
 			appliance := ap
 			qw.Push(appliance)
 			statusReport := make(chan string)
-			go a.UpgradeStatusWorker.Watch(ctx, cancelProgressBars, appliance, appliancepkg.UpgradeStatusIdle, appliancepkg.UpgradeStatusReady, statusReport)
+			go a.UpgradeStatusWorker.Watch(ctx, cancelProgressBars, appliance, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusReady}, statusReport)
 
 			go func(appliance openapi.Appliance) {
 				defer func() {
@@ -180,7 +180,7 @@ func upgradeCancelRun(cmd *cobra.Command, args []string, opts *upgradeCancelOpti
 			if err := a.UpgradeStatusWorker.Wait(ctx, appliance, wantedStatus, undesiredStatus); err != nil {
 				log.Warn(err)
 			}
-			return a.ApplianceStats.WaitForStatus(ctx, appliance, appliancepkg.StatusNotBusy)
+			return a.ApplianceStats.WaitForApplianceStatus(ctx, appliance, appliancepkg.StatusNotBusy)
 		})
 		if err != nil {
 			return err

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -562,9 +562,6 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				if err != nil {
 					return err
 				}
-				if err := a.ApplianceStats.WaitForApplianceStatus(ctx, controller, appliancepkg.StatusNotBusy, statusReport); err != nil {
-					return err
-				}
 				log.WithFields(f).Info("Disabled maintenance mode")
 			}
 			p.Wait()

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -368,10 +368,6 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 
 	// verify the state for all controller
 	verifyingSpinner := prompt.AddDefaultSpinner(initP, "verifying states", "verifying", "ready")
-	state := "controller_ready"
-	if cfg.Version < 15 {
-		state = "single_controller_ready"
-	}
 	if err := a.ApplianceStats.WaitForApplianceState(ctx, *primaryController, appliancepkg.StatReady, nil); err != nil {
 		verifyingSpinner.Abort(false)
 		return fmt.Errorf("primary controller %s", err)
@@ -430,8 +426,8 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			if err := a.UpgradeComplete(ctx, controller.GetId(), true); err != nil {
 				return err
 			}
-			log.WithField("appliance", controller.GetName()).Infof("Waiting for primary controller to reach state %s", state)
-			if err := a.UpgradeStatusWorker.Subscribe(ctx, controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
+			log.WithField("appliance", controller.GetName()).Infof("Waiting for primary controller to reach state %s", appliancepkg.StatReady)
+			if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
 				return err
 			}
 			if err := a.ApplianceStats.WaitForApplianceState(ctx, controller, appliancepkg.StatReady, statusReport); err != nil {
@@ -459,18 +455,13 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				log.WithField("appliance", i.GetName()).Info("checking if ready")
 				statusReport := make(chan string)
 				defer cancel()
-				go a.UpgradeStatusWorker.Watch(ctx, p, i, []string{appliancepkg.UpgradeStatusReady}, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
-				go func() {
-					if err := a.UpgradeStatusWorker.Subscribe(ctx, i, []string{appliancepkg.UpgradeStatusSuccess}, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
-						log.Error(err)
-					}
-				}()
+				go a.UpgradeStatusWorker.Watch(ctx, p, i, appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
 				if err := a.UpgradeComplete(ctx, i.GetId(), SwitchPartition); err != nil {
 					return err
 				}
 				log.WithField("appliance", i.GetName()).Info("Install the downloaded to Upgrade image to the other partition")
 				if !SwitchPartition {
-					if err := a.UpgradeStatusWorker.Wait(ctx, i, []string{appliancepkg.UpgradeStatusSuccess}, []string{appliancepkg.UpgradeStatusFailed}); err != nil {
+					if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, i, []string{appliancepkg.UpgradeStatusSuccess}, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
 						return err
 					}
 					status, err := a.UpgradeStatus(ctx, i.GetId())
@@ -484,10 +475,10 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 						log.WithField("appliance", i.GetName()).Info("Switching partition")
 					}
 				}
-				if err := a.UpgradeStatusWorker.Wait(ctx, i, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}); err != nil {
+				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, i, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
 					return err
 				}
-				if err := a.ApplianceStats.WaitForApplianceState(ctx, i, appliancepkg.StatReady, nil); err != nil {
+				if err := a.ApplianceStats.WaitForApplianceState(ctx, i, appliancepkg.StatReady, statusReport); err != nil {
 					return err
 				}
 				select {
@@ -537,7 +528,9 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 			defer cancel()
 			p := mpb.NewWithContext(ctx, mpb.WithOutput(spinnerOut))
-			bar := prompt.AddDefaultSpinner(p, controller.GetName(), "upgrading", "done")
+			statusReport := make(chan string)
+			defer close(statusReport)
+			go a.UpgradeStatusWorker.Watch(ctx, p, controller, appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
 			if err := a.UpgradeComplete(ctx, controller.GetId(), true); err != nil {
 				return err
 			}
@@ -555,11 +548,11 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 					return err
 				}
 			}
-			if err := a.UpgradeStatusWorker.Wait(ctx, controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}); err != nil {
+			if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
 				log.WithFields(f).WithError(err).Error("Controller never reached desired upgrade status")
 				return err
 			}
-			if err := a.ApplianceStats.WaitForApplianceState(ctx, controller, appliancepkg.StatReady, nil); err != nil {
+			if err := a.ApplianceStats.WaitForApplianceState(ctx, controller, appliancepkg.StatReady, statusReport); err != nil {
 				log.WithFields(f).WithError(err).Error("Controller never reached desired state")
 				return err
 			}
@@ -569,9 +562,11 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				if err != nil {
 					return err
 				}
+				if err := a.ApplianceStats.WaitForApplianceStatus(ctx, controller, appliancepkg.StatusNotBusy, statusReport); err != nil {
+					return err
+				}
 				log.WithFields(f).Info("Disabled maintenance mode")
 			}
-			bar.Increment()
 			p.Wait()
 			log.Infof("Upgraded controller %s", controller.GetName())
 			return nil

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -424,7 +424,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				go func() {
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
-					go a.UpgradeStatusWorker.Watch(ctx, primaryP, controller, appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
+					a.UpgradeStatusWorker.Watch(ctx, primaryP, controller, appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
 				}()
 			}
 
@@ -470,7 +470,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 					go func() {
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
-						go a.UpgradeStatusWorker.Watch(ctx, p, i, appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
+						a.UpgradeStatusWorker.Watch(ctx, p, i, appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
 					}()
 				}
 				if err := a.UpgradeComplete(ctx, i.GetId(), SwitchPartition); err != nil {
@@ -552,7 +552,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				go func() {
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
-					go a.UpgradeStatusWorker.Watch(ctx, p, controller, appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
+					a.UpgradeStatusWorker.Watch(ctx, p, controller, appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
 				}()
 				defer p.Wait()
 			}

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -19,6 +19,7 @@ import (
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/prompt"
 	"github.com/appgate/sdpctl/pkg/terminal"
+	"github.com/appgate/sdpctl/pkg/tui"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-multierror"
@@ -353,7 +354,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	disableAdditionalControllers := appliancepkg.ShouldDisable(currentPrimaryControllerVersion, newVersion)
 	if disableAdditionalControllers {
 		for _, controller := range additionalControllers {
-			spinner := prompt.AddDefaultSpinner(initP, controller.GetName(), "disabling", "disabled")
+			spinner := tui.AddDefaultSpinner(initP, controller.GetName(), "disabling", "disabled")
 			f := log.Fields{"appliance": controller.GetName()}
 			log.WithFields(f).Info("Disabling controller function")
 			if err := a.DisableController(ctx, controller.GetId(), controller); err != nil {
@@ -371,7 +372,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	}
 
 	// verify the state for all controller
-	verifyingSpinner := prompt.AddDefaultSpinner(initP, "verifying states", "verifying", "ready")
+	verifyingSpinner := tui.AddDefaultSpinner(initP, "verifying states", "verifying", "ready")
 	if err := a.ApplianceStats.WaitForApplianceState(ctx, *primaryController, appliancepkg.StatReady, nil); err != nil {
 		verifyingSpinner.Abort(false)
 		return fmt.Errorf("primary controller %s", err)

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -428,11 +428,12 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				}()
 			}
 
-			log.WithField("appliance", controller.GetName()).Info("Completing upgrade and switching partition")
+			logEntry := log.WithField("appliance", controller.GetName())
+			logEntry.Info("completing upgrade and switching partition")
 			if err := a.UpgradeComplete(ctx, controller.GetId(), true); err != nil {
 				return err
 			}
-			log.WithField("appliance", controller.GetName()).Infof("Waiting for primary controller to reach state %s", appliancepkg.StatReady)
+			logEntry.WithField("want", appliancepkg.StatReady).Info("waiting for primary controller to reach a wanted state")
 			if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
 				return err
 			}
@@ -440,7 +441,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				return err
 			}
 
-			log.WithField("appliance", controller.GetName()).Info("Primary controller updated")
+			logEntry.Info("primary controller updated")
 			return nil
 		}
 		if err := upgradeReadyPrimary(ctx, *primaryController); err != nil {
@@ -462,7 +463,8 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			g.Go(func() error {
 				ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 				defer cancel()
-				log.WithField("appliance", i.GetName()).Info("checking if ready")
+				logEntry := log.WithField("appliance", i.GetName())
+				logEntry.Info("checking if ready")
 				var statusReport chan string
 				if !ciMode {
 					statusReport = make(chan string)
@@ -476,7 +478,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				if err := a.UpgradeComplete(ctx, i.GetId(), SwitchPartition); err != nil {
 					return err
 				}
-				log.WithField("appliance", i.GetName()).Info("Install the downloaded to Upgrade image to the other partition")
+				logEntry.Info("install the downloaded upgrade image to the other partition")
 				if !SwitchPartition {
 					if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, i, []string{appliancepkg.UpgradeStatusSuccess}, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
 						return err

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -21,19 +21,19 @@ import (
 
 type mockApplianceStatus struct{}
 
-func (u *mockApplianceStatus) WaitForState(ctx context.Context, appliance openapi.Appliance, expectedState string, status chan<- string) error {
+func (u *mockApplianceStatus) WaitForApplianceState(ctx context.Context, appliance openapi.Appliance, want []string, status chan<- string) error {
 	return nil
 }
-func (u *mockApplianceStatus) WaitForStatus(ctx context.Context, appliance openapi.Appliance, want []string) error {
+func (u *mockApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance openapi.Appliance, want []string) error {
 	return nil
 }
 
 type errApplianceStatus struct{}
 
-func (u *errApplianceStatus) WaitForState(ctx context.Context, appliance openapi.Appliance, expectedState string, status chan<- string) error {
-	return fmt.Errorf("never reached expected state %s", expectedState)
+func (u *errApplianceStatus) WaitForApplianceState(ctx context.Context, appliance openapi.Appliance, want []string, status chan<- string) error {
+	return fmt.Errorf("never reached expected state %s", want)
 }
-func (u *errApplianceStatus) WaitForStatus(ctx context.Context, appliance openapi.Appliance, want []string) error {
+func (u *errApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance openapi.Appliance, want []string) error {
 	return fmt.Errorf("Never reached expected status %s", want)
 }
 
@@ -234,7 +234,7 @@ func TestUpgradeCompleteCommand(t *testing.T) {
 				},
 			},
 			upgradeApplianeStatusWorker: &errApplianceStatus{},
-			wantErrOut:                  regexp.MustCompile(`primary controller never reached expected state single_controller_ready`),
+			wantErrOut:                  regexp.MustCompile(`primary controller never reached expected state`),
 			wantErr:                     true,
 		},
 		{

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -343,6 +343,7 @@ func TestUpgradeCompleteCommand(t *testing.T) {
 			// cobra hack
 			cmd.Flags().BoolP("help", "x", false, "")
 			cmd.Flags().Bool("no-interactive", false, "usage")
+			cmd.PersistentFlags().Bool("ci-mode", false, "usage")
 			cmd.PersistentFlags().String("actual-hostname", "", "")
 
 			argv, err := shlex.Split(tt.cli)

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -24,7 +24,7 @@ type mockApplianceStatus struct{}
 func (u *mockApplianceStatus) WaitForApplianceState(ctx context.Context, appliance openapi.Appliance, want []string, status chan<- string) error {
 	return nil
 }
-func (u *mockApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance openapi.Appliance, want []string) error {
+func (u *mockApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance openapi.Appliance, want []string, status chan<- string) error {
 	return nil
 }
 
@@ -33,7 +33,7 @@ type errApplianceStatus struct{}
 func (u *errApplianceStatus) WaitForApplianceState(ctx context.Context, appliance openapi.Appliance, want []string, status chan<- string) error {
 	return fmt.Errorf("never reached expected state %s", want)
 }
-func (u *errApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance openapi.Appliance, want []string) error {
+func (u *errApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance openapi.Appliance, want []string, status chan<- string) error {
 	return fmt.Errorf("Never reached expected status %s", want)
 }
 

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -396,7 +396,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			status := ""
 			statusChan := make(chan string)
 			defer close(statusChan)
-			go a.UpgradeStatusWorker.Watch(ctx, p, controller, appliancepkg.FileReady, appliancepkg.FileFailed, statusChan)
+			go a.UpgradeStatusWorker.Watch(ctx, p, controller, []string{appliancepkg.FileReady}, []string{appliancepkg.FileFailed}, statusChan)
 			for status != appliancepkg.FileReady {
 				remoteFile, err := a.FileStatus(ctx, opts.filename)
 				if err != nil {
@@ -512,7 +512,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				}
 			}(appliance)
 
-			go a.UpgradeStatusWorker.Watch(ctx, updateProgressBars, appliance, appliancepkg.UpgradeStatusReady, appliancepkg.UpgradeStatusFailed, statusReport)
+			go a.UpgradeStatusWorker.Watch(ctx, updateProgressBars, appliance, []string{appliancepkg.UpgradeStatusReady}, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
 		}
 
 		// Process the inital queue and wait until the status check has passed the 'downloading' stage,

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -474,9 +474,13 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			if err != nil {
 				log.WithError(err).WithField("applianceID", appliance.GetId()).Debug("Failed to determine current upgrade status")
 			}
-			preparedVersion, err := appliancepkg.ParseVersionString(status.GetDetails())
-			if err != nil {
-				log.WithError(err).Warn("Failed to determine currently prepared version")
+			details := status.GetDetails()
+			var preparedVersion *version.Version
+			if len(details) > 0 {
+				preparedVersion, err = appliancepkg.ParseVersionString(details)
+				if err != nil {
+					log.WithError(err).Warn("Failed to determine currently prepared version")
+				}
 			}
 			uploadVersion, _ := appliancepkg.ParseVersionString(opts.image)
 

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -27,6 +27,7 @@ import (
 	"github.com/appgate/sdpctl/pkg/prompt"
 	"github.com/appgate/sdpctl/pkg/queue"
 	"github.com/appgate/sdpctl/pkg/terminal"
+	"github.com/appgate/sdpctl/pkg/tui"
 	"github.com/appgate/sdpctl/pkg/util"
 	multierr "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-version"
@@ -357,7 +358,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				decor.OnComplete(decor.AverageSpeed(decor.UnitKiB, "% .2f"), ""),
 			),
 		)
-		waitSpinner := prompt.AddDefaultSpinner(uploadProgress, fileStat.Name(), "waiting for server ok", "uploaded", mpb.BarQueueAfter(bar, false))
+		waitSpinner := tui.AddDefaultSpinner(uploadProgress, fileStat.Name(), "waiting for server ok", "uploaded", mpb.BarQueueAfter(bar, false))
 		proxyReader := bar.ProxyReader(reader)
 		log.WithField("file", imageFile.Name()).Info("Uploading file")
 		headers := map[string]string{

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -493,7 +493,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 					if err := a.UpgradeCancel(ctx, appliance.GetId()); err != nil {
 						errs = multierr.Append(errs, err)
 					}
-					if err := a.UpgradeStatusWorker.Wait(ctx, appliance, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}); err != nil {
+					if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, appliance, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, nil); err != nil {
 						errs = multierr.Append(errs, err)
 					}
 				}
@@ -502,17 +502,16 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			qw.Push(appliance)
 			statusReport := make(chan string)
 
+			go a.UpgradeStatusWorker.Watch(ctx, updateProgressBars, appliance, []string{appliancepkg.UpgradeStatusReady}, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
 			go func(appliance openapi.Appliance) {
 				defer func() {
 					wg.Done()
 					close(statusReport)
 				}()
-				if err := a.UpgradeStatusWorker.Subscribe(ctx, appliance, prepareReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
+				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, appliance, prepareReady, []string{appliancepkg.UpgradeStatusFailed}, statusReport); err != nil {
 					errorChannel <- err
 				}
 			}(appliance)
-
-			go a.UpgradeStatusWorker.Watch(ctx, updateProgressBars, appliance, []string{appliancepkg.UpgradeStatusReady}, []string{appliancepkg.UpgradeStatusFailed}, statusReport)
 		}
 
 		// Process the inital queue and wait until the status check has passed the 'downloading' stage,
@@ -527,7 +526,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			if err := a.PrepareFileOn(ctx, remoteFilePath, appliance.GetId(), opts.DevKeyring); err != nil {
 				return err
 			}
-			return a.UpgradeStatusWorker.Wait(ctx, appliance, wantedStatus, []string{appliancepkg.UpgradeStatusFailed})
+			return a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, appliance, wantedStatus, []string{appliancepkg.UpgradeStatusFailed}, nil)
 		})
 		if err != nil {
 			errs = multierr.Append(errs, err)

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -36,7 +36,7 @@ func (u *mockUpgradeStatus) Subscribe(ctx context.Context, appliance openapi.App
 	return nil
 }
 
-func (u *mockUpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, failState string, current <-chan string) {
+func (u *mockUpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endStates []string, failStates []string, current <-chan string) {
 }
 
 type errorUpgradeStatus struct{}
@@ -48,7 +48,7 @@ func (u *errorUpgradeStatus) Subscribe(ctx context.Context, appliance openapi.Ap
 	return fmt.Errorf("gateway never reached %s, got failed", strings.Join(desiredStatuses, ", "))
 }
 
-func (u *errorUpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endState string, failState string, current <-chan string) {
+func (u *errorUpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endStates []string, failStates []string, current <-chan string) {
 }
 
 func NewApplianceCmd(f *factory.Factory) *cobra.Command {

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -29,7 +29,7 @@ func init() {
 
 type mockUpgradeStatus struct{}
 
-func (u *mockUpgradeStatus) Wait(ctx context.Context, appliance openapi.Appliance, desiredStatuses []string, undesiredStatuses []string) error {
+func (u *mockUpgradeStatus) WaitForUpgradeStatus(ctx context.Context, appliance openapi.Appliance, desiredStatuses []string, undesiredStatuses []string, status chan<- string) error {
 	return nil
 }
 func (u *mockUpgradeStatus) Subscribe(ctx context.Context, appliance openapi.Appliance, desiredStatuses []string, undesiredStatuses []string, current chan<- string) error {
@@ -41,7 +41,7 @@ func (u *mockUpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, applianc
 
 type errorUpgradeStatus struct{}
 
-func (u *errorUpgradeStatus) Wait(ctx context.Context, appliance openapi.Appliance, desiredStatuses []string, undesiredStatuses []string) error {
+func (u *errorUpgradeStatus) WaitForUpgradeStatus(ctx context.Context, appliance openapi.Appliance, desiredStatuses []string, undesiredStatuses []string, status chan<- string) error {
 	return fmt.Errorf("gateway never reached %s, got failed", strings.Join(desiredStatuses, ", "))
 }
 func (u *errorUpgradeStatus) Subscribe(ctx context.Context, appliance openapi.Appliance, desiredStatuses []string, undesiredStatuses []string, current chan<- string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -215,6 +215,7 @@ func rootPersistentPreRunEFunc(f *factory.Factory, cfg *configuration.Config) fu
 		case "debug":
 			log.SetLevel(log.DebugLevel)
 		case "trace":
+			log.SetReportCaller(true)
 			log.SetLevel(log.TraceLevel)
 		default:
 			log.SetLevel(log.ErrorLevel)

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/filesystem"
 	"github.com/appgate/sdpctl/pkg/prompt"
+	"github.com/appgate/sdpctl/pkg/tui"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-multierror"
@@ -245,7 +246,7 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 
 	for _, a := range toBackup {
 		appliance := a
-		bar := prompt.AddDefaultSpinner(progressBars, appliance.GetName(), backup.Processing, backup.Done)
+		bar := tui.AddDefaultSpinner(progressBars, appliance.GetName(), backup.Processing, backup.Done)
 		go func(appliance openapi.Appliance) {
 			defer wg.Done()
 			backedUp, err := b(appliance)

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -218,7 +218,6 @@ func HasDiffVersions(stats []openapi.StatsAppliancesListAllOfData) (bool, map[st
 	versionList := []string{}
 	for _, stat := range stats {
 		statVersionString := stat.GetVersion()
-		log.WithField("stat_version", statVersionString).Debug("parsing version string")
 		v, err := ParseVersionString(statVersionString)
 		if err != nil {
 			log.WithError(err).WithFields(log.Fields{

--- a/pkg/appliance/status.go
+++ b/pkg/appliance/status.go
@@ -12,16 +12,16 @@ import (
 )
 
 type WaitForApplianceStatus interface {
-	WaitForState(ctx context.Context, appliance openapi.Appliance, expectedState string, status chan<- string) error
+	WaitForApplianceState(ctx context.Context, appliance openapi.Appliance, want []string, status chan<- string) error
 	// WaitForStatus tries appliance stats until the appliance has want status or it reaches the timeout
-	WaitForStatus(ctx context.Context, appliance openapi.Appliance, want []string) error
+	WaitForApplianceStatus(ctx context.Context, appliance openapi.Appliance, want []string) error
 }
 
 type ApplianceStatus struct {
 	Appliance *Appliance
 }
 
-func (u *ApplianceStatus) WaitForStatus(ctx context.Context, appliance openapi.Appliance, want []string) error {
+func (u *ApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance openapi.Appliance, want []string) error {
 	return backoff.Retry(func() error {
 		stats, _, err := u.Appliance.Stats(ctx)
 		if err != nil {
@@ -39,7 +39,7 @@ func (u *ApplianceStatus) WaitForStatus(ctx context.Context, appliance openapi.A
 	}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
 }
 
-func (u *ApplianceStatus) WaitForState(ctx context.Context, appliance openapi.Appliance, expectedState string, status chan<- string) error {
+func (u *ApplianceStatus) WaitForApplianceState(ctx context.Context, appliance openapi.Appliance, want []string, status chan<- string) error {
 	b := backoff.WithContext(&backoff.ExponentialBackOff{
 		InitialInterval:     10 * time.Second,
 		RandomizationFactor: 0.7,
@@ -69,20 +69,20 @@ func (u *ApplianceStatus) WaitForState(ctx context.Context, appliance openapi.Ap
 				}
 				log.WithFields(fields).Infof(
 					"Waiting for state %q",
-					expectedState,
+					want,
 				)
 				if status != nil {
 					status <- state
 				}
-				if state != expectedState {
+				if !util.InSlice(state, want) {
 					log.WithFields(fields).Errorf("never reached desired state")
-					return fmt.Errorf("never reached desired state %s", expectedState)
+					return fmt.Errorf("never reached desired state %s", want)
 				}
 			}
 		}
 		log.WithFields(log.Fields{
 			"appliance":     appliance.GetName(),
-			"current_state": expectedState,
+			"current_state": want,
 		}).Info("reached desired state")
 		return nil
 	}, b)

--- a/pkg/appliance/status.go
+++ b/pkg/appliance/status.go
@@ -65,8 +65,6 @@ func (u *ApplianceStatus) WaitForApplianceState(ctx context.Context, appliance o
 		"appliance": appliance.GetName(),
 	})
 	logEntry.WithField("want", want).Info("polling for appliance state")
-	// initial sleep period
-	time.Sleep(2 * time.Second)
 	return backoff.Retry(func() error {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()

--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -135,7 +135,7 @@ func (u *UpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance op
 					}
 					select {
 					case msg := <-barMessage:
-						body = fmt.Sprintf("%s %s", cond, msg)
+						body = fmt.Sprintf("%s: %s", cond, strings.ReplaceAll(msg, "_", " "))
 						// default refreshrate is 150ms, we will check
 						// the channel every 2/3 of that time to reduce duplicate
 					case <-time.After(100 * time.Millisecond):

--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -107,6 +107,7 @@ func (u *UpgradeStatus) WaitForUpgradeStatus(ctx context.Context, appliance open
 // Watch will print the spinner progress bar and listen for message from <-current and present it to the statusbar
 func (u *UpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance openapi.Appliance, endStates []string, failStates []string, current <-chan string) {
 	name := appliance.GetName()
+	log.WithField("appliance", name).Debug("watching status on appliance")
 	// we will lock each time we add a new bar to avoid duplicates
 	u.mu.Lock()
 	barMessage := make(chan string, 1)
@@ -144,7 +145,7 @@ func (u *UpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance op
 						}
 					}
 					return body
-				}, decor.WCSyncSpaceR)
+				})
 			}(name),
 		),
 		mpb.BarFillerMiddleware(
@@ -167,6 +168,10 @@ func (u *UpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance op
 	// each time we update it, we will lock to avoid duplicate
 	for !bar.Completed() {
 		v, ok := <-current
+		log.WithFields(log.Fields{
+			"appliance": name,
+			"status":    v,
+		}).Debug("recieved status")
 		if !ok {
 			bar.Abort(true)
 			break

--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -129,7 +129,7 @@ func (u *UpgradeStatus) Watch(ctx context.Context, p *mpb.Progress, appliance op
 						if ctx.Err() == nil {
 							doneText = cond
 						} else {
-							doneText = fmt.Sprintf("time out on %s %s", cond, ctx.Err())
+							doneText = fmt.Sprintf("time out on %s: %s", cond, ctx.Err())
 						}
 						return doneText
 					}

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -15,15 +15,15 @@ type Progress struct {
 }
 
 var (
-	DefaultRefreshRate = 120 * time.Millisecond
+	defaultRefreshRate = 120 * time.Millisecond
 )
 
-// NewProgress initiates a new progress tracking container
-func NewProgress(ctx context.Context, out io.Writer, options ...mpb.ContainerOption) *Progress {
+// New initiates a new progress tracking container
+func New(ctx context.Context, out io.Writer, options ...mpb.ContainerOption) *Progress {
 	p := Progress{
 		ctx: ctx,
 	}
-	options = append(options, mpb.WithWidth(1), mpb.WithOutput(out), mpb.WithRefreshRate(DefaultRefreshRate))
+	options = append(options, mpb.WithWidth(1), mpb.WithOutput(out), mpb.WithRefreshRate(defaultRefreshRate))
 	p.pc = mpb.NewWithContext(ctx, options...)
 	return &p
 }
@@ -70,7 +70,7 @@ func (p *Progress) Abort() {
 // all bars remaining and return
 func (p *Progress) Wait(timeout time.Duration) {
 	// wait one refresh cycle to give bars a chance to complete
-	time.Sleep(DefaultRefreshRate)
+	time.Sleep(defaultRefreshRate)
 
 	done := make(chan bool)
 	ctx, cancel := context.WithTimeout(p.ctx, timeout)

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/sirupsen/logrus"
+	"github.com/vbauerster/mpb/v7"
+)
+
+type Progress struct {
+	ctx      context.Context
+	pc       *mpb.Progress
+	trackers []*Tracker
+}
+
+// NewProgress initiates a new progress tracking container
+func NewProgress(ctx context.Context, out io.Writer, options ...mpb.ContainerOption) *Progress {
+	p := Progress{
+		ctx: ctx,
+	}
+	options = append(options, mpb.WithWidth(1), mpb.WithOutput(out))
+	p.pc = mpb.NewWithContext(ctx, options...)
+	return &p
+}
+
+// AddTracker will add a status tracker to the appliance
+// the returned channel is to be used by other functions to update the tracker progress
+func (p *Progress) AddTracker(appliance openapi.Appliance) (*Tracker, chan<- string) {
+	statusReport := make(chan string, 1)
+	t := Tracker{
+		container:    p,
+		appliance:    appliance,
+		statusReport: statusReport,
+	}
+	return &t, statusReport
+}
+
+// Complete will complete all currently active trackers and wait for them to finish before returning
+func (p *Progress) Complete() {
+	for _, t := range p.trackers {
+		t.complete()
+	}
+	p.pc.Wait()
+}
+
+// Abort will abort all currently active trackers and wait for them to finish before returning
+func (p *Progress) Abort() {
+	for _, t := range p.trackers {
+		t.abort()
+	}
+}
+
+// Wait will wait for all progress bars to complete with a timeout
+// If deadline is reached before the bars are complete, it will abort
+// all bars remaining and return
+func (p *Progress) Wait(timeout time.Duration) {
+	doneChan := make(chan bool)
+	ctx, cancel := context.WithTimeout(p.ctx, timeout)
+	defer cancel()
+
+	go func() {
+		p.pc.Wait()
+		doneChan <- true
+		close(doneChan)
+	}()
+
+	select {
+	case <-ctx.Done():
+		p.Abort()
+		logrus.Debug("bars aborted")
+	case <-doneChan:
+	}
+}

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -19,7 +19,7 @@ func NewProgress(ctx context.Context, out io.Writer, options ...mpb.ContainerOpt
 	p := Progress{
 		ctx: ctx,
 	}
-	options = append(options, mpb.WithWidth(1), mpb.WithOutput(out))
+	options = append(options, mpb.WithWidth(1), mpb.WithOutput(out), mpb.WithRefreshRate(80*time.Millisecond))
 	p.pc = mpb.NewWithContext(ctx, options...)
 	return &p
 }
@@ -35,7 +35,7 @@ func (p *Progress) AddTracker(name, endMsg string) (*Tracker, chan<- string) {
 	}
 
 	t.mu.Lock()
-	t.bar = t.container.pc.New(1,
+	t.bar = p.pc.New(1,
 		mpb.SpinnerStyle(SpinnerStyle...),
 		mpb.AppendDecorators(t.decoratorFunc(t.name, endMsg)),
 		mpb.BarFillerMiddleware(t.barFillerFunc()),

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -68,12 +68,12 @@ func (p *Progress) Abort() {
 // Wait will wait for all progress bars to complete with a timeout
 // If deadline is reached before the bars are complete, it will abort
 // all bars remaining and return
-func (p *Progress) Wait(timeout time.Duration) {
+func (p *Progress) Wait() {
 	// wait one refresh cycle to give bars a chance to complete
 	time.Sleep(defaultRefreshRate)
 
 	done := make(chan bool)
-	ctx, cancel := context.WithTimeout(p.ctx, timeout)
+	ctx, cancel := context.WithTimeout(p.ctx, 2*defaultRefreshRate)
 	defer cancel()
 
 	go func() {

--- a/pkg/tui/spinner.go
+++ b/pkg/tui/spinner.go
@@ -1,4 +1,4 @@
-package prompt
+package tui
 
 import (
 	"context"

--- a/pkg/tui/style.go
+++ b/pkg/tui/style.go
@@ -1,7 +1,7 @@
 //go:build !windows
 // +build !windows
 
-package prompt
+package tui
 
 var SpinnerStyle = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 

--- a/pkg/tui/style_windows.go
+++ b/pkg/tui/style_windows.go
@@ -1,7 +1,7 @@
 //go:build windows
 // +build windows
 
-package prompt
+package tui
 
 // SpinnerStyle for Windows has no special unicode characters, to support cmd.exe out-of-the-box.
 var SpinnerStyle = []string{"-", "\\", "|", "/"}

--- a/pkg/tui/tracker.go
+++ b/pkg/tui/tracker.go
@@ -1,0 +1,117 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdpctl/pkg/util"
+	"github.com/vbauerster/mpb/v7"
+	"github.com/vbauerster/mpb/v7/decor"
+)
+
+type Tracker struct {
+	mu           sync.Mutex
+	container    *Progress
+	appliance    openapi.Appliance
+	bar          *mpb.Bar
+	success      bool
+	endMsg       string
+	current      string
+	statusReport <-chan string
+}
+
+// Watch initiates the progress tracking for each appliance update
+// It succeeds if the status written to the statusReport is in the until slice
+// It will abort the tracker if status the same as included in the failOn slice
+func (t *Tracker) Watch(endMsg string, until, failOn []string) {
+	t.endMsg = endMsg
+
+	t.mu.Lock()
+	t.bar = t.container.pc.New(1,
+		mpb.SpinnerStyle(SpinnerStyle...),
+		mpb.AppendDecorators(t.decoratorFunc(t.appliance.GetName())),
+		mpb.BarFillerMiddleware(t.barFillerFunc()),
+	)
+	t.mu.Unlock()
+
+	// failCount keeps track of the amount of failed status updates
+	// the status needs to be reported as failed at least twice before
+	// failing the spinner. This avoids pre-mature spinner abort when
+	// the initial status is also part of the failOn status
+	failCount := 0
+	var ok bool
+	for !t.bar.Completed() && !t.bar.Aborted() {
+		if util.InSlice(t.current, until) {
+			t.success = true
+			t.complete()
+		}
+		if util.InSlice(t.current, failOn) {
+			if failCount > 0 {
+				t.complete()
+			}
+			failCount++
+		}
+
+		// This will keep the loop updating even if no new status is sent
+		// if the parent context is done, it will abort the tracker
+		select {
+		case t.current, ok = <-t.statusReport:
+			if !ok {
+				t.abort()
+			}
+		case <-t.container.ctx.Done():
+			t.abort()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func (t *Tracker) complete() {
+	for !t.bar.Completed() {
+		t.bar.Increment()
+	}
+	t.bar.Wait()
+}
+
+func (t *Tracker) abort() {
+	for !t.bar.Aborted() {
+		t.bar.Abort(false)
+	}
+	t.bar.Wait()
+}
+
+func (t *Tracker) decoratorFunc(name string) decor.Decorator {
+	return decor.Any(func(s decor.Statistics) string {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		if s.Completed && t.success {
+			t.current = t.endMsg
+		}
+		if (s.Completed && !t.success) || s.Aborted {
+			t.current = "failed"
+		}
+		return fmt.Sprintf("%s: %s", name, strings.ReplaceAll(t.current, "_", " "))
+	})
+}
+
+func (t *Tracker) barFillerFunc() func(mpb.BarFiller) mpb.BarFiller {
+	return func(bf mpb.BarFiller) mpb.BarFiller {
+		return mpb.BarFillerFunc(func(w io.Writer, reqWidth int, st decor.Statistics) {
+			t.mu.Lock()
+			defer t.mu.Unlock()
+			if st.Completed && t.success {
+				io.WriteString(w, SpinnerDone)
+				return
+			}
+			if (st.Completed && !t.success) || st.Aborted {
+				io.WriteString(w, SpinnerErr)
+				return
+			}
+			bf.Fill(w, reqWidth, st)
+		})
+	}
+}

--- a/pkg/tui/tracker.go
+++ b/pkg/tui/tracker.go
@@ -3,11 +3,9 @@ package tui
 import (
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/vbauerster/mpb/v7"
 	"github.com/vbauerster/mpb/v7/decor"
@@ -16,85 +14,83 @@ import (
 type Tracker struct {
 	mu           sync.Mutex
 	container    *Progress
-	appliance    openapi.Appliance
+	name         string
 	bar          *mpb.Bar
 	success      bool
-	endMsg       string
-	current      string
-	statusReport <-chan string
+	done         bool
+	statusReport chan string
+	msgProxy     chan string
 }
 
 // Watch initiates the progress tracking for each appliance update
 // It succeeds if the status written to the statusReport is in the until slice
 // It will abort the tracker if status the same as included in the failOn slice
-func (t *Tracker) Watch(endMsg string, until, failOn []string) {
-	t.endMsg = endMsg
-
-	t.mu.Lock()
-	t.bar = t.container.pc.New(1,
-		mpb.SpinnerStyle(SpinnerStyle...),
-		mpb.AppendDecorators(t.decoratorFunc(t.appliance.GetName())),
-		mpb.BarFillerMiddleware(t.barFillerFunc()),
-	)
-	t.mu.Unlock()
+func (t *Tracker) Watch(until, failOn []string) {
+	defer func() {
+		close(t.msgProxy)
+		close(t.statusReport)
+	}()
 
 	// failCount keeps track of the amount of failed status updates
 	// the status needs to be reported as failed at least twice before
 	// failing the spinner. This avoids pre-mature spinner abort when
 	// the initial status is also part of the failOn status
 	failCount := 0
+	var msg string
 	var ok bool
-	for !t.bar.Completed() && !t.bar.Aborted() {
-		if util.InSlice(t.current, until) {
+	for {
+		if util.InSlice(msg, until) {
 			t.success = true
 			t.complete()
+			break
 		}
-		if util.InSlice(t.current, failOn) {
+		if util.InSlice(msg, failOn) {
 			if failCount > 0 {
-				t.complete()
+				t.abort(false)
+				break
 			}
 			failCount++
+			continue
 		}
-
-		// This will keep the loop updating even if no new status is sent
-		// if the parent context is done, it will abort the tracker
-		select {
-		case t.current, ok = <-t.statusReport:
-			if !ok {
-				t.abort()
-			}
-		case <-t.container.ctx.Done():
-			t.abort()
-		case <-time.After(100 * time.Millisecond):
+		msg, ok = <-t.statusReport
+		if !ok {
+			t.abort(false)
+			break
 		}
+		t.msgProxy <- msg
+	}
+	t.done = true
+	if !t.bar.Completed() || !t.bar.Aborted() {
+		t.abort(false)
 	}
 }
 
 func (t *Tracker) complete() {
-	for !t.bar.Completed() {
-		t.bar.Increment()
-	}
-	t.bar.Wait()
+	t.bar.Increment()
 }
 
-func (t *Tracker) abort() {
-	for !t.bar.Aborted() {
-		t.bar.Abort(false)
-	}
-	t.bar.Wait()
+func (t *Tracker) abort(drop bool) {
+	t.bar.Abort(drop)
 }
 
-func (t *Tracker) decoratorFunc(name string) decor.Decorator {
+func (t *Tracker) decoratorFunc(name, endMsg string) decor.Decorator {
+	msg := "waiting"
 	return decor.Any(func(s decor.Statistics) string {
 		t.mu.Lock()
 		defer t.mu.Unlock()
-		if s.Completed && t.success {
-			t.current = t.endMsg
+		select {
+		case <-time.After(100 * time.Millisecond):
+			return fmt.Sprintf("%s: %s", name, msg)
+		case msg = <-t.msgProxy:
+			if t.done {
+				if t.success {
+					msg = endMsg
+				} else {
+					msg = "failed"
+				}
+			}
+			return fmt.Sprintf("%s: %s", name, msg)
 		}
-		if (s.Completed && !t.success) || s.Aborted {
-			t.current = "failed"
-		}
-		return fmt.Sprintf("%s: %s", name, strings.ReplaceAll(t.current, "_", " "))
 	})
 }
 
@@ -103,13 +99,14 @@ func (t *Tracker) barFillerFunc() func(mpb.BarFiller) mpb.BarFiller {
 		return mpb.BarFillerFunc(func(w io.Writer, reqWidth int, st decor.Statistics) {
 			t.mu.Lock()
 			defer t.mu.Unlock()
-			if st.Completed && t.success {
-				io.WriteString(w, SpinnerDone)
-				return
-			}
-			if (st.Completed && !t.success) || st.Aborted {
-				io.WriteString(w, SpinnerErr)
-				return
+			if t.done {
+				if t.success {
+					io.WriteString(w, SpinnerDone)
+					return
+				} else {
+					io.WriteString(w, SpinnerErr)
+					return
+				}
 			}
 			bf.Fill(w, reqWidth, st)
 		})

--- a/pkg/tui/tracker.go
+++ b/pkg/tui/tracker.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -79,8 +80,8 @@ func (t *Tracker) decoratorFunc(name, endMsg string) decor.Decorator {
 		t.mu.Lock()
 		defer t.mu.Unlock()
 		select {
-		case <-time.After(100 * time.Millisecond):
-			return fmt.Sprintf("%s: %s", name, msg)
+		case <-time.After(80 * time.Millisecond):
+			return fmt.Sprintf("%s: %s", name, strings.ReplaceAll(msg, "_", " "))
 		case msg = <-t.msgProxy:
 			if t.done {
 				if t.success {
@@ -89,7 +90,7 @@ func (t *Tracker) decoratorFunc(name, endMsg string) decor.Decorator {
 					msg = "failed"
 				}
 			}
-			return fmt.Sprintf("%s: %s", name, msg)
+			return fmt.Sprintf("%s: %s", name, strings.ReplaceAll(msg, "_", " "))
 		}
 	})
 }

--- a/pkg/tui/tracker.go
+++ b/pkg/tui/tracker.go
@@ -92,10 +92,9 @@ func (t *Tracker) barFillerFunc() func(mpb.BarFiller) mpb.BarFiller {
 				if t.success {
 					io.WriteString(w, SpinnerDone)
 					return
-				} else {
-					io.WriteString(w, SpinnerErr)
-					return
 				}
+				io.WriteString(w, SpinnerErr)
+				return
 			}
 			bf.Fill(w, reqWidth, st)
 		})


### PR DESCRIPTION
This PR decouples the spinner logic from the upgrade logic and puts it into its own package called `tui`. The old spinner code still remains until replaced by the `tui` package. Although the logic is here, this does not actually implement any of the new code yet. That will be implementet in seperate PR:s

Needs: #197 

E2E test ID: 65215fb7-517e-4c04-956e-9526e99632ed