### PR TITLE
fix: disambiguity in prepare message

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -667,11 +667,11 @@ func showPrepareUpgradeMessage(f string, appliance []openapi.Appliance, skip []o
 				i := applianceData{
 					Name:           a.GetName(),
 					CurrentVersion: version.String(),
-					Online:         "Offline ⨯",
+					Online:         "Online " + tui.No,
 				}
 
 				if appliancepkg.StatsIsOnline(stat) {
-					i.Online = "Online ✓"
+					i.Online = "Online " + tui.Yes
 				}
 				data.Appliances = append(data.Appliances, i)
 			}
@@ -685,10 +685,10 @@ func showPrepareUpgradeMessage(f string, appliance []openapi.Appliance, skip []o
 				i := applianceData{
 					Name:           s.GetName(),
 					CurrentVersion: version.String(),
-					Online:         "Offline ⨯",
+					Online:         "Online " + tui.No,
 				}
 				if appliancepkg.StatsIsOnline(stat) {
-					i.Online = "Online ✓"
+					i.Online = "Online " + tui.Yes
 				}
 				data.SkipAppliances = append(data.SkipAppliances, i)
 			}

--- a/pkg/tui/spinner.go
+++ b/pkg/tui/spinner.go
@@ -10,7 +10,7 @@ import (
 
 func AddDefaultSpinner(p *mpb.Progress, name string, stage string, cmsg string, opts ...mpb.BarOption) *mpb.Bar {
 	options := []mpb.BarOption{
-		mpb.BarFillerOnComplete(SpinnerDone),
+		mpb.BarFillerOnComplete(Check),
 		mpb.BarWidth(1),
 		mpb.AppendDecorators(
 			decor.Name(name, decor.WCSyncWidthR),
@@ -39,9 +39,9 @@ func CheckBarFiller(
 			if st.Completed || waitCtx.Err() != nil {
 				done = true
 				if success(waitCtx) {
-					doneText = SpinnerDone
+					doneText = Check
 				} else {
-					doneText = SpinnerErr
+					doneText = Cross
 				}
 				io.WriteString(w, doneText)
 			} else {

--- a/pkg/tui/style.go
+++ b/pkg/tui/style.go
@@ -3,7 +3,11 @@
 
 package tui
 
-var SpinnerStyle = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+var (
+	SpinnerStyle []string = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
-var SpinnerDone = "✓"
-var SpinnerErr = "⨯"
+	Check string = "✓"
+	Cross string = "⨯"
+	Yes   string = Check
+	No    string = Cross
+)

--- a/pkg/tui/style_windows.go
+++ b/pkg/tui/style_windows.go
@@ -3,9 +3,13 @@
 
 package tui
 
-// SpinnerStyle for Windows has no special unicode characters, to support cmd.exe out-of-the-box.
-var SpinnerStyle = []string{"-", "\\", "|", "/"}
+var (
+	// SpinnerStyle for Windows has no special unicode characters, to support cmd.exe out-of-the-box.
+	SpinnerStyle []string = []string{"-", "\\", "|", "/"}
 
-// SpinnerDone intentionally left empty due to causing false positives in cmd.exe
-var SpinnerDone = ""
-var SpinnerErr = "Error"
+	// SpinnerDone intentionally left empty due to causing false positives in cmd.exe
+	Check string = "[COMPLETE]"
+	Cross string = "[ERROR]"
+	Yes   string = "Y"
+	No    string = "N"
+)

--- a/pkg/tui/tracker.go
+++ b/pkg/tui/tracker.go
@@ -91,10 +91,10 @@ func (t *Tracker) barFillerFunc() func(mpb.BarFiller) mpb.BarFiller {
 			defer t.mu.Unlock()
 			if t.done {
 				if t.success {
-					io.WriteString(w, SpinnerDone)
+					io.WriteString(w, Check)
 					return
 				}
-				io.WriteString(w, SpinnerErr)
+				io.WriteString(w, Cross)
 				return
 			}
 			bf.Fill(w, reqWidth, st)


### PR DESCRIPTION
This fixes a disambiguity in the prepare message where the use of both "Online" and "Offline" was combined with a "yes" or "no". This makes the language conflict where offline appliances would be presented as "Offline [no]", which could be interpreted as it actually being in an online state.

- all states are either presented as "Online [yes|no]"
- message is also converted to use non-utf8 characters in the windows build
- added more symbols to account for "yes|no" on windows systems