### PR TITLE
fix packaging binary issue

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,7 @@ nfpms:
 snapshot:
   name_template: "{{ incpatch .Version }}"
 changelog:
+  use: github
   sort: asc
   groups:
     - title: Features

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,8 +18,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    no_unique_dist_dir: true
-    binary: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}/{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}"
+    binary: "{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}"
     ldflags:
       - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ .Env.RELEASE_VERSION }}"
       - -X "github.com/appgate/sdpctl/cmd.commit={{ .Commit }}"


### PR DESCRIPTION
This reverts some changes introduced in #230, which made the binaries be placed in subdirectories in the db and rpm packages.

Also changes the changelog generation to use the github api instead of just pulling from git log