### PR TITLE
fix: packaging lint errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ^1.18
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Goreleaser build"
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SDPCTL_VERSION: ${{ github.ref_name }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,8 +78,7 @@ nfpms:
         dst: /usr/share/bash-completion/completions/sdpctl
         file_info:
           mode: 0644
-          group: notRoot
-          owner: notRoot
+          group: root
       - src: ./build/man/*.gz
         dst: /usr/share/man/man3/
     deb:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,7 @@ before:
 builds:
   - id: sdpctl_linux
     main: ./main.go
+    mod_timestamp: "{{ .CommitTimestamp }}"
     env:
       - CGO_ENABLED=0
     goos:
@@ -20,6 +21,7 @@ builds:
       - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
   - id: sdpctl_windows
     main: ./main.go
+    mod_timestamp: "{{ .CommitTimestamp }}"
     env:
       - CGO_ENABLED=0
     goos:
@@ -34,6 +36,7 @@ builds:
       - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
   - id: sdpctl_darwin
     main: ./main.go
+    mod_timestamp: "{{ .CommitTimestamp }}"
     env:
       - CGO_ENABLED=0
     goos:
@@ -62,15 +65,27 @@ release:
 nfpms:
   - homepage: https://www.appgate.com
     maintainer: Appgate Cybersecurity, Inc <appgatesdp.support@appgate.com>
-    description: Command line tool for managing Appgate SDP collectives.
+    description: |-
+      Command line tool for managing Appgate SDP collectives
+    license: MIT
     formats:
       - deb
       - rpm
     contents:
       - src: ./build/bash_completion
-        dst: /etc/bash_completion.d/sdpctl
+        dst: /usr/share/bash-completion/completions/sdpctl
+        file_info:
+          mode: 0644
+          group: notRoot
+          owner: notRoot
       - src: ./build/man/*.gz
         dst: /usr/share/man/man3/
+    deb:
+      lintian_overrides:
+        - statically-linked-binary
+        - changelog-file-missing-in-native-package
+    rpm:
+      compression: lzma
 snapshot:
   name_template: "{{ incpatch .Version }}"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,8 @@ env:
 before:
   hooks:
     - make deps
+github_urls:
+  download: https://github.com/appgate/sdpctl/releases
 builds:
   - id: sdpctl_linux
     main: ./main.go
@@ -90,6 +92,15 @@ snapshot:
   name_template: "{{ incpatch .Version }}"
 changelog:
   sort: asc
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: "Bug Fixes"
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: Other
+      order: 999
   filters:
     exclude:
       - "^docs:"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ deps:
 	go run main.go completion bash > build/bash_completion
 	go run main.go generate man
 
-snapshot:
+snapshot: clean
 	goreleaser release --snapshot --rm-dist
 
 fmtcheck:

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"compress/flate"
 	"compress/gzip"
 	"errors"
 	"fmt"
@@ -82,7 +83,11 @@ func generateManPages(cmd *cobra.Command) error {
 		}
 		defer out.Close()
 
-		w := gzip.NewWriter(out)
+		out.Chmod(0644)
+		w, err := gzip.NewWriterLevel(out, flate.BestCompression)
+		if err != nil {
+			return err
+		}
 		defer w.Close()
 		b, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", path, f.Name()))
 		if err != nil {


### PR DESCRIPTION
This fixes some (but not all) packaging lint errors from lintian and rpmlint.
- man pages are more aggressively compressed
- license field added on packaging
- fix file permissions on man pages
- bump github action version for release flow

other:
- test flow github action now ignores tags (to not duplicate jobs)