### PR TITLE
SA1019 - replaced deprecated function

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -72,7 +71,7 @@ func generateManPages(cmd *cobra.Command) error {
 		return err
 	}
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return err
 	}
@@ -89,7 +88,7 @@ func generateManPages(cmd *cobra.Command) error {
 			return err
 		}
 		defer w.Close()
-		b, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", path, f.Name()))
+		b, err := os.ReadFile(fmt.Sprintf("%s/%s", path, f.Name()))
 		if err != nil {
 			return err
 		}

--- a/cmd/token/revoke.go
+++ b/cmd/token/revoke.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -198,7 +197,7 @@ func revokeByTokenTypeRun(args []string, opts *RevokeOptions) error {
 }
 
 func PrintRevokedTokens(response *http.Response, out io.Writer, printJSON bool) error {
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
replaced deprecated function with latest standard lib recommendations

See:
https://pkg.go.dev/io/ioutil#ReadDir
https://pkg.go.dev/io/ioutil#ReadFile


```
staticcheck ./...

cmd/generate.go:8:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
cmd/token/revoke.go:9:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
```