### PR TITLE
updated outdated key value in default filter.

### DIFF
--- a/cmd/appliance/upgrade/status.go
+++ b/cmd/appliance/upgrade/status.go
@@ -31,7 +31,7 @@ func NewUpgradeStatusCmd(f *factory.Factory) *cobra.Command {
 		debug:     f.Config.Debug,
 		Out:       f.IOOutWriter,
 		defaultFilter: map[string]map[string]string{
-			"filter": {},
+			"include": {},
 			"exclude": {
 				"active": "false",
 			},


### PR DESCRIPTION
resolve issue where filter was not applicble for example
`sdpctl appliance upgrade status --include=function=gateway`