### PR TITLE
fix: get all tags when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,19 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --force --tags
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
           go-version: ^1.18
         id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
 
       - name: "Goreleaser build"
         uses: goreleaser/goreleaser-action@v3


### PR DESCRIPTION
Get all tags when running the automatic release job. This will make goreleaser build a dynamic changelog based on commits.