### PR TITLE
fix: enable the backup API

### DIFF
--- a/cmd/appliance/backup/api.go
+++ b/cmd/appliance/backup/api.go
@@ -83,6 +83,7 @@ func backupAPIrun(cmd *cobra.Command, args []string, opts *apiOptions) error {
 		if err != nil {
 			return err
 		}
+		settings.SetBackupApiEnabled(true)
 		settings.SetBackupPassphrase(answer)
 		message = "Backup API and passphrase has been updated."
 	}


### PR DESCRIPTION
The `appliance backup api` command was broken in #195 due to forgetting to actually set the boolean to enable the backup API before making the request. This fixes it.

Fixes:
- SA-19614