### PR TITLE
clear credentials when configuring

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -46,6 +46,11 @@ func NewCmdConfigure(f *factory.Factory) *cobra.Command {
 }
 
 func configRun(cmd *cobra.Command, args []string, opts *configureOptions) error {
+	// Clear old credentials when configuring
+	if err := opts.Config.ClearCredentials(); err != nil {
+		return err
+	}
+
 	q := &survey.Input{
 		Message: "Enter the url for the controller API (example https://appgate.controller.com/admin)",
 		Default: opts.Config.URL,

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -8,9 +8,11 @@ import (
 	"time"
 
 	"github.com/appgate/sdpctl/pkg/keyring"
+	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/denisbrodbeck/machineid"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type Config struct {
@@ -168,6 +170,21 @@ func (c *Config) ClearCredentials() error {
 	}
 	c.BearerToken = ""
 	c.ExpiresAt = ""
+	keys := []string{"bearer", "expires_at"}
+	allKeys := viper.AllKeys()
+	for _, k := range keys {
+		if util.InSlice(k, allKeys) {
+			viper.Set(k, "")
+		}
+	}
+	if err := viper.WriteConfig(); err != nil {
+		// only return error if there is a config file to write to
+		// as is the case when using environment variables for configuration
+		// or in testing
+		if !errors.As(err, &viper.ConfigFileNotFoundError{}) {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Clear credentials when running `sdpctl configure`. This will prevent any old tokens that may present to not be re-used before the user has logged in after re-configuring. It will also force the user to re-enter user credentials before any other command requiring the user to be signed in can be run.

Fixes: SA-19900