### PR TITLE
fix #243: system shortcuts in file paths not allowed

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/appgate/sdpctl/pkg/filesystem"
 	"github.com/appgate/sdpctl/pkg/prompt"
 	"github.com/appgate/sdpctl/pkg/terminal"
 	"github.com/appgate/sdpctl/pkg/tui"
@@ -160,7 +160,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 		if opts.backup {
 			destPrompt := &survey.Input{
 				Message: "Path to where backup should be saved",
-				Default: os.ExpandEnv(opts.backupDestination),
+				Default: filesystem.AbsolutePath(opts.backupDestination),
 			}
 
 			if err := survey.AskOne(destPrompt, &opts.backupDestination, nil); err != nil {

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -2,13 +2,12 @@ package configure
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/appgate/sdpctl/pkg/filesystem"
 	"github.com/appgate/sdpctl/pkg/prompt"
 	"github.com/appgate/sdpctl/pkg/util"
 	log "github.com/sirupsen/logrus"
@@ -58,10 +57,7 @@ func configRun(cmd *cobra.Command, args []string, opts *configureOptions) error 
 	}
 
 	if len(opts.PEM) > 0 {
-		opts.PEM = os.ExpandEnv(opts.PEM)
-		if absPath, err := filepath.Abs(opts.PEM); err == nil {
-			opts.PEM = absPath
-		}
+		opts.PEM = filesystem.AbsolutePath(opts.PEM)
 		if ok, err := util.FileExists(opts.PEM); err != nil || !ok {
 			return fmt.Errorf("File not found: %s", opts.PEM)
 		}

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -59,6 +59,7 @@ func PrepareBackup(opts *BackupOpts) error {
 		return fmt.Errorf("This should not be executed on an appliance")
 	}
 
+	opts.Destination = filesystem.AbsolutePath(opts.Destination)
 	if err := os.MkdirAll(opts.Destination, 0700); err != nil {
 		return err
 	}

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/adrg/xdg"
 )
@@ -14,6 +15,20 @@ const (
 	XdgConfigHome = "XDG_CONFIG_HOME"
 	AppData       = "AppData"
 )
+
+func AbsolutePath(s string) string {
+	cs := s
+	if strings.HasPrefix(cs, "~") {
+		// remove tilde and replace with homedir
+		h, _ := os.UserHomeDir()
+		cs = h + cs[1:]
+	}
+	cs = os.ExpandEnv(cs)
+	if absPath, err := filepath.Abs(cs); err == nil {
+		cs = absPath
+	}
+	return cs
+}
 
 func ConfigDir() string {
 	if path := os.Getenv(AgConfigDir); len(path) > 0 {

--- a/pkg/filesystem/filesystem_test.go
+++ b/pkg/filesystem/filesystem_test.go
@@ -61,3 +61,40 @@ func TestConfigDir(t *testing.T) {
 		})
 	}
 }
+
+func TestAbsolutePath(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "absolute path",
+			arg:  "/tmp/path",
+			want: "/tmp/path",
+		},
+		{
+			name: "relative path",
+			arg:  "tmp/path",
+			want: os.ExpandEnv("${PWD}/tmp/path"),
+		},
+		{
+			name: "path with env variable",
+			arg:  "${HOME}/tmp/path",
+			want: os.ExpandEnv("${HOME}/tmp/path"),
+		},
+		{
+			name: "path with tilde",
+			arg:  "~/tmp/path",
+			want: os.ExpandEnv("${HOME}/tmp/path"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AbsolutePath(tt.arg)
+			if got != tt.want {
+				t.Errorf("AbsolutePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In some cases the '\~' (tilde) would not be parsed as a system shortcut by `os.ExpandEnv`. This PR introduces a helper function for getting the absolute path, `filesystem.AbsolutePath`, that replaces the '\~' if it's prefixed in the path argument.

Fixes:
- #243