### PR TITLE
print error details in tracker when prepare/complete fails

### DIFF
--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -69,7 +69,7 @@ func (u *UpgradeStatus) upgradeStatus(ctx context.Context, appliance openapi.App
 			if util.InSlice(s, undesiredStatuses) {
 				if tracker != nil {
 					// send error details for tracker
-					tracker.Update(details)
+					tracker.Update(s + " - " + details)
 				}
 				return backoff.Permanent(fmt.Errorf("Upgrade failed on %s - %s", name, details))
 			}

--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -67,6 +67,10 @@ func (u *UpgradeStatus) upgradeStatus(ctx context.Context, appliance openapi.App
 				tracker.Update(s)
 			}
 			if util.InSlice(s, undesiredStatuses) {
+				if tracker != nil {
+					// send error details for tracker
+					tracker.Update(details)
+				}
 				return backoff.Permanent(fmt.Errorf("Upgrade failed on %s - %s", name, details))
 			}
 			if util.InSlice(s, desiredStatuses) {

--- a/pkg/tui/tracker.go
+++ b/pkg/tui/tracker.go
@@ -51,7 +51,12 @@ func (t *Tracker) Watch(until, failOn []string) {
 		}
 		if util.InSlice(msg, failOn) {
 			if failCount > 0 {
+				// on failure, we expect the next update to be the details of the failure
+				msg, ok = <-t.statusReport
 				t.current = "failed"
+				if ok {
+					t.current += " - " + msg
+				}
 				t.abort(false)
 				break
 			}

--- a/pkg/tui/tracker.go
+++ b/pkg/tui/tracker.go
@@ -53,9 +53,9 @@ func (t *Tracker) Watch(until, failOn []string) {
 			if failCount > 0 {
 				// on failure, we expect the next update to be the details of the failure
 				msg, ok = <-t.statusReport
-				t.current = "failed"
-				if ok {
-					t.current += " - " + msg
+				t.current = msg
+				if !ok {
+					t.current = "failed"
 				}
 				t.abort(false)
 				break


### PR DESCRIPTION
Tracker now prints the error details when an upgrade prepare/complete fails for some reason, which will help the user know the error before the command exits.