### PR TITLE
remove v from tag

### DIFF
--- a/.github/workflows/release-flow.yml
+++ b/.github/workflows/release-flow.yml
@@ -3,7 +3,7 @@ name: Release Flow
 on:
   push:
     tags:
-      - v*
+      - '*.*.*'
 
 jobs:
   test:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,7 +72,7 @@ nfpms:
       - src: ./build/man/*.gz
         dst: /usr/share/man/man3/
 snapshot:
-  name_template: "v{{ incpatch .Version }}"
+  name_template: "{{ incpatch .Version }}"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Removes `v` prefix on tags and only trigger release job when the tag adheres to the right format (e.g. `2022.06.27`) 