### PR TITLE
remove timeout for backups

### DIFF
--- a/cmd/appliance/backup/backup.go
+++ b/cmd/appliance/backup/backup.go
@@ -1,8 +1,6 @@
 package backup
 
 import (
-	"time"
-
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/factory"
@@ -52,7 +50,6 @@ func NewCmdBackup(f *factory.Factory) *cobra.Command {
 	flags.BoolVar(&opts.PrimaryFlag, "primary", false, "backup primary controller")
 	flags.BoolVar(&opts.CurrentFlag, "current", false, "backup current peer controller")
 	flags.StringSliceVar(&opts.With, "with", []string{}, "include extra data in backup (audit,logs)")
-	flags.DurationVarP(&opts.Timeout, "timeout", "t", 15*time.Minute, "time out for status check on the backups")
 	flags.BoolVar(&opts.Quiet, "quiet", false, "backup summary will not be printed if setting this flag")
 
 	cmd.AddCommand(NewBackupAPICmd(f))

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -193,7 +193,6 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 		Destination:   opts.backupDestination,
 		AllFlag:       false,
 		PrimaryFlag:   false,
-		Timeout:       5 * time.Minute,
 		Out:           opts.Out,
 		SpinnerOut:    opts.SpinnerOut,
 		NoInteractive: opts.NoInteractive,


### PR DESCRIPTION
Remove the timeout for backups. We cannot cancel a backup that is being processed in the appliance, so having a timeout does not make sense.

Fixes: SA-19896