### PR TITLE
Update summaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,18 +66,4 @@ nfpms:
 snapshot:
   name_template: "{{ incpatch .Version }}"
 changelog:
-  use: github
-  sort: asc
-  groups:
-    - title: Features
-      regexp: "^.*feat[(\\w)]*:+.*$"
-      order: 0
-    - title: "Bug Fixes"
-      regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 1
-    - title: Other
-      order: 999
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  use: github-native

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"text/template"
 	"time"
@@ -829,20 +830,34 @@ Appliances that will be skipped:{{ range .Skipped }}
 }
 
 func printPostCompleteSummary(applianceVersions map[string]string, hasDiff bool) (string, error) {
-	type tplStub struct {
-		ApplianceVersions map[string]string
-		HasDiff           bool
+	keys := make([]string, 0, len(applianceVersions))
+	for k := range applianceVersions {
+		keys = append(keys, k)
 	}
+	sort.Strings(keys)
+
+	type tplStub struct {
+		VersionTable string
+		HasDiff      bool
+	}
+
 	tpl := `UPGRADE COMPLETE
 
-{{ if .HasDiff }}WARNING: Upgrade was completed, but not all appliances are running the same version.{{ end }}
-Appliances are now running these versions:
-{{- range $appliance, $version := .ApplianceVersions }}
-  {{ $appliance }}: {{ $version }}{{ end }}
+{{ .VersionTable }}{{ if .HasDiff }}
+WARNING: Upgrade was completed, but not all appliances are running the same version.{{ end }}
 `
+
+	tb := &bytes.Buffer{}
+	tp := util.NewPrinter(tb, 4)
+	tp.AddHeader("Name", "Upgraded to")
+	for _, k := range keys {
+		tp.AddLine(k, applianceVersions[k])
+	}
+	tp.Print()
+
 	tplData := tplStub{
-		ApplianceVersions: applianceVersions,
-		HasDiff:           hasDiff,
+		VersionTable: tb.String(),
+		HasDiff:      hasDiff,
 	}
 	t := template.Must(template.New("").Parse(tpl))
 	var buf bytes.Buffer

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -726,7 +726,7 @@ Appliances that will be skipped:{{ range .Skipped }}
 			"Other appliances need a connection to to these appliances for logging.",
 		}
 		AdditionalAppliancesDescription = []string{
-			"The remaining appliances will be upgraded. The additional appliances will be split into",
+			"Additional appliances will be upgraded. The additional appliances will be split into",
 			"batches to keep the collective as available as possible during the upgrade process.",
 			"Some of the additional appliances may need to be rebooted for the upgrade to take effect.",
 		}
@@ -849,7 +849,7 @@ WARNING: Upgrade was completed, but not all appliances are running the same vers
 
 	tb := &bytes.Buffer{}
 	tp := util.NewPrinter(tb, 4)
-	tp.AddHeader("Name", "Upgraded to")
+	tp.AddHeader("Appliance", "Upgraded to")
 	for _, k := range keys {
 		tp.AddLine(k, applianceVersions[k])
 	}

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -427,7 +427,7 @@ Upgrade will be completed in steps:
     - secondary-controller
 
 
- 3. The remaining appliances will be upgraded. The additional appliances will be split into
+ 3. Additional appliances will be upgraded. The additional appliances will be split into
     batches to keep the collective as available as possible during the upgrade process.
     Some of the additional appliances may need to be rebooted for the upgrade to take effect.
 
@@ -488,7 +488,7 @@ Upgrade will be completed in steps:
     - primary-controller
 
 
- 3. The remaining appliances will be upgraded. The additional appliances will be split into
+ 3. Additional appliances will be upgraded. The additional appliances will be split into
     batches to keep the collective as available as possible during the upgrade process.
     Some of the additional appliances may need to be rebooted for the upgrade to take effect.
 
@@ -563,7 +563,7 @@ Upgrade will be completed in steps:
     - logforwarder2
 
 
- 4. The remaining appliances will be upgraded. The additional appliances will be split into
+ 4. Additional appliances will be upgraded. The additional appliances will be split into
     batches to keep the collective as available as possible during the upgrade process.
     Some of the additional appliances may need to be rebooted for the upgrade to take effect.
 
@@ -608,8 +608,8 @@ func TestPrintPostCompleteSummary(t *testing.T) {
 			hasDiff: false,
 			expect: `UPGRADE COMPLETE
 
-Name          Upgraded to
-----          -----------
+Appliance     Upgraded to
+---------     -----------
 controller    6.0.0+12345
 gateway       6.0.0+12345
 
@@ -625,8 +625,8 @@ gateway       6.0.0+12345
 			hasDiff: true,
 			expect: `UPGRADE COMPLETE
 
-Name                    Upgraded to
-----                    -----------
+Appliance               Upgraded to
+---------               -----------
 gateway                 6.0.0+23456
 primary-controller      6.0.0-beta+12345
 secondary-controller    6.0.0+23456

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -608,10 +608,11 @@ func TestPrintPostCompleteSummary(t *testing.T) {
 			hasDiff: false,
 			expect: `UPGRADE COMPLETE
 
+Name          Upgraded to
+----          -----------
+controller    6.0.0+12345
+gateway       6.0.0+12345
 
-Appliances are now running these versions:
-  controller: 6.0.0+12345
-  gateway: 6.0.0+12345
 `,
 		},
 		{
@@ -624,11 +625,13 @@ Appliances are now running these versions:
 			hasDiff: true,
 			expect: `UPGRADE COMPLETE
 
+Name                    Upgraded to
+----                    -----------
+gateway                 6.0.0+23456
+primary-controller      6.0.0-beta+12345
+secondary-controller    6.0.0+23456
+
 WARNING: Upgrade was completed, but not all appliances are running the same version.
-Appliances are now running these versions:
-  gateway: 6.0.0+23456
-  primary-controller: 6.0.0-beta+12345
-  secondary-controller: 6.0.0+23456
 `,
 		},
 	}
@@ -638,9 +641,7 @@ Appliances are now running these versions:
 			if err != nil {
 				t.Fatal("error printing summary")
 			}
-			if res != tt.expect {
-				t.Fatalf("Output don't match expected:\nWANT: %s\nGOT: %s", tt.expect, res)
-			}
+			assert.Equal(t, tt.expect, res)
 		})
 	}
 }

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -707,7 +707,7 @@ func showPrepareUpgradeMessage(f string, appliance []openapi.Appliance, skip []s
 
 	abuf := &bytes.Buffer{}
 	at := util.NewPrinter(abuf, 4)
-	at.AddHeader("Name", "Online", "Current version", "Prepare version")
+	at.AddHeader("Appliance", "Online", "Current version", "Prepare version")
 	for _, a := range appliance {
 		for _, stat := range stats {
 			if a.GetId() == stat.GetId() {
@@ -726,7 +726,7 @@ func showPrepareUpgradeMessage(f string, appliance []openapi.Appliance, skip []s
 	if len(skip) > 0 {
 		bbuf := &bytes.Buffer{}
 		bt := util.NewPrinter(bbuf, 4)
-		bt.AddHeader("Name", "Online", "Current version", "Reason")
+		bt.AddHeader("Appliance", "Online", "Current version", "Reason")
 		for _, s := range skip {
 			for _, stat := range stats {
 				if s.Appliance.GetId() == stat.GetId() {

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/appgate/sdpctl/pkg/tui"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -633,6 +634,176 @@ func TestCheckImageFilename(t *testing.T) {
 			if err := checkImageFilename(tt.args.i); (err != nil) != tt.wantErr {
 				t.Errorf("checkImageFilename() error = %v, wantErr %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func Test_showPrepareUpgradeMessage(t *testing.T) {
+	type args struct {
+		f         string
+		appliance []openapi.Appliance
+		skip      []skipStruct
+		stats     []openapi.StatsAppliancesListAllOfData
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "prepare appliance default",
+			args: args{
+				f: "appgate-6.0.0-29426-release.img.zip",
+				appliance: []openapi.Appliance{
+					{
+						Id:   openapi.PtrString("d4dc0b97-ef59-4431-871b-6b214099797a"),
+						Name: "controller1",
+					},
+					{
+						Id:   openapi.PtrString("3f6f9e42-33c3-446c-9e0d-855c7d5b933b"),
+						Name: "controller2",
+					},
+					{
+						Id:   openapi.PtrString("8a064b81-c692-46ae-b0fa-c4661a018f24"),
+						Name: "gateway",
+					},
+				},
+				stats: []openapi.StatsAppliancesListAllOfData{
+					{
+						Id:      openapi.PtrString("d4dc0b97-ef59-4431-871b-6b214099797a"),
+						Name:    openapi.PtrString("controller1"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("5.5.7+28767"),
+					},
+					{
+						Id:      openapi.PtrString("3f6f9e42-33c3-446c-9e0d-855c7d5b933b"),
+						Name:    openapi.PtrString("controller2"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("5.5.7+28767"),
+					},
+					{
+						Id:      openapi.PtrString("8a064b81-c692-46ae-b0fa-c4661a018f24"),
+						Name:    openapi.PtrString("gateway"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("5.5.7+28767"),
+					},
+					{
+						Id:      openapi.PtrString("92a8ceed-a364-4e99-a2eb-0a8546bab48f"),
+						Name:    openapi.PtrString("controller3"),
+						Online:  openapi.PtrBool(false),
+						Version: openapi.PtrString("5.5.7+28767"),
+					},
+					{
+						Id:      openapi.PtrString("57a06ae4-8204-4780-a7c2-a9cdf03e5a0f"),
+						Name:    openapi.PtrString("gateway2"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("6.0.0+29426"),
+					},
+				},
+				skip: []skipStruct{
+					{
+						Appliance: openapi.Appliance{
+							Id:   openapi.PtrString("92a8ceed-a364-4e99-a2eb-0a8546bab48f"),
+							Name: "controller3",
+						},
+						Reason: "appliance is offline",
+					},
+					{
+						Appliance: openapi.Appliance{
+							Id:   openapi.PtrString("57a06ae4-8204-4780-a7c2-a9cdf03e5a0f"),
+							Name: "gateway2",
+						},
+						Reason: "version is already greater or equal to prepare version",
+					},
+				},
+			},
+			want: `PREPARE SUMMARY
+
+1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
+2. Prepare upgrade on the following appliances:
+
+Name           Online    Current version    Prepare version
+----           ------    ---------------    ---------------
+controller1    ✓         5.5.7+28767        6.0.0+29426
+controller2    ✓         5.5.7+28767        6.0.0+29426
+gateway        ✓         5.5.7+28767        6.0.0+29426
+
+
+3. Delete upgrade image from Controller
+
+The following appliances will be skipped:
+
+Name           Online    Current version    Reason
+----           ------    ---------------    ------
+controller3    ⨯         5.5.7+28767        appliance is offline
+gateway2       ✓         6.0.0+29426        version is already greater or equal to prepare version
+
+`,
+		},
+		{
+			name: "prepare appliance no-skipped",
+			args: args{
+				f: "appgate-6.0.0-29426-release.img.zip",
+				appliance: []openapi.Appliance{
+					{
+						Id:   openapi.PtrString("d4dc0b97-ef59-4431-871b-6b214099797a"),
+						Name: "controller1",
+					},
+					{
+						Id:   openapi.PtrString("3f6f9e42-33c3-446c-9e0d-855c7d5b933b"),
+						Name: "controller2",
+					},
+					{
+						Id:   openapi.PtrString("8a064b81-c692-46ae-b0fa-c4661a018f24"),
+						Name: "gateway",
+					},
+				},
+				stats: []openapi.StatsAppliancesListAllOfData{
+					{
+						Id:      openapi.PtrString("d4dc0b97-ef59-4431-871b-6b214099797a"),
+						Name:    openapi.PtrString("controller1"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("5.5.7+28767"),
+					},
+					{
+						Id:      openapi.PtrString("3f6f9e42-33c3-446c-9e0d-855c7d5b933b"),
+						Name:    openapi.PtrString("controller2"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("5.5.7+28767"),
+					},
+					{
+						Id:      openapi.PtrString("8a064b81-c692-46ae-b0fa-c4661a018f24"),
+						Name:    openapi.PtrString("gateway"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("5.5.7+28767"),
+					},
+				},
+			},
+			want: `PREPARE SUMMARY
+
+1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
+2. Prepare upgrade on the following appliances:
+
+Name           Online    Current version    Prepare version
+----           ------    ---------------    ---------------
+controller1    ✓         5.5.7+28767        6.0.0+29426
+controller2    ✓         5.5.7+28767        6.0.0+29426
+gateway        ✓         5.5.7+28767        6.0.0+29426
+
+
+3. Delete upgrade image from Controller
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := showPrepareUpgradeMessage(tt.args.f, tt.args.appliance, tt.args.skip, tt.args.stats)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("showPrepareUpgradeMessage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -723,8 +723,8 @@ func Test_showPrepareUpgradeMessage(t *testing.T) {
 1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
 2. Prepare upgrade on the following appliances:
 
-Name           Online    Current version    Prepare version
-----           ------    ---------------    ---------------
+Appliance      Online    Current version    Prepare version
+---------      ------    ---------------    ---------------
 controller1    ✓         5.5.7+28767        6.0.0+29426
 controller2    ✓         5.5.7+28767        6.0.0+29426
 gateway        ✓         5.5.7+28767        6.0.0+29426
@@ -734,8 +734,8 @@ gateway        ✓         5.5.7+28767        6.0.0+29426
 
 The following appliances will be skipped:
 
-Name           Online    Current version    Reason
-----           ------    ---------------    ------
+Appliance      Online    Current version    Reason
+---------      ------    ---------------    ------
 controller3    ⨯         5.5.7+28767        appliance is offline
 gateway2       ✓         6.0.0+29426        version is already greater or equal to prepare version
 
@@ -785,8 +785,8 @@ gateway2       ✓         6.0.0+29426        version is already greater or equa
 1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
 2. Prepare upgrade on the following appliances:
 
-Name           Online    Current version    Prepare version
-----           ------    ---------------    ---------------
+Appliance      Online    Current version    Prepare version
+---------      ------    ---------------    ---------------
 controller1    ✓         5.5.7+28767        6.0.0+29426
 controller2    ✓         5.5.7+28767        6.0.0+29426
 gateway        ✓         5.5.7+28767        6.0.0+29426


### PR DESCRIPTION
This continues the work from #236 with additional summary text re-works to make more clear.

These summaries have been updated:
- post-upgrade summary
- prepare summary

Additional changes:
- set goreleaser to use github-native api for generating release notes