### PR TITLE
235: make summaries more dynamic

### DIFF
--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/appgate/sdpctl/pkg/tui"
 	"github.com/google/shlex"
 	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
 )
 
 type mockApplianceStatus struct{}
@@ -393,19 +394,13 @@ func TestPrintCompleteSummary(t *testing.T) {
 				Name: "primary-controller",
 			},
 			additionalControllers: []openapi.Appliance{
-				{
-					Name: "secondary-controller",
-				},
+				{Name: "secondary-controller"},
 			},
 			logServersForwarders: []openapi.Appliance{},
 			chunks: [][]openapi.Appliance{
 				{
-					{
-						Name: "gateway",
-					},
-					{
-						Name: "gateway-2",
-					},
+					{Name: "gateway"},
+					{Name: "gateway-2"},
 				},
 			},
 			skipped:   []openapi.Appliance{},
@@ -413,10 +408,13 @@ func TestPrintCompleteSummary(t *testing.T) {
 			expect: `
 UPGRADE COMPLETE SUMMARY
 
-Upgrade will be completed in four steps:
+Upgrade will be completed in steps:
 
  1. The primary controller will be upgraded.
     This will result in the API being unreachable while completing the primary controller upgrade.
+
+    - primary-controller
+
 
  2. Additional controllers will be upgraded.
     In some cases, the controller function on additional controllers will need to be disabled
@@ -424,23 +422,17 @@ Upgrade will be completed in four steps:
     the upgrade is completed.
     This step will also reboot the upgraded controllers for the upgrade to take effect.
 
- 3. Appliances with LogForwarder/LogServer functions are updated
-    Other appliances need a connection to to these appliances for logging.
+    - secondary-controller
 
- 4. The remaining appliances will be upgraded. The additional appliances will be split into
+
+ 3. The remaining appliances will be upgraded. The additional appliances will be split into
     batches to keep the collective as available as possible during the upgrade process.
     Some of the additional appliances may need to be rebooted for the upgrade to take effect.
 
-The following appliances will be upgraded to version 5.5.4:
-  Primary Controller: primary-controller
-
-  Additional Controllers:
-  - secondary-controller
-
-  Additional Appliances:
     Batch #1:
     - gateway
     - gateway-2
+
 `,
 		},
 		{
@@ -478,39 +470,32 @@ The following appliances will be upgraded to version 5.5.4:
 			expect: `
 UPGRADE COMPLETE SUMMARY
 
-Upgrade will be completed in four steps:
+Upgrade will be completed in steps:
 
- 1. The primary controller will be upgraded.
+ 1. Backup will be performed on the selected appliances
+    and downloaded to /tmp/appgate/backup:
+
+    - primary-controller
+
+
+ 2. The primary controller will be upgraded.
     This will result in the API being unreachable while completing the primary controller upgrade.
 
- 2. Additional controllers will be upgraded.
-    In some cases, the controller function on additional controllers will need to be disabled
-    before proceeding with the upgrade. The disabled controllers will then be re-enabled once
-    the upgrade is completed.
-    This step will also reboot the upgraded controllers for the upgrade to take effect.
+    - primary-controller
 
- 3. Appliances with LogForwarder/LogServer functions are updated
-    Other appliances need a connection to to these appliances for logging.
 
- 4. The remaining appliances will be upgraded. The additional appliances will be split into
+ 3. The remaining appliances will be upgraded. The additional appliances will be split into
     batches to keep the collective as available as possible during the upgrade process.
     Some of the additional appliances may need to be rebooted for the upgrade to take effect.
 
-The following appliances will be upgraded to version 5.5.4:
-  Primary Controller: primary-controller
-
-  Additional Appliances:
     Batch #1:
     - gateway
     - gateway-2
 
+
 Appliances that will be skipped:
   - secondary-controller
   - additional-controller
-
-Appliances that will be backed up before completing upgrade:
-  - primary-controller
-Backup destination is: /tmp/appgate/backup
 `,
 		},
 		{
@@ -551,43 +536,39 @@ Backup destination is: /tmp/appgate/backup
 			expect: `
 UPGRADE COMPLETE SUMMARY
 
-Upgrade will be completed in four steps:
+Upgrade will be completed in steps:
 
- 1. The primary controller will be upgraded.
+ 1. Backup will be performed on the selected appliances
+    and downloaded to /tmp/appgate/backup:
+
+    - primary-controller
+
+
+ 2. The primary controller will be upgraded.
     This will result in the API being unreachable while completing the primary controller upgrade.
 
- 2. Additional controllers will be upgraded.
-    In some cases, the controller function on additional controllers will need to be disabled
-    before proceeding with the upgrade. The disabled controllers will then be re-enabled once
-    the upgrade is completed.
-    This step will also reboot the upgraded controllers for the upgrade to take effect.
+    - primary-controller
+
 
  3. Appliances with LogForwarder/LogServer functions are updated
     Other appliances need a connection to to these appliances for logging.
+
+    - logforwarder1
+    - logforwarder2
+
 
  4. The remaining appliances will be upgraded. The additional appliances will be split into
     batches to keep the collective as available as possible during the upgrade process.
     Some of the additional appliances may need to be rebooted for the upgrade to take effect.
 
-The following appliances will be upgraded to version 5.5.4:
-  Primary Controller: primary-controller
-
-  LogServers/LogForwarders:
-  - logforwarder1
-  - logforwarder2
-
-  Additional Appliances:
     Batch #1:
     - gateway
     - gateway-2
 
+
 Appliances that will be skipped:
   - secondary-controller
   - additional-controller
-
-Appliances that will be backed up before completing upgrade:
-  - primary-controller
-Backup destination is: /tmp/appgate/backup
 `,
 		},
 	}
@@ -600,9 +581,7 @@ Backup destination is: /tmp/appgate/backup
 			if err != nil {
 				t.Errorf("printCompleteSummary() error - %s", err)
 			}
-			if res != tt.expect {
-				t.Errorf("printCompleteSummary() fail\nEXPECT:%s\nGOT:%s", tt.expect, res)
-			}
+			assert.Equal(t, tt.expect, res)
 		})
 	}
 }

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -408,6 +408,8 @@ func TestPrintCompleteSummary(t *testing.T) {
 			expect: `
 UPGRADE COMPLETE SUMMARY
 
+Appliances will be upgraded to version 5.5.4
+
 Upgrade will be completed in steps:
 
  1. The primary controller will be upgraded.
@@ -469,6 +471,8 @@ Upgrade will be completed in steps:
 			toVersion:         "5.5.4",
 			expect: `
 UPGRADE COMPLETE SUMMARY
+
+Appliances will be upgraded to version 5.5.4
 
 Upgrade will be completed in steps:
 
@@ -535,6 +539,8 @@ Appliances that will be skipped:
 			toVersion:         "5.5.4",
 			expect: `
 UPGRADE COMPLETE SUMMARY
+
+Appliances will be upgraded to version 5.5.4
 
 Upgrade will be completed in steps:
 

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -1,0 +1,11 @@
+package util
+
+import "text/template"
+
+func sum(x, y int) int {
+	return x + y
+}
+
+var TPLFuncMap = template.FuncMap{
+	"sum": sum,
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/spf13/pflag"
@@ -121,4 +122,19 @@ func ParseFilteringFlags(flags *pflag.FlagSet, defaultFilter map[string]map[stri
 func IsUUID(str string) bool {
 	_, err := uuid.Parse(str)
 	return err == nil
+}
+
+func PrefixStringLines(s, prefixChar string, prefixLength int) string {
+	split := strings.Split(s, "\n")
+	for i, l := range split {
+		if len(l) <= 0 {
+			continue
+		}
+		res := l
+		for i := 0; i < prefixLength; i++ {
+			res = prefixChar + res
+		}
+		split[i] = res
+	}
+	return strings.Join(split, "\n")
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -127,14 +127,9 @@ func IsUUID(str string) bool {
 func PrefixStringLines(s, prefixChar string, prefixLength int) string {
 	split := strings.Split(s, "\n")
 	for i, l := range split {
-		if len(l) <= 0 {
-			continue
+		if len(l) > 0 {
+			split[i] = strings.Repeat(string(prefixChar), prefixLength) + l
 		}
-		res := l
-		for i := 0; i < prefixLength; i++ {
-			res = prefixChar + res
-		}
-		split[i] = res
 	}
 	return strings.Join(split, "\n")
 }


### PR DESCRIPTION
This changes the `upgrade complete` summary text to more dynamic. It will not print upgrade steps that are not going to be executed when there are no appliances in that step. It also re-orders the summary so that the appliances that are included in the particular upgrade step is going to be listed in direct relation to the description.

Summary on main:
```bash
>sdpctl appliance upgrade complete

UPGRADE COMPLETE SUMMARY

Upgrade will be completed in four steps:

 1. The primary controller will be upgraded.
    This will result in the API being unreachable while completing the primary controller upgrade.

 2. Additional controllers will be upgraded.
    In some cases, the controller function on additional controllers will need to be disabled
    before proceeding with the upgrade. The disabled controllers will then be re-enabled once
    the upgrade is completed.
    This step will also reboot the upgraded controllers for the upgrade to take effect.

 3. Appliances with LogForwarder/LogServer functions are updated
    Other appliances need a connection to to these appliances for logging.

 4. The remaining appliances will be upgraded. The additional appliances will be split into
    batches to keep the collective as available as possible during the upgrade process.
    Some of the additional appliances may need to be rebooted for the upgrade to take effect.

The following appliances will be upgraded to version 6.0.0+29426:
  Primary Controller: controller-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1

  LogServers/LogForwarders:
  - controller2-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1

  Additional Appliances:
    Batch #1:
    - gateway-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1

Appliances that will be backed up before completing upgrade:
  - controller-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1
  - controller2-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1
Backup destination is: /home/larskajes/Downloads/appgate/backup
```

Summary after merge:
```bash
>sdpctl appliance upgrade complete
[...]

UPGRADE COMPLETE SUMMARY

Appliances will be upgraded to version 6.0.0+29426

Upgrade will be completed in steps:

 1. Backup will be performed on the selected appliances
    and downloaded to /home/larskajes/Downloads/appgate/backup:

    - controller-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1
    - controller2-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1


 2. The primary controller will be upgraded.
    This will result in the API being unreachable while completing the primary controller upgrade.

    - controller-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1


 3. Appliances with LogForwarder/LogServer functions are updated
    Other appliances need a connection to to these appliances for logging.

    - controller2-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1


 4. The remaining appliances will be upgraded. The additional appliances will be split into
    batches to keep the collective as available as possible during the upgrade process.
    Some of the additional appliances may need to be rebooted for the upgrade to take effect.

    Batch #1:
    - gateway-cc6d1fc3-c28a-4d14-9067-7ecd4bbe9853-site1
```