### PR TITLE
fix: goreleaser build error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SDPCTL_VERSION: ${{ github.ref_name }}
         with:
+          distribution: goreleaser
+          version: v1.9.2
           args: "release"


### PR DESCRIPTION
This updates the version of goreleaser used in the gihub actions, which will fix build errors that occured after #214