### PR TITLE
fix: no upload progress bar in ci-mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/appgate/sdpctl/cmd/token"
 	"github.com/hashicorp/go-multierror"
@@ -182,7 +183,7 @@ func Execute() exitCode {
 func logOutput(cmd *cobra.Command, f *factory.Factory, cfg *configuration.Config) io.Writer {
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp:   true,
-		TimestampFormat: "2006-01-02 15:04:05",
+		TimestampFormat: time.RFC3339,
 		PadLevelText:    true,
 	})
 	if v, err := cmd.Flags().GetBool("ci-mode"); err == nil && v {

--- a/pkg/tui/spinner.go
+++ b/pkg/tui/spinner.go
@@ -1,9 +1,6 @@
 package tui
 
 import (
-	"context"
-	"io"
-
 	"github.com/vbauerster/mpb/v7"
 	"github.com/vbauerster/mpb/v7/decor"
 )
@@ -21,33 +18,4 @@ func AddDefaultSpinner(p *mpb.Progress, name string, stage string, cmsg string, 
 	options = append(options, opts...)
 
 	return p.New(1, mpb.SpinnerStyle(SpinnerStyle...), options...)
-}
-
-func CheckBarFiller(
-	waitCtx context.Context,
-	success func(context.Context) bool,
-) func(mpb.BarFiller) mpb.BarFiller {
-	return func(base mpb.BarFiller) mpb.BarFiller {
-		done := false
-		var doneText string
-		return mpb.BarFillerFunc(func(w io.Writer, reqWidth int, st decor.Statistics) {
-			if done {
-				io.WriteString(w, doneText)
-				return
-			}
-
-			if st.Completed || waitCtx.Err() != nil {
-				done = true
-				if success(waitCtx) {
-					doneText = Check
-				} else {
-					doneText = Cross
-				}
-				io.WriteString(w, doneText)
-			} else {
-				base.Fill(w, reqWidth, st)
-			}
-
-		})
-	}
 }


### PR DESCRIPTION
This will prevent the progress bar for the file upload progress to execute in ci-mode. It also fixes some styling in the upload bar to unify it's looks with the other spinners.
- changed the upload progress bar to only execute when not using `ci-mode`
- made some styling changes to unify looks of progress bar and spinner trackers
- removed unused function