### PR TITLE
Fix partial upgrade with filter fails

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -214,7 +214,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	}
 	if !opts.forcePrepare {
 		var skip []openapi.Appliance
-		appliances, skip = appliancepkg.CheckVersions(ctx, initialStats, appliances, targetVersion)
+		appliances, skip = appliancepkg.CheckVersions(ctx, *initialStats, appliances, targetVersion)
 		if len(appliances) <= 0 {
 			return errors.New("No appliances to prepare for upgrade. All appliances are already greater or equal to the upgrade image")
 		}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -146,7 +146,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 	flags.BoolVar(&opts.DevKeyring, "dev-keyring", false, "Use the development keyring to verify the upgrade image")
 	flags.Int("throttle", 5, "Upgrade is done in batches using a throttle value. You can control the throttle using this flag.")
 	flags.BoolVar(&opts.hostOnController, "host-on-controller", false, "Use primary controller as image host when uploading from remote source.")
-	flags.BoolVar(&opts.forcePrepare, "force", false, "force prepare of upgrade on appliances even though the version uploaded is the same as the version already running on the appliance")
+	flags.BoolVar(&opts.forcePrepare, "force", false, "force prepare of upgrade on appliances even though the version uploaded is the same or lower then the version already running on the appliance")
 
 	return prepareCmd
 }

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -427,7 +427,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrOut: regexp.MustCompile(`No appliances to prepare for upgrade. All appliances are already at the same version as the upgrade image`),
+			wantErrOut: regexp.MustCompile(`No appliances to prepare for upgrade. All appliances are already greater or equal to the upgrade image`),
 		},
 		{
 			name:                     "force prepare same version",

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -161,9 +161,9 @@ func ShowAutoscalingWarningMessage(templateAppliance *openapi.Appliance, gateway
 	return tpl.String(), nil
 }
 
-// CheckVersionsEqual will check if appliance versions are equal to the version being uploaded on all appliances
+// CheckVersions will check if appliance versions are equal to the version being uploaded on all appliances
 // Returns a slice of appliances that are not equal, a slice of appliances that have the same version and an error
-func CheckVersionsEqual(ctx context.Context, stats openapi.StatsAppliancesList, appliances []openapi.Appliance, v *version.Version) ([]openapi.Appliance, []openapi.Appliance) {
+func CheckVersions(ctx context.Context, stats openapi.StatsAppliancesList, appliances []openapi.Appliance, v *version.Version) ([]openapi.Appliance, []openapi.Appliance) {
 	skip := []openapi.Appliance{}
 	keep := []openapi.Appliance{}
 
@@ -177,8 +177,7 @@ func CheckVersionsEqual(ctx context.Context, stats openapi.StatsAppliancesList, 
 				}
 				statBuildNr, _ := strconv.ParseInt(statV.Metadata(), 10, 64)
 				uploadBuildNr, _ := strconv.ParseInt(v.Metadata(), 10, 64)
-				if statV.Equal(v) && statBuildNr == uploadBuildNr {
-					log.WithField("appliance", appliance.GetName()).Info("Appliance is already at the same version. Skipping.")
+				if v.LessThanOrEqual(statV) && uploadBuildNr <= statBuildNr {
 					skip = append(skip, appliance)
 				} else {
 					keep = append(keep, appliance)

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -175,9 +174,7 @@ func CheckVersions(ctx context.Context, stats openapi.StatsAppliancesList, appli
 					log.Warn("failed to parse version from stats")
 					continue
 				}
-				statBuildNr, _ := strconv.ParseInt(statV.Metadata(), 10, 64)
-				uploadBuildNr, _ := strconv.ParseInt(v.Metadata(), 10, 64)
-				if v.LessThanOrEqual(statV) && uploadBuildNr <= statBuildNr {
+				if CompareVersionsAndBuildNumber(statV, v) < 1 {
 					skip = append(skip, appliance)
 				} else {
 					keep = append(keep, appliance)


### PR DESCRIPTION
This simplifies the version check when preparing an upgrade and accounts for all appliance versions instead of just the primary controllers version.

Fixes: SA-19776