### PR TITLE
Table output unification

### DIFF
--- a/cmd/appliance/list.go
+++ b/cmd/appliance/list.go
@@ -60,7 +60,7 @@ func listRun(cmd *cobra.Command, args []string, opts *listOptions) error {
 		return util.PrintJSON(opts.Out, allAppliances)
 	}
 
-	p := util.NewPrinter(opts.Out)
+	p := util.NewPrinter(opts.Out, 4)
 	p.AddHeader("Name", "ID", "Hostname", "Site", "Activated")
 	for _, a := range allAppliances {
 		p.AddLine(a.GetName(), a.GetId(), a.GetHostname(), a.GetSiteName(), a.GetActivated())

--- a/cmd/appliance/list_test.go
+++ b/cmd/appliance/list_test.go
@@ -115,10 +115,10 @@ func TestApplianceListCommandTable(t *testing.T) {
 		t.Fatalf("unable to read stdout %s", err)
 	}
 	gotStr := string(got)
-	want := `Name                                                   ID                                    Hostname        Site          Activated
-----                                                   --                                    --------        ----          ---------
-controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1  4c07bc67-57ea-42dd-b702-c2d6c45419fc  appgate.com     Default Site  true
-gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1     ee639d70-e075-4f01-596b-930d5f24f569  gateway.devops  Default Site  true
+	want := `Name                                                     ID                                      Hostname          Site            Activated
+----                                                     --                                      --------          ----            ---------
+controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1    4c07bc67-57ea-42dd-b702-c2d6c45419fc    appgate.com       Default Site    true
+gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1       ee639d70-e075-4f01-596b-930d5f24f569    gateway.devops    Default Site    true
 `
 	if !cmp.Equal(want, gotStr) {
 		t.Fatalf("\nGot: \n %q \n\n Want: \n %q \n", gotStr, want)
@@ -176,9 +176,9 @@ func TestApplianceFiltering(t *testing.T) {
 		t.Fatalf("unable to read stdout %s", err)
 	}
 	gotStr := string(got)
-	want := `Name                                                   ID                                    Hostname     Site          Activated
-----                                                   --                                    --------     ----          ---------
-controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1  4c07bc67-57ea-42dd-b702-c2d6c45419fc  appgate.com  Default Site  true
+	want := `Name                                                     ID                                      Hostname       Site            Activated
+----                                                     --                                      --------       ----            ---------
+controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1    4c07bc67-57ea-42dd-b702-c2d6c45419fc    appgate.com    Default Site    true
 `
 	if !cmp.Equal(want, gotStr) {
 		t.Fatalf("\nGot: \n %q \n\n Want: \n %q \n", gotStr, want)

--- a/cmd/appliance/resolve_name_status.go
+++ b/cmd/appliance/resolve_name_status.go
@@ -102,7 +102,7 @@ func resolveNameStatusRun(cmd *cobra.Command, args []string, opts *resolveNameSt
 		return util.PrintJSON(opts.Out, result)
 	}
 
-	p := util.NewPrinter(opts.Out)
+	p := util.NewPrinter(opts.Out, 4)
 	p.AddHeader("Partial", "Finals", "Partials", "Errors")
 	for _, r := range result.GetResolutions() {
 		p.AddLine(r.GetPartial(), r.GetFinals(), r.GetPartials(), r.GetErrors())

--- a/cmd/appliance/stats.go
+++ b/cmd/appliance/stats.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -65,14 +65,14 @@ func statsRun(cmd *cobra.Command, args []string, opts *statsOptions) error {
 		fmt.Fprintf(opts.Out, "\n%s\n", string(j))
 		return nil
 	}
-	w := tabwriter.NewWriter(opts.Out, 4, 4, 8, ' ', tabwriter.DiscardEmptyColumns)
-	fmt.Fprintln(w, "Name\tStatus\tFunction\tCPU\tMemory\tNetwork out/in\tDisk\tVersion")
+	w := util.NewPrinter(opts.Out, 4)
+	w.AddHeader("Name", "Status", "Function", "CPU", "Memory", "Network out/in", "Disk", "Version")
 	for _, s := range stats.GetData() {
 		version := s.GetVersion()
 		if v, err := appliancepkg.ParseVersionString(version); err == nil {
 			version = v.String()
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		w.AddLine(
 			s.GetName(),
 			s.GetStatus(),
 			statsActiveFunction(s),
@@ -83,7 +83,7 @@ func statsRun(cmd *cobra.Command, args []string, opts *statsOptions) error {
 			version,
 		)
 	}
-	w.Flush()
+	w.Print()
 	return nil
 }
 

--- a/cmd/appliance/stats_test.go
+++ b/cmd/appliance/stats_test.go
@@ -116,9 +116,10 @@ func TestApplianceStatsCommandTable(t *testing.T) {
 		t.Fatalf("unable to read stdout %s", err)
 	}
 	gotStr := string(got)
-	want := `Name                                                         Status         Function                     CPU         Memory        Network out/in               Disk        Version
-controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1        healthy        LogServer, Controller        0.8%        48.8%         0.26 Kbps / 0.26 Kbps        1.2%        5.3.4+24950
-gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1           healthy        Gateway                      0.7%        7.8%          76.8 bps / 96.0 bps          4.9%        5.3.4+24950
+	want := `Name                                                     Status     Function                 CPU     Memory    Network out/in           Disk    Version
+----                                                     ------     --------                 ---     ------    --------------           ----    -------
+controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1    healthy    LogServer, Controller    0.8%    48.8%     0.26 Kbps / 0.26 Kbps    1.2%    5.3.4+24950
+gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1       healthy    Gateway                  0.7%    7.8%      76.8 bps / 96.0 bps      4.9%    5.3.4+24950
 `
 	if !cmp.Equal(want, gotStr) {
 		t.Fatalf("\n Diff \n %s", cmp.Diff(want, gotStr))

--- a/cmd/appliance/upgrade/status.go
+++ b/cmd/appliance/upgrade/status.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"text/tabwriter"
 
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
@@ -113,11 +112,11 @@ func upgradeStatusRun(cmd *cobra.Command, args []string, opts *upgradeStatusOpti
 		return nil
 	}
 
-	w := tabwriter.NewWriter(opts.Out, 4, 4, 8, ' ', tabwriter.DiscardEmptyColumns)
-	fmt.Fprintln(w, "ID\tName\tStatus\tUpgrade Status\tDetails")
+	w := util.NewPrinter(opts.Out, 4)
+	w.AddHeader("ID", "Name", "Status", "Upgrade Status", "Details")
 	for _, s := range statuses {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", s.ID, s.Name, s.Status, s.UpgradeStatus, s.Details)
+		w.AddLine(s.ID, s.Name, s.Status, s.UpgradeStatus, s.Details)
 	}
-	w.Flush()
+	w.Print()
 	return nil
 }

--- a/cmd/appliance/upgrade/status_test.go
+++ b/cmd/appliance/upgrade/status_test.go
@@ -155,9 +155,10 @@ func TestUpgradeStatusCommandTable(t *testing.T) {
 		t.Fatalf("unable to read stdout %s", err)
 	}
 	gotStr := string(got)
-	want := `ID                                          Name                                                         Status        Upgrade Status        Details
-4c07bc67-57ea-42dd-b702-c2d6c45419fc        controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1        online        idle                  a reboot is required for the Upgrade to go into effect
-ee639d70-e075-4f01-596b-930d5f24f569        gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1           online        idle                  a reboot is required for the Upgrade to go into effect
+	want := `ID                                      Name                                                     Status    Upgrade Status    Details
+--                                      ----                                                     ------    --------------    -------
+4c07bc67-57ea-42dd-b702-c2d6c45419fc    controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1    online    idle              a reboot is required for the Upgrade to go into effect
+ee639d70-e075-4f01-596b-930d5f24f569    gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1       online    idle              a reboot is required for the Upgrade to go into effect
 `
 	if !cmp.Equal(want, gotStr) {
 		t.Fatalf("\nGot: \n %q \n\n Want: \n %q \n", gotStr, want)

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -39,7 +39,7 @@ func tokenListRun(opts *TokenOptions) error {
 		return util.PrintJSON(opts.Out, distinguishedNames)
 	}
 
-	p := util.NewPrinter(opts.Out)
+	p := util.NewPrinter(opts.Out, 4)
 	p.AddHeader("Distinguished Name", "Device ID", "Last Token Issued At", "Provider Name", "Username")
 	for _, dn := range distinguishedNames {
 		p.AddLine(dn.GetDistinguishedName(), dn.GetDeviceId(), dn.GetLastTokenIssuedAt(), dn.GetProviderName(), dn.GetUsername())

--- a/cmd/token/list_test.go
+++ b/cmd/token/list_test.go
@@ -74,22 +74,22 @@ func TestTokenList(t *testing.T) {
 		t.Fatalf("unable to read stdout %s", err)
 	}
 
-	expected := `Distinguished Name                                     Device ID                             Last Token Issued At         Provider Name  Username
-------------------                                     ---------                             --------------------         -------------  --------
-CN=f0f4305444d24991b070160de7b69fe9,CN=bob,OU=local    f0f43054-44d2-4991-b070-160de7b69fe9  2021-12-20T19:29:29.107201Z  local          bob
-CN=55e3408fe69c49358d6f345e3d2ee4bd,CN=admin,OU=local  55e3408f-e69c-4935-8d6f-345e3d2ee4bd  2021-12-20T19:29:27.451869Z  local          admin
-CN=877b2d887c2048e4b2e8daae6bb4c077,CN=bob,OU=local    877b2d88-7c20-48e4-b2e8-daae6bb4c077  2021-12-20T19:29:25.778469Z  local          bob
-CN=37b8c15f300d40b6898c9131019327d4,CN=bob,OU=local    37b8c15f-300d-40b6-898c-9131019327d4  2021-12-20T19:29:22.380330Z  local          bob
-CN=522db03c06494122a508befb91ba95af,CN=bob,OU=local    522db03c-0649-4122-a508-befb91ba95af  2021-12-20T19:29:17.801181Z  local          bob
-CN=43f87ebf811249f8a3a965edc7db0601,CN=bob,OU=local    43f87ebf-8112-49f8-a3a9-65edc7db0601  2021-12-20T19:29:14.519041Z  local          bob
-CN=d7d47adbb1bc4a0baaaf9c970d9682c8,CN=bob,OU=local    d7d47adb-b1bc-4a0b-aaaf-9c970d9682c8  2021-12-20T19:29:11.319131Z  local          bob
-CN=9c607025108d4a03b25a22f0d4b2ffba,CN=bob,OU=local    9c607025-108d-4a03-b25a-22f0d4b2ffba  2021-12-20T19:29:07.997339Z  local          bob
-CN=b37de2ed4b4c4d21952f718e2dd6e34b,CN=bob,OU=local    b37de2ed-4b4c-4d21-952f-718e2dd6e34b  2021-12-20T19:29:04.809781Z  local          bob
-CN=a3c70825dc0945c48dbc6a6d991d7d0b,CN=bob,OU=local    a3c70825-dc09-45c4-8dbc-6a6d991d7d0b  2021-12-20T19:29:01.415945Z  local          bob
-CN=f7e1d6fec2344b49b1d65a107025e795,CN=bob,OU=local    f7e1d6fe-c234-4b49-b1d6-5a107025e795  2021-12-20T19:28:56.367895Z  local          bob
-CN=6633333637304266a631306131646637,CN=admin,OU=local  66333336-3730-4266-a631-306131646637  2021-12-20T19:25:29.414827Z  local          admin
-CN=70e076801c4b5bdc87b4afc71540e720,CN=admin,OU=local  70e07680-1c4b-5bdc-87b4-afc71540e720  2021-12-20T19:24:34.652187Z  local          admin
-CN=3332396333654131b235633864363134,CN=admin,OU=local  33323963-3365-4131-b235-633864363134  2021-12-20T18:37:46.634198Z  local          admin
+	expected := `Distinguished Name                                       Device ID                               Last Token Issued At           Provider Name    Username
+------------------                                       ---------                               --------------------           -------------    --------
+CN=f0f4305444d24991b070160de7b69fe9,CN=bob,OU=local      f0f43054-44d2-4991-b070-160de7b69fe9    2021-12-20T19:29:29.107201Z    local            bob
+CN=55e3408fe69c49358d6f345e3d2ee4bd,CN=admin,OU=local    55e3408f-e69c-4935-8d6f-345e3d2ee4bd    2021-12-20T19:29:27.451869Z    local            admin
+CN=877b2d887c2048e4b2e8daae6bb4c077,CN=bob,OU=local      877b2d88-7c20-48e4-b2e8-daae6bb4c077    2021-12-20T19:29:25.778469Z    local            bob
+CN=37b8c15f300d40b6898c9131019327d4,CN=bob,OU=local      37b8c15f-300d-40b6-898c-9131019327d4    2021-12-20T19:29:22.380330Z    local            bob
+CN=522db03c06494122a508befb91ba95af,CN=bob,OU=local      522db03c-0649-4122-a508-befb91ba95af    2021-12-20T19:29:17.801181Z    local            bob
+CN=43f87ebf811249f8a3a965edc7db0601,CN=bob,OU=local      43f87ebf-8112-49f8-a3a9-65edc7db0601    2021-12-20T19:29:14.519041Z    local            bob
+CN=d7d47adbb1bc4a0baaaf9c970d9682c8,CN=bob,OU=local      d7d47adb-b1bc-4a0b-aaaf-9c970d9682c8    2021-12-20T19:29:11.319131Z    local            bob
+CN=9c607025108d4a03b25a22f0d4b2ffba,CN=bob,OU=local      9c607025-108d-4a03-b25a-22f0d4b2ffba    2021-12-20T19:29:07.997339Z    local            bob
+CN=b37de2ed4b4c4d21952f718e2dd6e34b,CN=bob,OU=local      b37de2ed-4b4c-4d21-952f-718e2dd6e34b    2021-12-20T19:29:04.809781Z    local            bob
+CN=a3c70825dc0945c48dbc6a6d991d7d0b,CN=bob,OU=local      a3c70825-dc09-45c4-8dbc-6a6d991d7d0b    2021-12-20T19:29:01.415945Z    local            bob
+CN=f7e1d6fec2344b49b1d65a107025e795,CN=bob,OU=local      f7e1d6fe-c234-4b49-b1d6-5a107025e795    2021-12-20T19:28:56.367895Z    local            bob
+CN=6633333637304266a631306131646637,CN=admin,OU=local    66333336-3730-4266-a631-306131646637    2021-12-20T19:25:29.414827Z    local            admin
+CN=70e076801c4b5bdc87b4afc71540e720,CN=admin,OU=local    70e07680-1c4b-5bdc-87b4-afc71540e720    2021-12-20T19:24:34.652187Z    local            admin
+CN=3332396333654131b235633864363134,CN=admin,OU=local    33323963-3365-4131-b235-633864363134    2021-12-20T18:37:46.634198Z    local            admin
 `
 	assert.Equal(t, string(actual), expected)
 }

--- a/cmd/token/revoke.go
+++ b/cmd/token/revoke.go
@@ -213,7 +213,7 @@ func PrintRevokedTokens(response *http.Response, out io.Writer, printJSON bool) 
 	}
 
 	if len(result.GetData()) > 0 {
-		p := util.NewPrinter(out)
+		p := util.NewPrinter(out, 2)
 		p.AddHeader("ID", "Type", "Distinguished Name", "Issued", "Expires", "Revoked", "Site ID", "Site Name", "Revocation Time", "Device ID", "Username", "Provider Name", "Controller Hostname")
 		for _, t := range result.GetData() {
 			p.AddLine(

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -17,7 +17,7 @@ import (
 )
 
 func PrintDiskSpaceWarningMessage(out io.Writer, stats []openapi.StatsAppliancesListAllOfData) {
-	p := util.NewPrinter(out)
+	p := util.NewPrinter(out, 4)
 	p.AddHeader("Name", "Disk Usage")
 	for _, a := range stats {
 		p.AddLine(a.GetName(), fmt.Sprintf("%v%%", a.GetDisk()))

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -39,10 +39,10 @@ func TestPrintDiskSpaceWarningMessage(t *testing.T) {
 			want: `
 WARNING: Some appliances have very little space available
 
-Name         Disk Usage
-----         ----------
-controller   90%
-controller2  75%
+Name           Disk Usage
+----           ----------
+controller     90%
+controller2    75%
 
 Upgrading requires the upload and decompression of big images.
 To avoid problems during the upgrade process it's recommended to

--- a/pkg/util/printer.go
+++ b/pkg/util/printer.go
@@ -3,20 +3,20 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cheynewallace/tabby"
 	"io"
 	"text/tabwriter"
+
+	"github.com/cheynewallace/tabby"
 )
 
 const (
 	MinWidth = 0
 	TabWidth = 0
-	Padding  = 2
 	PadChar  = ' '
 )
 
-func NewPrinter(output io.Writer) *tabby.Tabby {
-	w := tabwriter.NewWriter(output, MinWidth, TabWidth, Padding, PadChar, tabwriter.DiscardEmptyColumns)
+func NewPrinter(output io.Writer, padding int) *tabby.Tabby {
+	w := tabwriter.NewWriter(output, MinWidth, TabWidth, padding, PadChar, tabwriter.DiscardEmptyColumns)
 	return tabby.NewCustom(w)
 }
 


### PR DESCRIPTION
This unifies the table output for different commands, most notably the `appliance stats` and `appliance upgrade status` commands used different output functions that made the output different from other table listing commands.

`appliance stats` before:
```bash
>sdpctl appliance stats
Name                                                          Status         Function                     CPU         Memory        Network out/in               Disk        Version
controller-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1         healthy        LogServer, Controller        2.1%        60.8%         89.6 Kbps / 0.21 Mbps        9%          6.0.0+29426
controller2-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1        healthy                                     0.5%        1.9%          8.53 Kbps / 3.09 Kbps        0.8%        6.0.0+29426
gateway-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1            healthy        Gateway                      0.8%        8%            11.1 Kbps / 3.46 Kbps        0.8%        6.0.0+29426
```

`appliance stats` after:
```
>sdpctl appliance stats
Name                                                      Status     Function                 CPU     Memory    Network out/in           Disk    Version
----                                                      ------     --------                 ---     ------    --------------           ----    -------
controller-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1     healthy    LogServer, Controller    2.2%    60.8%     94.6 Kbps / 0.23 Mbps    9%      6.0.0+29426
controller2-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1    healthy                             0.5%    1.9%      8.65 Kbps / 3.25 Kbps    0.8%    6.0.0+29426
gateway-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1        healthy    Gateway                  0.7%    8%        11.0 Kbps / 3.36 Kbps    0.8%    6.0.0+29426