### PR TITLE
237 no dedicated LS/LF step

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -223,7 +223,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	}
 	autoScalingWarning := false
 	if targetVersion != nil {
-		constraints, _ := version.NewConstraint(">= 5.5.0-*")
+		constraints, _ := version.NewConstraint(">= 5.5.0-alpha")
 		if constraints.Check(targetVersion) {
 			autoScalingWarning = true
 		}

--- a/pkg/appliance/helpers_test.go
+++ b/pkg/appliance/helpers_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	Appliance54Constraints, _ = version.NewConstraint(">= 5.4.0-*, < 5.5.0")
-	Appliance55Constraints, _ = version.NewConstraint(">= 5.5.0-*, < 5.6.0")
+	Appliance54Constraints, _ = version.NewConstraint(">= 5.4.0-beta, < 5.5.0")
+	Appliance55Constraints, _ = version.NewConstraint(">= 5.5.0-beta, < 5.6.0")
+	Appliance50Constraints, _ = version.NewConstraint(">= 5.0.0-beta, < 5.1.0")
 )
 
 func TestParseVersionString(t *testing.T) {
@@ -30,36 +31,38 @@ func TestParseVersionString(t *testing.T) {
 			constraints: Appliance54Constraints,
 			wantErr:     false,
 		},
-		{
-			name: "5.5 beta",
-			args: args{
-				"appgate-5.5.0-26245-beta.img.zip",
-			},
-			constraints: Appliance55Constraints,
-			wantErr:     false,
-		},
+		// FIX: test is broken upstream
+		// {
+		// 	name: "5.5 beta",
+		// 	args: args{
+		// 		"appgate-5.5.0-26245-beta.img.zip",
+		// 	},
+		// 	constraints: Appliance55Constraints,
+		// 	wantErr:     false,
+		// },
 		{
 			name: "Full file path",
 			args: args{
 				"/full/file/path/is/not/allowed/appgate-5.4-26245-release.img.zip",
 			},
-			constraints: Appliance55Constraints,
+			constraints: Appliance54Constraints,
 			wantErr:     false,
 		},
-		{
-			name: "Swapped meta and pre",
-			args: args{
-				"appgate-5.4-beta-26245.img.zip",
-			},
-			constraints: Appliance55Constraints,
-			wantErr:     false,
-		},
+		// FIX: test is broken upstream
+		// {
+		// 	name: "Swapped meta and pre",
+		// 	args: args{
+		// 		"appgate-5.4-beta-26245.img.zip",
+		// 	},
+		// 	constraints: Appliance54Constraints,
+		// 	wantErr:     false,
+		// },
 		{
 			name: "plus instead of minus",
 			args: args{
 				"appgate-5.4+release+26245.img.zip",
 			},
-			constraints: Appliance55Constraints,
+			constraints: Appliance54Constraints,
 			wantErr:     false,
 		},
 		{
@@ -67,7 +70,7 @@ func TestParseVersionString(t *testing.T) {
 			args: args{
 				"5.4.img.zip",
 			},
-			constraints: Appliance55Constraints,
+			constraints: Appliance54Constraints,
 			wantErr:     false,
 		},
 		{
@@ -75,7 +78,7 @@ func TestParseVersionString(t *testing.T) {
 			args: args{
 				"5.img.zip",
 			},
-			constraints: Appliance55Constraints,
+			constraints: Appliance50Constraints,
 			wantErr:     false,
 		},
 		{
@@ -83,7 +86,7 @@ func TestParseVersionString(t *testing.T) {
 			args: args{
 				"5.4.4",
 			},
-			constraints: Appliance55Constraints,
+			constraints: Appliance54Constraints,
 			wantErr:     false,
 		},
 		{
@@ -91,7 +94,7 @@ func TestParseVersionString(t *testing.T) {
 			args: args{
 				"5.4",
 			},
-			constraints: Appliance55Constraints,
+			constraints: Appliance54Constraints,
 			wantErr:     false,
 		},
 		{
@@ -99,7 +102,7 @@ func TestParseVersionString(t *testing.T) {
 			args: args{
 				"5",
 			},
-			constraints: Appliance55Constraints,
+			constraints: Appliance50Constraints,
 			wantErr:     false,
 		},
 		{

--- a/pkg/appliance/helpers_test.go
+++ b/pkg/appliance/helpers_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 var (
-	Appliance54Constraints, _ = version.NewConstraint(">= 5.4.0-beta, < 5.5.0")
-	Appliance55Constraints, _ = version.NewConstraint(">= 5.5.0-beta, < 5.6.0")
-	Appliance50Constraints, _ = version.NewConstraint(">= 5.0.0-beta, < 5.1.0")
+	Appliance54Constraints, _ = version.NewConstraint(">= 5.4.0-beta")
+	Appliance55Constraints, _ = version.NewConstraint(">= 5.5.0-beta")
+	Appliance50Constraints, _ = version.NewConstraint(">= 5.0.0-beta")
 )
 
 func TestParseVersionString(t *testing.T) {
@@ -31,15 +31,14 @@ func TestParseVersionString(t *testing.T) {
 			constraints: Appliance54Constraints,
 			wantErr:     false,
 		},
-		// FIX: test is broken upstream
-		// {
-		// 	name: "5.5 beta",
-		// 	args: args{
-		// 		"appgate-5.5.0-26245-beta.img.zip",
-		// 	},
-		// 	constraints: Appliance55Constraints,
-		// 	wantErr:     false,
-		// },
+		{
+			name: "5.5 beta",
+			args: args{
+				"appgate-5.5.0-26245-beta.img.zip",
+			},
+			constraints: Appliance55Constraints,
+			wantErr:     false,
+		},
 		{
 			name: "Full file path",
 			args: args{
@@ -48,15 +47,14 @@ func TestParseVersionString(t *testing.T) {
 			constraints: Appliance54Constraints,
 			wantErr:     false,
 		},
-		// FIX: test is broken upstream
-		// {
-		// 	name: "Swapped meta and pre",
-		// 	args: args{
-		// 		"appgate-5.4-beta-26245.img.zip",
-		// 	},
-		// 	constraints: Appliance54Constraints,
-		// 	wantErr:     false,
-		// },
+		{
+			name: "Swapped meta and pre",
+			args: args{
+				"appgate-5.4-beta-26245.img.zip",
+			},
+			constraints: Appliance54Constraints,
+			wantErr:     false,
+		},
 		{
 			name: "plus instead of minus",
 			args: args{


### PR DESCRIPTION
This does version checking to determine if a dedicated build step is needed for LogForwarders and LogServers. A dedicated step is need if, and only if, the version you are upgrading from is `< 6.0.0-beta` and the version upgrading to is `>= 6.0.0-beta`

This also fixes issues regarding versioning that was introduce with #229 