### PR TITLE
 Add timestamps to important output events

### DIFF
--- a/cmd/appliance/upgrade/cancel.go
+++ b/cmd/appliance/upgrade/cancel.go
@@ -195,7 +195,7 @@ func upgradeCancelRun(cmd *cobra.Command, args []string, opts *upgradeCancelOpti
 
 		return nil
 	}
-	fmt.Fprintln(opts.Out, "Cancelling pending upgrades...")
+	fmt.Fprintf(opts.Out, "[%s] Cancelling pending upgrades:\n", time.Now().Format(time.RFC3339))
 	// workers is intentionally a fixed value of 2
 	// because otherwise its a high risk of triggering failure from 1 or more appliances
 	if err := cancel(ctx, noneIdleAppliances, 2); err != nil {

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -635,7 +635,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(opts.Out, "\n%s\n", postSummary)
+	fmt.Fprintf(opts.Out, "\n[%s] %s\n", time.Now().Format(time.RFC3339), postSummary)
 
 	return nil
 }

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -335,7 +335,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				},
 			}
 		}
-		fmt.Fprint(opts.Out, "\nBacking up:\n")
+		fmt.Fprintf(opts.Out, "\n[%s] Backing up:\n", time.Now().Format(time.RFC3339))
 		if err := appliancepkg.PrepareBackup(&bOpts); err != nil {
 			return err
 		}
@@ -351,7 +351,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	// 1. Disable Controller function on the following appliance
 	// we will run this sequencelly, since this is a sensitive operation
 	// so that we can leave the collective gracefully.
-	fmt.Fprint(opts.Out, "\nInitializing upgrade:\n")
+	fmt.Fprintf(opts.Out, "\n[%s] Initializing upgrade:\n", time.Now().Format(time.RFC3339))
 	initP := mpb.NewWithContext(ctx, mpb.WithOutput(spinnerOut))
 	disableAdditionalControllers := appliancepkg.ShouldDisable(currentPrimaryControllerVersion, newVersion)
 	if disableAdditionalControllers {
@@ -416,7 +416,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	initP.Wait()
 
 	if primaryControllerUpgradeStatus.GetStatus() == appliancepkg.UpgradeStatusReady {
-		fmt.Fprint(opts.Out, "\nUpgrading primary controller:\n")
+		fmt.Fprintf(opts.Out, "\n[%s] Upgrading primary controller:\n", time.Now().Format(time.RFC3339))
 		upgradeReadyPrimary := func(ctx context.Context, controller openapi.Appliance) error {
 			ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 			defer cancel()
@@ -538,7 +538,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	}
 
 	if len(additionalControllers) > 0 {
-		fmt.Fprint(opts.Out, "\nUpgrading additional controllers:\n")
+		fmt.Fprintf(opts.Out, "\n[%s] Upgrading additional controllers:\n", time.Now().Format(time.RFC3339))
 
 		upgradeAdditionalController := func(ctx context.Context, controller openapi.Appliance, disable bool, p *tui.Progress) error {
 			log.Infof("Upgrading controller %s", controller.GetName())
@@ -603,7 +603,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	}
 
 	for index, chunk := range chunks {
-		fmt.Fprintf(opts.Out, "\nUpgrading additional appliances (Batch %d / %d):\n", index+1, chunkLength)
+		fmt.Fprintf(opts.Out, "\n[%s] Upgrading additional appliances (Batch %d / %d):\n", time.Now().Format(time.RFC3339), index+1, chunkLength)
 		if err := batchUpgrade(ctx, chunk, false); err != nil {
 			return fmt.Errorf("failed during upgrade of additional appliances %w", err)
 		}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -394,7 +394,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 
 	}
 	if opts.remoteImage && opts.hostOnController && existingFile.GetStatus() != appliancepkg.FileReady {
-		fmt.Fprintf(opts.Out, "Primary controller as host. Uploading upgrade image:\n")
+		fmt.Fprintf(opts.Out, "[%s] Primary controller as host. Uploading upgrade image:\n", time.Now().Format(time.RFC3339))
 
 		p := mpb.NewWithContext(ctx, mpb.WithOutput(spinnerOut))
 		if err := a.UploadToController(fileStatusCtx, opts.image, opts.filename); err != nil {
@@ -609,7 +609,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	if workers <= 0 {
 		workers = len(appliances)
 	}
-	fmt.Fprint(opts.Out, "\nPreparing image on appliances:\n")
+	fmt.Fprintf(opts.Out, "[%s] Preparing image on appliances:\n", time.Now().Format(time.RFC3339))
 	if err := prepare(ctx, remoteFilePath, appliances, workers); err != nil {
 		return err
 	}


### PR DESCRIPTION
This will prepend some of the important event logs with timestamps.