### PR TITLE
Fix test builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,8 @@ builds:
     goarch:
       - amd64
       - arm64
-    binary: "{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}"
+    no_unique_dist_dir: true
+    binary: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}/{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}"
     ldflags:
       - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ .Env.RELEASE_VERSION }}"
       - -X "github.com/appgate/sdpctl/cmd.commit={{ .Commit }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,53 +6,29 @@ before:
 github_urls:
   download: https://github.com/appgate/sdpctl/releases
 builds:
-  - id: sdpctl_linux
+  - id: sdpctl
     main: ./main.go
     mod_timestamp: "{{ .CommitTimestamp }}"
     env:
       - CGO_ENABLED=0
     goos:
       - linux
-    goarch:
-      - amd64
-      - arm64
-    binary: "{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}"
-    ldflags:
-      - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ .Env.RELEASE_VERSION }}"
-      - -X "github.com/appgate/sdpctl/cmd.commit={{ .Commit }}"
-      - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
-  - id: sdpctl_windows
-    main: ./main.go
-    mod_timestamp: "{{ .CommitTimestamp }}"
-    env:
-      - CGO_ENABLED=0
-    goos:
       - windows
-    goarch:
-      - amd64
-      - arm64
-    binary: "{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}"
-    ldflags:
-      - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ .Env.RELEASE_VERSION }}"
-      - -X "github.com/appgate/sdpctl/cmd.commit={{ .Commit }}"
-      - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
-  - id: sdpctl_darwin
-    main: ./main.go
-    mod_timestamp: "{{ .CommitTimestamp }}"
-    env:
-      - CGO_ENABLED=0
-    goos:
       - darwin
     goarch:
       - amd64
+      - arm64
     binary: "{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}"
     ldflags:
       - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ .Env.RELEASE_VERSION }}"
       - -X "github.com/appgate/sdpctl/cmd.commit={{ .Commit }}"
       - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
+    ignore:
+      - goos: darwin
+        goarch: arm64
 universal_binaries:
   - replace: false
-    id: sdpctl_darwin
+    id: sdpctl
 archives:
   - format_overrides:
       - goos: windows


### PR DESCRIPTION
In a recent upgrade of goreleaser, the build process started including goarch version in the directory name when building, which resulted in the directory having a different name than expected in test runs and thus fail.

Another issue is that goreleaser, by default, includes the build job name in the directory structure as well, which also made directory names not expected by testing.

This fixes the issue by ignoring the goarch version when creating directories for the binary, restoring the directory name to that which is expected by tests.

The three build jobs has also been merged into one build job to account for directory naming issues as well.

main branch:
```bash
>make snapshot
[...]
   • release succeeded after 19.55s
>ls -d dist/sdpctl_linux*_amd64*
dist/sdpctl_linux_linux_amd64_v1
```

this branch_
```bash
>make snapshot
[...]
   • release succeeded after 19.55s
>ls -d dist/sdpctl_linux*_amd64*
dist/sdpctl_linux_amd64
```