### PR TITLE
dry-run needs .release.env as well

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,14 @@ jobs:
           go-version: ^1.18
         id: go
 
-      - name: GoReleaser release dry run
-        run: make release-dry-run
-
       - name: Setup release environment
         run: |-
           echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> .release-env
           echo 'SDPCTL_VERSION=${{ github.ref_name }}' >> .release-env
           echo 'SDPCTL_CONFIG_DIR=/go/src/github.com/user/repo' >> .release-env
+
+      - name: GoReleaser release dry run
+        run: make release-dry-run
 
       - name: GoReleaser release
         run: make release


### PR DESCRIPTION
Github release action is broken since https://github.com/appgate/sdpctl/pull/250. Dry-run also needs the environment variable file. See https://github.com/appgate/sdpctl/runs/8110063636?check_suite_focus=true