### PR TITLE
Wrap http err

### DIFF
--- a/pkg/api/apiutil.go
+++ b/pkg/api/apiutil.go
@@ -41,5 +41,5 @@ func HTTPErrorResponse(response *http.Response, err error) error {
 		}
 		return errors
 	}
-	return multierror.Append(errors, err)
+	return err
 }

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -385,9 +385,9 @@ func BackupPrompt(appliances []openapi.Appliance, preSelected []openapi.Applianc
 }
 
 func backupEnabled(ctx context.Context, client *openapi.APIClient, token string, noInteraction bool) (bool, error) {
-	settings, _, err := client.GlobalSettingsApi.GlobalSettingsGet(ctx).Authorization(token).Execute()
+	settings, response, err := client.GlobalSettingsApi.GlobalSettingsGet(ctx).Authorization(token).Execute()
 	if err != nil {
-		return false, err
+		return false, api.HTTPErrorResponse(response, err)
 	}
 	enabled := settings.GetBackupApiEnabled()
 	if !enabled && !noInteraction {


### PR DESCRIPTION
this PR mitigates showing the user nested multierr lists and wrap backup api error within `api.HTTPErrorResponse`

Example:
based on edge case, where the user had outdated credentials stored on localhost,
which caused error message

```
1 error occurred:
	* Failed to determine backup option: 401 Unauthorized
```

updated format will now be.
```
1 error occurred:
	* Credentials are required to access this resource.
```