### PR TITLE
5.2 backwards compatability

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -230,6 +230,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	} else if opts.Config.Version == 15 {
 		autoScalingWarning = true
 	}
+	if opts.Config.Version <= 13 {
+		// Versions before v13 does not have dev-keyring functionality
+		opts.DevKeyring = false
+	}
 	if t, gws := appliancepkg.AutoscalingGateways(appliances); autoScalingWarning && len(gws) > 0 && !opts.NoInteractive {
 		msg, err := appliancepkg.ShowAutoscalingWarningMessage(t, gws)
 		if err != nil {

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -206,8 +206,12 @@ func (a *Appliance) DeleteFile(ctx context.Context, filename string) error {
 
 func (a *Appliance) PrepareFileOn(ctx context.Context, filename, id string, devKeyring bool) error {
 	u := openapi.ApplianceUpgrade{
-		ImageUrl:   filename,
-		DevKeyring: openapi.PtrBool(devKeyring),
+		ImageUrl: filename,
+	}
+	if devKeyring {
+		// Only set dev keyring if it is true
+		// will prevent errors with older api-version that don't support dev-keyring
+		u.DevKeyring = openapi.PtrBool(devKeyring)
 	}
 	_, r, err := a.APIClient.ApplianceUpgradeApi.AppliancesIdUpgradePreparePost(ctx, id).ApplianceUpgrade(u).Authorization(a.Token).Execute()
 	if err != nil {


### PR DESCRIPTION
This fixes backwards compatability with api-version 13 (appliance version 5.2). Api-version 13 does not have support for dev-keyring, so preparing an upgrade image on appliance version 5.2 would fail because of this.. This fixes it by:
1. only setting the dev-keyring value for the prepare request if it is true
2. Checking the api-version in the prepare command and setting dev-keyring to false if it v13 or below.