### PR TITLE
Use keybase/go-keychain for storing credentials in macOS keychain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,14 @@ jobs:
           go-version: ^1.18
         id: go
 
-      - name: "Goreleaser build"
-        uses: goreleaser/goreleaser-action@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SDPCTL_VERSION: ${{ github.ref_name }}
-        with:
-          distribution: goreleaser
-          version: v1.9.2
-          args: "release"
+      - name: GoReleaser release dry run
+        run: make release-dry-run
+
+      - name: Setup release environment
+        run: |-
+          echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> .release-env
+          echo 'SDPCTL_VERSION=${{ github.ref_name }}' >> .release-env
+          echo 'SDPCTL_CONFIG_DIR=/go/src/github.com/user/repo' >> .release-env
+
+      - name: GoReleaser release
+        run: make release

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 dist/
 cover.out
 .idea/
+.release-env

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,6 @@ builds:
     goos:
       - linux
       - windows
-      - darwin
     goarch:
       - amd64
       - arm64
@@ -23,9 +22,6 @@ builds:
       - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ .Env.RELEASE_VERSION }}"
       - -X "github.com/appgate/sdpctl/cmd.commit={{ .Commit }}"
       - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
-    ignore:
-      - goos: darwin
-        goarch: arm64
 universal_binaries:
   - replace: false
     id: sdpctl

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,9 +22,26 @@ builds:
       - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ .Env.RELEASE_VERSION }}"
       - -X "github.com/appgate/sdpctl/cmd.commit={{ .Commit }}"
       - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
+  - id: sdpctl-darwin
+    main: ./main.go
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    env:
+      - CGO_ENABLED=1
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    binary: "{{ if .IsSnapshot }}{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}"
+    ldflags:
+      - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ .Env.RELEASE_VERSION }}"
+      - -X "github.com/appgate/sdpctl/cmd.commit={{ .Commit }}"
+      - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
 universal_binaries:
   - replace: false
-    id: sdpctl
+    id: sdpctl-darwin
 archives:
   - format_overrides:
       - goos: windows

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,14 @@ bindir  := ${prefix}/bin
 commit=$$(git rev-parse HEAD)
 commitPath=github.com/appgate/sdpctl/cmd.commit=${commit}
 
+CGO := 0
+ifeq ($(shell uname),Darwin)
+	CGO = 1
+endif
+
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -o build/$(BIN_NAME) -ldflags="-X '${commitPath}'"
+	CGO_ENABLED=$(CGO) go build -o build/$(BIN_NAME) -ldflags="-X '${commitPath}'"
 
 .PHONY: deps
 deps:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BIN_NAME=sdpctl
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
+GORELEASER_CROSS_VERSION=v1.18.3
 DESTDIR :=
 prefix  := /usr/local
 bindir  := ${prefix}/bin
@@ -41,3 +42,26 @@ install: build
 	install -d ${DESTDIR}${bindir}
 	install -m755 build/$(BIN_NAME) ${DESTDIR}${bindir}/
 
+.PHONY: release-dry-run
+release-dry-run:
+	docker run \
+		--rm \
+		--env-file .release-env \
+		-v $(PWD):/go/src/github.com/user/repo \
+		-w /go/src/github.com/user/repo \
+		goreleaser/goreleaser-cross:$(GORELEASER_CROSS_VERSION) \
+		--skip-validate --rm-dist --skip-publish
+
+.PHONY: release
+release:
+	@if [ ! -f ".release-env" ]; then \
+		echo "\033[91m.release-env is required for release\033[0m";\
+		exit 1;\
+	fi
+	docker run \
+        --rm \
+        --env-file .release-env \
+		-v $(PWD):/go/src/github.com/user/repo \
+		-w /go/src/github.com/user/repo \
+		goreleaser/goreleaser-cross:$(GORELEASER_CROSS_VERSION) \
+		release --rm-dist

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec
+	github.com/keybase/go-keychain v0.0.0-20220610143837-c2ce06069005
 	github.com/mattn/go-isatty v0.0.14
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/rogpeppe/go-internal v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,9 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a/go.mod h1:YPNKjjE7Ubp9dTbnWvsP3HT+hYnY6TfXzubYTBeUxc8=
+github.com/keybase/go-keychain v0.0.0-20220610143837-c2ce06069005 h1:0uT5p980qZwIkSkOHuMgGLUMbz39d6cqQk7eaOE3uso=
+github.com/keybase/go-keychain v0.0.0-20220610143837-c2ce06069005/go.mod h1:5p1xgRXY2da7ggc/67EZO7WlWAZ8TXftfCU6RtvWZJ0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -466,6 +469,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/pkg/keyring/keyring_darwin.go
+++ b/pkg/keyring/keyring_darwin.go
@@ -56,7 +56,7 @@ func AddKeychain(key string, value string) error {
 	item.SetSynchronizable(keychain.SynchronizableNo)
 	item.SetAccessible(keychain.AccessibleWhenUnlocked)
 	err := keychain.AddItem(item)
-	if err != nil {
+	if err != nil && err != keychain.ErrorDuplicateItem {
 		return err
 	}
 	return nil

--- a/pkg/keyring/keyring_darwin.go
+++ b/pkg/keyring/keyring_darwin.go
@@ -1,28 +1,63 @@
 //go:build darwin
 // +build darwin
 
-// The bearer token is not saved in the OS keychain for macOS because of string length limitation.
-// If the user choose to save their username/password in the keychain, they will still experiance a
-// seemless integration, however they need todo a few more http requests on startup for each command they execute.
 package keyring
 
 import (
 	"errors"
+	"fmt"
+	"github.com/keybase/go-keychain"
 	"os"
-
-	zkeyring "github.com/zalando/go-keyring"
 )
 
 // ClearCredentials removes any existing items in the keychain,
 // it will ignore if not found errors
 func ClearCredentials(prefix string) error {
-	for _, k := range []string{username, password} {
-		if err := deleteSecret(format(prefix, k)); err != nil {
-			if !errors.Is(err, zkeyring.ErrNotFound) {
-				return err
-			}
-
+	for _, k := range []string{username, password, bearer} {
+		item := keychain.NewItem()
+		item.SetSecClass(keychain.SecClassGenericPassword)
+		item.SetService(keyringService)
+		item.SetAccount(format(prefix, k))
+		err := keychain.DeleteItem(item)
+		if err != nil {
+			return errors.New("failed to delete credential from keychain")
 		}
+	}
+	return nil
+}
+
+func QueryKeychain(key string) (string, error) {
+	query := keychain.NewItem()
+	query.SetService(keyringService)
+	query.SetSecClass(keychain.SecClassGenericPassword)
+	query.SetMatchLimit(keychain.MatchLimitOne)
+	query.SetAccessGroup(keyringService)
+	query.SetAccount(key)
+	query.SetReturnAttributes(true)
+	query.SetReturnData(true)
+	result, err := keychain.QueryItem(query)
+	if err != nil {
+		return "", errors.New("encountered error when querying the keychain")
+	}
+	if len(result) != 1 {
+		return "", errors.New(fmt.Sprintf("could not find key: %s", key))
+	}
+	return string(result[0].Data), nil
+}
+
+func AddKeychain(key string, value string) error {
+	item := keychain.NewItem()
+	item.SetService(keyringService)
+	item.SetSecClass(keychain.SecClassGenericPassword)
+	item.SetMatchLimit(keychain.MatchLimitOne)
+	item.SetAccessGroup(keyringService)
+	item.SetAccount(key)
+	item.SetData([]byte(value))
+	item.SetSynchronizable(keychain.SynchronizableNo)
+	item.SetAccessible(keychain.AccessibleWhenUnlocked)
+	err := keychain.AddItem(item)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -31,50 +66,68 @@ func GetPassword(prefix string) (string, error) {
 	if v, ok := os.LookupEnv("SDPCTL_PASSWORD"); ok {
 		return v, nil
 	}
-	return getSecret(format(prefix, password))
+	pw, err := QueryKeychain(format(prefix, password))
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("failed to get password from keychain: %s", err))
+	}
+	return pw, nil
 }
 
 func SetPassword(prefix, secret string) error {
-	err := setSecret(format(prefix, password), secret)
+	err := AddKeychain(format(prefix, password), secret)
 	if err != nil {
-		os.Setenv("SDPCTL_PASSWORD", secret)
-		return nil
+		return err
 	}
-	return err
+	return nil
 }
 
 func GetBearer(prefix string) (string, error) {
-	if v, ok := os.LookupEnv("SDPCTL_BEARER"); ok {
-		return v, nil
+	token, err := QueryKeychain(format(prefix, bearer))
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("failed to get bearer token from keychain: %s", err))
 	}
-	return "", errors.New("bearer token not saved persistently on macOS")
+	return token, nil
 }
 
 func SetBearer(prefix, secret string) error {
-	os.Setenv("SDPCTL_BEARER", secret)
+	err := AddKeychain(format(prefix, bearer), secret)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 func SetUsername(prefix, secret string) error {
-	err := setSecret(format(prefix, username), secret)
+	err := AddKeychain(format(prefix, username), secret)
 	if err != nil {
-		os.Setenv("SDPCTL_USERNAME", secret)
-		return nil
+		return err
 	}
-	return err
+	return nil
 }
 
 func GetUsername(prefix string) (string, error) {
 	if v, ok := os.LookupEnv("SDPCTL_USERNAME"); ok {
 		return v, nil
 	}
-	return getSecret(format(prefix, username))
+	user, err := QueryKeychain(format(prefix, username))
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("failed to get username from keychain: %s", err))
+	}
+	return user, nil
 }
 
 func GetRefreshToken(prefix string) (string, error) {
-	return "", errors.New("macOS is not supported")
+	token, err := QueryKeychain(format(prefix, refreshToken))
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("failed to get refresh token from keychain: %s", err))
+	}
+	return token, nil
 }
 
 func SetRefreshToken(prefix, secret string) error {
-	return errors.New("macOS is not supported")
+	err := AddKeychain(format(prefix, refreshToken), secret)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
We could not use zalando/go-keyring to store bearer token because its underlying darwin implementation used the command `/usr/bin/security add-generic-password` which imposed a 256K BSD buffer size limit. This wasn't enough buffer to store the bearer token. 

Switch the macOS implementation for keychain management to [keybase/go-keychain](https://github.com/keybase/go-keychain). 

Internal ticket: SA-19422 and SA-19363