### PR TITLE
Show help/usage in `sdpctl completion`

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -14,13 +14,11 @@ func NewCmdCompletion() *cobra.Command {
 		Annotations: map[string]string{
 			"skipAuthCheck": "true",
 		},
-		Short:                 docs.CompletionDocs.Short,
-		Long:                  docs.CompletionDocs.Long,
-		DisableFlagsInUseLine: true,
-		DisableFlagParsing:    true,
-		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.ExactValidArgs(1),
-		Example:               docs.CompletionDocs.ExampleString(),
+		Short:     docs.CompletionDocs.Short,
+		Long:      docs.CompletionDocs.Long,
+		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+		Args:      cobra.ExactValidArgs(1),
+		Example:   docs.CompletionDocs.ExampleString(),
 		Run: func(cmd *cobra.Command, args []string) {
 			switch args[0] {
 			case "bash":


### PR DESCRIPTION
`DisableFlagsInUseLine` and `DisableFlagParsing` were set to `true`

When flag parsing is disabled on the command, we get the following when you run `sdpctl completion --help`
```
1 error occurred:
	* invalid argument "--help" for "sdpctl completion"

exit status 1
```


Internal Ticket: SA-19774