### PR TITLE
Remove m1 arm64 build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,12 +35,11 @@ builds:
   - id: sdpctl_darwin
     main: ./main.go
     env:
-      - CGO_ENABLED=1
+      - CGO_ENABLED=0
     goos:
       - darwin
     goarch:
       - amd64
-      - arm64
     binary: "{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}"
     ldflags:
       - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ .Env.RELEASE_VERSION }}"


### PR DESCRIPTION
M1 build is broken unless you do it on a actual M1 Mac