### PR TITLE
add 2 hour padding on expires_at

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -139,7 +139,7 @@ func (c *Config) ExpiredAtValid() bool {
 		return false
 	}
 	t1 := time.Now()
-	return t1.Before(d)
+	return t1.Add(-time.Hour * 2).Before(d)
 }
 
 func (c *Config) LoadCredentials() (*Credentials, error) {


### PR DESCRIPTION
To mitigate getting HTTP 401 mid upgrade, we make sure we have atleast 2 hours valid token.