### PR TITLE
242 feature implement command for managing the file repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ $ sdpctl token revoke CN=8401189b492f4d76b6671a9ba03b4ce1,CN=admin,OU=local
 More details on the token command can be found in [the token command documentation](./docs/token.md)
 
 ---
+## The `files` command
+The files command lets you manage the file repository of the currently connected Controller. It supports basic file operations, such as listing files, deleting files and uploading files.
+```bash
+# List files in the repository
+$ sdpctl files list
+Name                                Status    Created                                 Modified                                Failure Reason
+----                                ------    -------                                 --------                                --------------
+appgate-6.0.1-29983-beta.img.zip    Ready     2022-08-19 08:06:20.909002 +0000 UTC    2022-08-19 08:06:20.909002 +0000 UTC
+```
+
+---
 ## Other available commands
 
 ### `sdpctl open`

--- a/cmd/files/delete.go
+++ b/cmd/files/delete.go
@@ -1,0 +1,102 @@
+package files
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/appgate/sdpctl/pkg/docs"
+	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/appgate/sdpctl/pkg/prompt"
+	"github.com/spf13/cobra"
+)
+
+func NewFilesDeleteCmd(f *factory.Factory) *cobra.Command {
+	opts := &FilesOptions{
+		Config: f.Config,
+		Out:    f.IOOutWriter,
+		API:    f.Files,
+	}
+
+	deleteCmd := &cobra.Command{
+		Use:       "delete",
+		Aliases:   []string{"remove", "rm"},
+		Short:     docs.FilesDeleteDocs.Short,
+		Long:      docs.FilesDeleteDocs.Long,
+		Example:   docs.FilesDeleteDocs.ExampleString(),
+		ValidArgs: []string{"filename"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			api, err := opts.API(f.Config)
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+
+			if len(args) == 1 {
+				if err := api.Delete(ctx, args[0]); err != nil {
+					return err
+				}
+				fmt.Fprintf(opts.Out, "%s: deleted\n", args[0])
+				return nil
+			}
+
+			allFlag, err := cmd.Flags().GetBool("all")
+			if err != nil {
+				return err
+			}
+
+			fileList, err := api.List(ctx)
+			if err != nil {
+				return err
+			}
+
+			if allFlag {
+				for _, file := range fileList {
+					if err := api.Delete(ctx, file.GetName()); err != nil {
+						return err
+					}
+					fmt.Fprintf(opts.Out, "%s: deleted\n", file.GetName())
+				}
+				return nil
+			}
+
+			noInteractive, err := cmd.Flags().GetBool("no-interactive")
+			if err != nil {
+				return err
+			}
+			if !noInteractive {
+				fileNameList := []string{}
+				for _, file := range fileList {
+					fileNameList = append(fileNameList, file.GetName())
+				}
+				qs := &survey.MultiSelect{
+					PageSize: len(fileNameList),
+					Message:  "select files to delete:",
+					Options:  fileNameList,
+				}
+
+				selected := []string{}
+				if err := prompt.SurveyAskOne(qs, &selected); err != nil {
+					return err
+				}
+
+				for _, s := range selected {
+					if err := api.Delete(ctx, s); err != nil {
+						return err
+					}
+					fmt.Fprintf(opts.Out, "%s: deleted\n", s)
+				}
+
+				return nil
+			}
+
+			return errors.New("No files were deleted")
+		},
+	}
+
+	deleteCmd.Flags().Bool("all", false, "delete all files from repository")
+
+	return deleteCmd
+}

--- a/cmd/files/delete_test.go
+++ b/cmd/files/delete_test.go
@@ -1,0 +1,143 @@
+package files
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdpctl/pkg/configuration"
+	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/appgate/sdpctl/pkg/files"
+	"github.com/appgate/sdpctl/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupDeleteTest(t *testing.T) (*httpmock.Registry, *factory.Factory, *bytes.Buffer) {
+	t.Helper()
+	registry := httpmock.NewRegistry(t)
+
+	stdout := &bytes.Buffer{}
+	stdin := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	in := io.NopCloser(stdin)
+	f := &factory.Factory{
+		Config: &configuration.Config{
+			Debug: false,
+			URL:   fmt.Sprintf("http://localhost:%d", registry.Port),
+		},
+		IOOutWriter: stdout,
+		Stdin:       in,
+		StdErr:      stderr,
+	}
+
+	f.APIClient = func(c *configuration.Config) (*openapi.APIClient, error) {
+		return registry.Client, nil
+	}
+	f.Files = func(c *configuration.Config) (*files.FilesAPI, error) {
+		api, _ := f.APIClient(c)
+		filesAPI := &files.FilesAPI{
+			Config:     c,
+			HTTPClient: api.GetConfig().HTTPClient,
+		}
+		return filesAPI, nil
+	}
+
+	return registry, f, stdout
+}
+
+func TestDeleteSingleFile(t *testing.T) {
+	registry, f, out := setupDeleteTest(t)
+	defer registry.Teardown()
+	registry.Register("/files/appgate-6.0.1-29983-beta.img.zip", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	registry.Serve()
+
+	cmd := NewFilesCmd(f)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"delete", "appgate-6.0.1-29983-beta.img.zip"})
+
+	_, err := cmd.ExecuteC()
+	if err != nil {
+		t.Fatalf("executeC %s", err)
+	}
+
+	actual, err := io.ReadAll(out)
+	if err != nil {
+		t.Fatalf("unable to read stdout %s", err)
+	}
+
+	expect := "appgate-6.0.1-29983-beta.img.zip: deleted\n"
+
+	assert.Equal(t, expect, string(actual))
+}
+
+func TestDeleteAllFiles(t *testing.T) {
+	registry, f, out := setupDeleteTest(t)
+	defer registry.Teardown()
+	registry.Register("/files", httpmock.JSONResponse("../../pkg/files/fixtures/list.json"))
+	registry.Register("/files/appgate-6.0.1-29983-beta.img.zip", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	registry.Register("/files/appgate-5.5.1-29983.img.zip", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	registry.Serve()
+
+	cmd := NewFilesCmd(f)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"delete", "--all"})
+
+	_, err := cmd.ExecuteC()
+	if err != nil {
+		t.Fatalf("executeC %s", err)
+	}
+
+	actual, err := io.ReadAll(out)
+	if err != nil {
+		t.Fatalf("unable to read stdout %s", err)
+	}
+
+	expect := `appgate-6.0.1-29983-beta.img.zip: deleted
+appgate-5.5.1-29983.img.zip: deleted
+`
+
+	assert.Equal(t, expect, string(actual))
+}
+
+func TestFilesDeleteNoInteractive(t *testing.T) {
+	registry, f, out := setupDeleteTest(t)
+	defer registry.Teardown()
+	registry.Register("/files", httpmock.JSONResponse("../../pkg/files/fixtures/list.json"))
+	registry.Serve()
+
+	cmd := NewFilesCmd(f)
+	cmd.PersistentFlags().Bool("no-interactive", false, "")
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"delete", "--no-interactive"})
+
+	_, err := cmd.ExecuteC()
+	if err == nil {
+		t.Fatalf("expected error, got no error")
+	}
+
+	assert.Equal(t, "No files were deleted", err.Error())
+}

--- a/cmd/files/files.go
+++ b/cmd/files/files.go
@@ -26,6 +26,7 @@ func NewFilesCmd(f *factory.Factory) *cobra.Command {
 	}
 
 	filesCmd.AddCommand(NewFilesListCmd(f))
+	filesCmd.AddCommand(NewFilesDeleteCmd(f))
 
 	return filesCmd
 }

--- a/cmd/files/files.go
+++ b/cmd/files/files.go
@@ -1,0 +1,31 @@
+package files
+
+import (
+	"io"
+
+	"github.com/appgate/sdpctl/pkg/configuration"
+	"github.com/appgate/sdpctl/pkg/docs"
+	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/appgate/sdpctl/pkg/files"
+	"github.com/spf13/cobra"
+)
+
+type FilesOptions struct {
+	Config *configuration.Config
+	Out    io.Writer
+	API    func(c *configuration.Config) (*files.FilesAPI, error)
+	JSON   bool
+}
+
+func NewFilesCmd(f *factory.Factory) *cobra.Command {
+	var filesCmd = &cobra.Command{
+		Use:     "files",
+		Short:   docs.FilesDocs.Short,
+		Long:    docs.FilesDocs.Long,
+		Example: docs.FilesDocs.ExampleString(),
+	}
+
+	filesCmd.AddCommand(NewFilesListCmd(f))
+
+	return filesCmd
+}

--- a/cmd/files/list.go
+++ b/cmd/files/list.go
@@ -1,0 +1,54 @@
+package files
+
+import (
+	"context"
+
+	"github.com/appgate/sdpctl/pkg/docs"
+	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/appgate/sdpctl/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+func NewFilesListCmd(f *factory.Factory) *cobra.Command {
+	opts := &FilesOptions{
+		Config: f.Config,
+		Out:    f.IOOutWriter,
+		API:    f.Files,
+	}
+	var listCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   docs.FilesListDocs.Short,
+		Long:    docs.FilesListDocs.Long,
+		Example: docs.FilesListDocs.ExampleString(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			f, err := opts.API(opts.Config)
+			if err != nil {
+				return err
+			}
+
+			files, err := f.List(ctx)
+			if err != nil {
+				return err
+			}
+
+			if opts.JSON {
+				return util.PrintJSON(opts.Out, files)
+			}
+
+			p := util.NewPrinter(opts.Out, 4)
+			p.AddHeader("Name", "Status", "Created", "Modified", "Failure Reason")
+			for _, file := range files {
+				p.AddLine(file.GetName(), file.GetStatus(), file.GetCreationTime(), file.GetLastModifiedTime(), file.GetFailureReason())
+			}
+			p.Print()
+
+			return nil
+		},
+	}
+
+	listCmd.Flags().BoolVar(&opts.JSON, "json", false, "output in json format")
+
+	return listCmd
+}

--- a/cmd/files/list_test.go
+++ b/cmd/files/list_test.go
@@ -1,0 +1,99 @@
+package files
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdpctl/pkg/configuration"
+	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/appgate/sdpctl/pkg/files"
+	"github.com/appgate/sdpctl/pkg/httpmock"
+	"github.com/appgate/sdpctl/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupTest(t *testing.T) (*httpmock.Registry, *factory.Factory, *bytes.Buffer) {
+	t.Helper()
+	registry := httpmock.NewRegistry(t)
+	registry.Register("/files", httpmock.JSONResponse("../../pkg/files/fixtures/list.json"))
+	registry.Serve()
+
+	stdout := &bytes.Buffer{}
+	stdin := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	in := io.NopCloser(stdin)
+	f := &factory.Factory{
+		Config: &configuration.Config{
+			Debug: false,
+			URL:   fmt.Sprintf("http://localhost:%d", registry.Port),
+		},
+		IOOutWriter: stdout,
+		Stdin:       in,
+		StdErr:      stderr,
+	}
+
+	f.APIClient = func(c *configuration.Config) (*openapi.APIClient, error) {
+		return registry.Client, nil
+	}
+	f.Files = func(c *configuration.Config) (*files.FilesAPI, error) {
+		api, _ := f.APIClient(c)
+		filesAPI := &files.FilesAPI{
+			Config:     c,
+			HTTPClient: api.GetConfig().HTTPClient,
+		}
+		return filesAPI, nil
+	}
+
+	return registry, f, stdout
+}
+
+func TestFilesList(t *testing.T) {
+	registry, f, out := setupTest(t)
+	defer registry.Teardown()
+
+	cmd := NewFilesCmd(f)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"list"})
+
+	_, err := cmd.ExecuteC()
+	if err != nil {
+		t.Fatalf("executeC %s", err)
+	}
+	actual, err := io.ReadAll(out)
+	if err != nil {
+		t.Fatalf("unable to read stdout %s", err)
+	}
+
+	expect := `Name                                Status    Created                                 Modified                                Failure Reason
+----                                ------    -------                                 --------                                --------------
+appgate-6.0.1-29983-beta.img.zip    Failed    2022-08-18 11:25:52.494572 +0000 UTC    2022-08-18 11:25:52.494572 +0000 UTC    401 Unauthorized
+appgate-5.5.1-29983.img.zip         Ready     2022-08-18 11:26:52.494572 +0000 UTC    2022-08-18 12:25:52.494572 +0000 UTC    
+`
+
+	assert.Equal(t, string(actual), expect)
+}
+
+func TestFilesListJSON(t *testing.T) {
+	registry, f, out := setupTest(t)
+	defer registry.Teardown()
+
+	cmd := NewFilesCmd(f)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"list", "--json"})
+
+	_, err := cmd.ExecuteC()
+	if err != nil {
+		t.Fatalf("executeC %s", err)
+	}
+	actual, err := io.ReadAll(out)
+	if err != nil {
+		t.Fatalf("unable to read stdout %s", err)
+	}
+
+	assert.True(t, util.IsJSON(string(actual)))
+}

--- a/cmd/files/list_test.go
+++ b/cmd/files/list_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func setupTest(t *testing.T) (*httpmock.Registry, *factory.Factory, *bytes.Buffer) {
+func setupListTest(t *testing.T) (*httpmock.Registry, *factory.Factory, *bytes.Buffer) {
 	t.Helper()
 	registry := httpmock.NewRegistry(t)
 	registry.Register("/files", httpmock.JSONResponse("../../pkg/files/fixtures/list.json"))
@@ -51,7 +51,7 @@ func setupTest(t *testing.T) (*httpmock.Registry, *factory.Factory, *bytes.Buffe
 }
 
 func TestFilesList(t *testing.T) {
-	registry, f, out := setupTest(t)
+	registry, f, out := setupListTest(t)
 	defer registry.Teardown()
 
 	cmd := NewFilesCmd(f)
@@ -78,7 +78,7 @@ appgate-5.5.1-29983.img.zip         Ready     2022-08-18 11:26:52.494572 +0000 U
 }
 
 func TestFilesListJSON(t *testing.T) {
-	registry, f, out := setupTest(t)
+	registry, f, out := setupListTest(t)
 	defer registry.Teardown()
 
 	cmd := NewFilesCmd(f)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 
 	appliancecmd "github.com/appgate/sdpctl/cmd/appliance"
 	cfgcmd "github.com/appgate/sdpctl/cmd/configure"
+	filescmd "github.com/appgate/sdpctl/cmd/files"
 	"github.com/appgate/sdpctl/pkg/auth"
 	"github.com/appgate/sdpctl/pkg/cmdutil"
 	"github.com/appgate/sdpctl/pkg/configuration"
@@ -98,6 +99,7 @@ func NewCmdRoot() *cobra.Command {
 	rootCmd.AddCommand(NewCmdCompletion())
 	rootCmd.AddCommand(NewHelpCmd(f))
 	rootCmd.AddCommand(NewOpenCmd(f))
+	rootCmd.AddCommand(filescmd.NewFilesCmd(f))
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.SetUsageTemplate(UsageTemplate())
 	rootCmd.SetHelpTemplate(HelpTemplate())

--- a/pkg/docs/files.go
+++ b/pkg/docs/files.go
@@ -32,4 +32,30 @@ appgate-6.0.1-29983-beta.img.zip    Ready     2022-08-19 08:06:20.909002 +0000 U
 			},
 		},
 	}
+	FilesDeleteDocs = CommandDoc{
+		Short: "delete files from the repository",
+		Long:  `Delete files from the repository with this command. There are multiple options on which file(s) should be deleted.`,
+		Examples: []ExampleDoc{
+			{
+				Description: "delete a single file using the filename as a parameter",
+				Command:     "sdpctl files delete file-to-delete.img.zip",
+				Output:      "file-to-delete.img.zip: deleted",
+			},
+			{
+				Description: "delete all files in the repository",
+				Command:     "sdpctl files delete --all",
+				Output: `deleted1.img.zip: deleted
+deleted2.img.zip: deleted`,
+			},
+			{
+				Description: "no arguments will prompt for which files to delete",
+				Command:     "sdpctl files delete",
+				Output: `? select files to delete:  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
+> [ ]  file1.img.zip
+  [ ]  file2.img.zip
+  [ ]  file3.img.zip
+`,
+			},
+		},
+	}
 )

--- a/pkg/docs/files.go
+++ b/pkg/docs/files.go
@@ -1,0 +1,35 @@
+package docs
+
+var (
+	FilesDocs = CommandDoc{
+		Short:    "The files command lets you manage the file repository on the connected Controller",
+		Long:     `The files command lets you manage the file repository on the currently connected Controller.`,
+		Examples: []ExampleDoc{},
+	}
+	FilesListDocs = CommandDoc{
+		Short: "lists the files in the controllers file repository",
+		Long: `Lists the files in the controllers file repository. Default output is in table format.
+Optionally print the output in JSON format by using the "--json" flag`,
+		Examples: []ExampleDoc{
+			{
+				Description: "list files table output",
+				Command:     "sdctl files list",
+				Output: `Name                                Status    Created                                 Modified                                Failure Reason
+----                                ------    -------                                 --------                                --------------
+appgate-6.0.1-29983-beta.img.zip    Ready     2022-08-19 08:06:20.909002 +0000 UTC    2022-08-19 08:06:20.909002 +0000 UTC`,
+			},
+			{
+				Description: "list files using JSON output",
+				Command:     "sdctl files list --json",
+				Output: `[
+  {
+    "creationTime": "2022-08-19T08:06:20.909002Z",
+    "lastModifiedTime": "2022-08-19T08:06:20.909002Z",
+    "name": "appgate-6.0.1-29983-beta.img.zip",
+    "status": "Ready"
+  }
+]`,
+			},
+		},
+	}
+)

--- a/pkg/files/api.go
+++ b/pkg/files/api.go
@@ -56,3 +56,34 @@ func (f *FilesAPI) List(ctx context.Context) ([]openapi.File, error) {
 
 	return respBody.Data, nil
 }
+
+func (f *FilesAPI) Delete(ctx context.Context, filename string) error {
+	url := fmt.Sprintf("%s/files/%s", f.Config.URL, filename)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	token, err := f.Config.GetBearTokenHeaderValue()
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Accept", fmt.Sprintf("application/vnd.appgate.peer-v%d+json", f.Config.Version))
+
+	resp, err := f.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return errors.New(string(body))
+	}
+
+	return nil
+}

--- a/pkg/files/api.go
+++ b/pkg/files/api.go
@@ -1,0 +1,58 @@
+package files
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdpctl/pkg/configuration"
+)
+
+type FilesAPI struct {
+	Config     *configuration.Config
+	HTTPClient *http.Client
+}
+
+func (f *FilesAPI) List(ctx context.Context) ([]openapi.File, error) {
+	url := fmt.Sprintf("%s/files", f.Config.URL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	token, err := f.Config.GetBearTokenHeaderValue()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Accept", fmt.Sprintf("application/vnd.appgate.peer-v%d+json", f.Config.Version))
+
+	response, err := f.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode >= 400 {
+		return nil, errors.New(string(body))
+	}
+
+	type responseBody struct {
+		Data []openapi.File
+	}
+
+	respBody := responseBody{}
+	if err := json.Unmarshal(body, &respBody); err != nil {
+		return nil, err
+	}
+
+	return respBody.Data, nil
+}

--- a/pkg/files/fixtures/list.json
+++ b/pkg/files/fixtures/list.json
@@ -1,0 +1,17 @@
+{
+    "data": [
+        {
+            "name": "appgate-6.0.1-29983-beta.img.zip",
+            "creationTime": "2022-08-18T11:25:52.494572Z",
+            "lastModifiedTime": "2022-08-18T11:25:52.494572Z",
+            "status": "Failed",
+            "failureReason": "401 Unauthorized"
+        },
+        {
+            "name": "appgate-5.5.1-29983.img.zip",
+            "creationTime": "2022-08-18T11:26:52.494572Z",
+            "lastModifiedTime": "2022-08-18T12:25:52.494572Z",
+            "status": "Ready"
+        }
+    ]
+}


### PR DESCRIPTION
This adds a new `files` command to sdpctl for managing the file repository in the currently connected controller. This PR includes commands for listing and deleting files in the repository. Other file operations, like uploading, will be handled in seperate PR.