### PR TITLE
Fix nil pointer error when no build number is detected

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -215,7 +215,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	}
 	if !opts.forcePrepare {
 		var skip []openapi.Appliance
-		appliances, skip = appliancepkg.CheckVersions(ctx, *initialStats, appliances, targetVersion)
+		appliances, skip, err = appliancepkg.CheckVersions(ctx, *initialStats, appliances, targetVersion)
+		if err != nil {
+			return err
+		}
 		if len(appliances) <= 0 {
 			return errors.New("No appliances to prepare for upgrade. All appliances are already greater or equal to the upgrade image")
 		}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -157,7 +157,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 func checkImageFilename(i string) error {
 	// Check if its a valid filename
 	if rg := regexp.MustCompile(`(.+)?\d\.\d\.\d(.+)?\.img\.zip`); !rg.MatchString(i) {
-		return errors.New("Invalid mimetype on image file. The format is expected to be a .img.zip archive with a version number, such as 5.5.1")
+		return errors.New("Invalid name on image file. The format is expected to be a .img.zip archive with a version number, such as 5.5.1")
 	}
 	return nil
 }
@@ -205,28 +205,27 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	if err != nil {
 		return err
 	}
-	skipAppliances := []skipStruct{}
+	skipAppliances := []appliancepkg.SkipStruct{}
 	appliances, offline, _ := appliancepkg.FilterAvailable(filteredAppliances, initialStats.GetData())
 	for _, a := range offline {
-		skipAppliances = append(skipAppliances, skipStruct{
+		skipAppliances = append(skipAppliances, appliancepkg.SkipStruct{
 			Reason:    "appliance is offline",
 			Appliance: a,
 		})
 	}
 	if !opts.forcePrepare {
-		var skip []openapi.Appliance
-		appliances, skip, err = appliancepkg.CheckVersions(ctx, *initialStats, appliances, targetVersion)
-		if err != nil {
-			return err
-		}
+		var skip []appliancepkg.SkipStruct
+		appliances, skip = appliancepkg.CheckVersions(ctx, *initialStats, appliances, targetVersion)
+		skipAppliances = append(skipAppliances, skip...)
 		if len(appliances) <= 0 {
-			return errors.New("No appliances to prepare for upgrade. All appliances are already greater or equal to the upgrade image")
-		}
-		for _, a := range skip {
-			skipAppliances = append(skipAppliances, skipStruct{
-				Reason:    "version is already greater or equal to prepare version",
-				Appliance: a,
-			})
+			var errs *multierr.Error
+			if len(skipAppliances) > 0 {
+				for _, skip := range skipAppliances {
+					errs = multierr.Append(fmt.Errorf("%s skipped: %s", skip.Appliance.GetName(), skip.Reason), errs)
+				}
+			}
+			errs = multierr.Append(errors.New("No appliances to prepare for upgrade."), errs)
+			return errs
 		}
 	}
 
@@ -670,12 +669,7 @@ The following appliances will be skipped:
 {{ .SkipTable }}{{ end }}
 `
 
-type skipStruct struct {
-	Reason    string
-	Appliance openapi.Appliance
-}
-
-func showPrepareUpgradeMessage(f string, appliance []openapi.Appliance, skip []skipStruct, stats []openapi.StatsAppliancesListAllOfData) (string, error) {
+func showPrepareUpgradeMessage(f string, appliance []openapi.Appliance, skip []appliancepkg.SkipStruct, stats []openapi.StatsAppliancesListAllOfData) (string, error) {
 	type stub struct {
 		Filepath       string
 		ApplianceTable string

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -205,16 +205,16 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	if err != nil {
 		return err
 	}
-	skipAppliances := []appliancepkg.SkipStruct{}
+	skipAppliances := []appliancepkg.SkipUpgrade{}
 	appliances, offline, _ := appliancepkg.FilterAvailable(filteredAppliances, initialStats.GetData())
 	for _, a := range offline {
-		skipAppliances = append(skipAppliances, appliancepkg.SkipStruct{
+		skipAppliances = append(skipAppliances, appliancepkg.SkipUpgrade{
 			Reason:    "appliance is offline",
 			Appliance: a,
 		})
 	}
 	if !opts.forcePrepare {
-		var skip []appliancepkg.SkipStruct
+		var skip []appliancepkg.SkipUpgrade
 		appliances, skip = appliancepkg.CheckVersions(ctx, *initialStats, appliances, targetVersion)
 		skipAppliances = append(skipAppliances, skip...)
 		if len(appliances) <= 0 {
@@ -669,7 +669,7 @@ The following appliances will be skipped:
 {{ .SkipTable }}{{ end }}
 `
 
-func showPrepareUpgradeMessage(f string, appliance []openapi.Appliance, skip []appliancepkg.SkipStruct, stats []openapi.StatsAppliancesListAllOfData) (string, error) {
+func showPrepareUpgradeMessage(f string, appliance []openapi.Appliance, skip []appliancepkg.SkipUpgrade, stats []openapi.StatsAppliancesListAllOfData) (string, error) {
 	type stub struct {
 		Filepath       string
 		ApplianceTable string

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -628,7 +628,7 @@ func Test_showPrepareUpgradeMessage(t *testing.T) {
 	type args struct {
 		f         string
 		appliance []openapi.Appliance
-		skip      []appliancepkg.SkipStruct
+		skip      []appliancepkg.SkipUpgrade
 		stats     []openapi.StatsAppliancesListAllOfData
 	}
 	tests := []struct {
@@ -687,7 +687,7 @@ func Test_showPrepareUpgradeMessage(t *testing.T) {
 						Version: openapi.PtrString("6.0.0+29426"),
 					},
 				},
-				skip: []appliancepkg.SkipStruct{
+				skip: []appliancepkg.SkipUpgrade{
 					{
 						Appliance: openapi.Appliance{
 							Id:   openapi.PtrString("92a8ceed-a364-4e99-a2eb-0a8546bab48f"),

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -393,7 +393,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 			name:       "file name error",
 			cli:        "upgrade prepare --image './testdata/appgate.img'",
 			wantErr:    true,
-			wantErrOut: regexp.MustCompile(`Invalid mimetype on image file. The format is expected to be a .img.zip archive.`),
+			wantErrOut: regexp.MustCompile(`Invalid name on image file. The format is expected to be a .img.zip archive.`),
 		},
 		{
 			name:       "invalid zip file error",
@@ -415,7 +415,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrOut: regexp.MustCompile(`No appliances to prepare for upgrade. All appliances are already greater or equal to the upgrade image`),
+			wantErrOut: regexp.MustCompile(`No appliances to prepare for upgrade.`),
 		},
 		{
 			name: "force prepare same version",
@@ -628,7 +628,7 @@ func Test_showPrepareUpgradeMessage(t *testing.T) {
 	type args struct {
 		f         string
 		appliance []openapi.Appliance
-		skip      []skipStruct
+		skip      []appliancepkg.SkipStruct
 		stats     []openapi.StatsAppliancesListAllOfData
 	}
 	tests := []struct {
@@ -687,7 +687,7 @@ func Test_showPrepareUpgradeMessage(t *testing.T) {
 						Version: openapi.PtrString("6.0.0+29426"),
 					},
 				},
-				skip: []skipStruct{
+				skip: []appliancepkg.SkipStruct{
 					{
 						Appliance: openapi.Appliance{
 							Id:   openapi.PtrString("92a8ceed-a364-4e99-a2eb-0a8546bab48f"),

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -160,15 +160,15 @@ func ShowAutoscalingWarningMessage(templateAppliance *openapi.Appliance, gateway
 	return tpl.String(), nil
 }
 
-type SkipStruct struct {
+type SkipUpgrade struct {
 	Reason    string
 	Appliance openapi.Appliance
 }
 
 // CheckVersions will check if appliance versions are equal to the version being uploaded on all appliances
 // Returns a slice of appliances that are not equal, a slice of appliances that have the same version and an error
-func CheckVersions(ctx context.Context, stats openapi.StatsAppliancesList, appliances []openapi.Appliance, v *version.Version) ([]openapi.Appliance, []SkipStruct) {
-	skip := []SkipStruct{}
+func CheckVersions(ctx context.Context, stats openapi.StatsAppliancesList, appliances []openapi.Appliance, v *version.Version) ([]openapi.Appliance, []SkipUpgrade) {
+	skip := []SkipUpgrade{}
 	keep := []openapi.Appliance{}
 
 	for _, appliance := range appliances {
@@ -177,7 +177,7 @@ func CheckVersions(ctx context.Context, stats openapi.StatsAppliancesList, appli
 				statV, err := ParseVersionString(stat.GetVersion())
 				if err != nil {
 					log.Warn("failed to parse version from stats")
-					skip = append(skip, SkipStruct{
+					skip = append(skip, SkipUpgrade{
 						Appliance: appliance,
 						Reason:    "failed to parse version from stats",
 					})
@@ -186,14 +186,14 @@ func CheckVersions(ctx context.Context, stats openapi.StatsAppliancesList, appli
 				res, err := CompareVersionsAndBuildNumber(statV, v)
 				if err != nil {
 					log.Warn("failed to compare versions")
-					skip = append(skip, SkipStruct{
+					skip = append(skip, SkipUpgrade{
 						Appliance: appliance,
 						Reason:    "failed to compare versions",
 					})
 					continue
 				}
 				if res < 1 {
-					skip = append(skip, SkipStruct{
+					skip = append(skip, SkipUpgrade{
 						Appliance: appliance,
 						Reason:    "appliance version is already greater or equal to prepare version",
 					})

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -200,7 +200,8 @@ func CompareVersionsAndBuildNumber(x, y *version.Version) int {
 	res := y.Compare(x)
 
 	// if res is 0, we also compare build number
-	if res == IsEqual {
+	// both x and y needs to have a parsable build number for this check to run
+	if res == IsEqual && len(y.Metadata()) > 0 && len(x.Metadata()) > 0 {
 		buildX, _ := version.NewVersion(x.Metadata())
 		buildY, _ := version.NewVersion(y.Metadata())
 		res = buildY.Compare(buildX)

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -265,10 +265,11 @@ Not disabling the health checks in those auto-scaled gateways could cause them t
 
 func TestCompareVersionAndBuildNumber(t *testing.T) {
 	testCases := []struct {
-		desc string
-		v1   string
-		v2   string
-		want int
+		desc    string
+		v1      string
+		v2      string
+		want    int
+		wantErr bool
 	}{
 		{
 			desc: "should equal",
@@ -306,12 +307,34 @@ func TestCompareVersionAndBuildNumber(t *testing.T) {
 			v2:   "6.0.1",
 			want: IsEqual,
 		},
+		{
+			desc:    "no v1 version",
+			v1:      "",
+			v2:      "6.0.1",
+			wantErr: true,
+		},
+		{
+			desc:    "no v2 version",
+			v1:      "6.0.1",
+			v2:      "",
+			wantErr: true,
+		},
+		{
+			desc:    "no version",
+			v1:      "",
+			v2:      "",
+			wantErr: true,
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			v1, _ := version.NewVersion(tC.v1)
 			v2, _ := version.NewVersion(tC.v2)
-			if res := CompareVersionsAndBuildNumber(v1, v2); res != tC.want {
+			res, err := CompareVersionsAndBuildNumber(v1, v2)
+			if err != nil && !tC.wantErr {
+				t.Fatal("unexpected error in CompareVersionAndBuildNumber()", err)
+			}
+			if res != tC.want {
 				t.Fatalf("Unexpected version compare:\nWANT\t%d\nGOT\t%d", tC.want, res)
 			}
 		})
@@ -361,27 +384,6 @@ func TestHasDiffVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if res, _ := HasDiffVersions(tt.stats); res != tt.expect {
 				t.Fatalf("HasDiffVersions() failed\nWANT: %v\nGOT: %v", tt.expect, res)
-			}
-		})
-	}
-}
-
-func TestCompareVersionsAndBuildNumber(t *testing.T) {
-	type args struct {
-		x *version.Version
-		y *version.Version
-	}
-	tests := []struct {
-		name string
-		args args
-		want int
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := CompareVersionsAndBuildNumber(tt.args.x, tt.args.y); got != tt.want {
-				t.Errorf("CompareVersionsAndBuildNumber() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -288,6 +288,24 @@ func TestCompareVersionAndBuildNumber(t *testing.T) {
 			v2:   "6.0.0-beta+23456",
 			want: IsGreater,
 		},
+		{
+			desc: "v2 no build number",
+			v1:   "6.0.1+30125",
+			v2:   "6.0.1",
+			want: IsEqual,
+		},
+		{
+			desc: "v1 no build number",
+			v1:   "6.0.1",
+			v2:   "6.0.1+30125",
+			want: IsEqual,
+		},
+		{
+			desc: "no build number",
+			v1:   "6.0.1",
+			v2:   "6.0.1",
+			want: IsEqual,
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
@@ -343,6 +361,27 @@ func TestHasDiffVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if res, _ := HasDiffVersions(tt.stats); res != tt.expect {
 				t.Fatalf("HasDiffVersions() failed\nWANT: %v\nGOT: %v", tt.expect, res)
+			}
+		})
+	}
+}
+
+func TestCompareVersionsAndBuildNumber(t *testing.T) {
+	type args struct {
+		x *version.Version
+		y *version.Version
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CompareVersionsAndBuildNumber(tt.args.x, tt.args.y); got != tt.want {
+				t.Errorf("CompareVersionsAndBuildNumber() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This fixes an issue where the `upgrade prepare` would crash with a nil pointer reference error. The error occurs when the image that is being uploaded is the same appliance version as the already present image and build number is missing from the image file name.

Manually tested on Linux and Windows (PS and CMD)