### PR TITLE
disable progress spinners in ci-mode

### DIFF
--- a/cmd/appliance/backup/backup_test.go
+++ b/cmd/appliance/backup/backup_test.go
@@ -76,6 +76,7 @@ func TestBackupCmd(t *testing.T) {
 
 	cmd := NewCmdBackup(f)
 	cmd.Flags().Bool("no-interactive", false, "usage")
+	cmd.Flags().Bool("ci-mode", false, "ci-mode")
 	cmd.SetArgs([]string{"--destination=/tmp/appgate-testing", "--primary", "--no-interactive"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
@@ -128,6 +129,7 @@ func TestBackupCmdDisabledAPI(t *testing.T) {
 
 	cmd := NewCmdBackup(f)
 	cmd.Flags().Bool("no-interactive", false, "usage")
+	cmd.Flags().Bool("ci-mode", false, "ci-mode")
 	cmd.SetArgs([]string{"--destination=/tmp/appgate-testing", "--no-interactive"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
@@ -170,6 +172,7 @@ func TestBackupCmdNoState(t *testing.T) {
 
 	cmd := NewCmdBackup(f)
 	cmd.Flags().Bool("no-interactive", false, "usage")
+	cmd.Flags().Bool("ci-mode", false, "ci-mode")
 	cmd.SetArgs([]string{"--destination=/tmp/appgate-testing", "--no-interactive"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -257,13 +257,12 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 	}
 
 	for _, a := range toBackup {
-		appliance := a
-		var bar *mpb.Bar
-		if !opts.CiMode {
-			bar = tui.AddDefaultSpinner(progressBars, appliance.GetName(), backup.Processing, backup.Done)
-		}
 		go func(appliance openapi.Appliance) {
 			defer wg.Done()
+			var bar *mpb.Bar
+			if !opts.CiMode {
+				bar = tui.AddDefaultSpinner(progressBars, appliance.GetName(), backup.Processing, backup.Done)
+			}
 			backedUp, err := b(appliance)
 			if err != nil {
 				if !opts.CiMode {
@@ -276,7 +275,7 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 				bar.Increment()
 			}
 			backups <- backedUp
-		}(appliance)
+		}(a)
 	}
 
 	go func() {


### PR DESCRIPTION
This disables execution of spinners on the backup command when using `ci-mode`