### PR TITLE
Move dry-run to testing

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -28,5 +28,5 @@ jobs:
           echo 'SDPCTL_VERSION=${{ github.ref_name }}' >> .release-env
           echo 'SDPCTL_CONFIG_DIR=/go/src/github.com/user/repo' >> .release-env
 
-      - name: GoReleaser release
-        run: make release
+      - name: GoReleaser release dry run
+        run: make release-dry-run

--- a/.github/workflows/release-flow.yml
+++ b/.github/workflows/release-flow.yml
@@ -12,7 +12,10 @@ jobs:
   lint:
     if: ${{ github.event.base_ref == 'refs/heads/main' }}
     uses: ./.github/workflows/lint.yml
+  dry-run:
+    if: ${{ github.event.base_ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/dry-run.yml
   release:
     if: ${{ github.event.base_ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yml
-    needs: [test, lint]
+    needs: [test, lint, dry-run]


### PR DESCRIPTION
Moved dry-run of release to testing instead. Leaving it in the release job makes the actual release run fail because the dry-run job is dirtying the git state, making the release job fail. See: https://github.com/appgate/sdpctl/runs/8112576925?check_suite_focus=true