### PR TITLE
apply latest patch, redact Auth header value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.5
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/adrg/xdg v0.4.0
-	github.com/appgate/sdp-api-client-go v1.0.7-0.20220810112420-1e750e8d00ec
+	github.com/appgate/sdp-api-client-go v1.0.7-0.20220905142808-43e1f52bd4f6
 	github.com/billgraziano/dpapi v0.4.0
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cheynewallace/tabby v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPp
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20220810112420-1e750e8d00ec h1:hZYSsgWfo+99cDbgEcR98M1Ih+zsceoRlFRXbix4fnA=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20220810112420-1e750e8d00ec/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20220905142808-43e1f52bd4f6 h1:gPg7nIy23/ycvwsBOVy8vtRqj0EebaTgF08lfBsN2z8=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20220905142808-43e1f52bd4f6/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=


### PR DESCRIPTION
example

```
sdpctl appliance ls --debug
2022/09/05 16:29:59
GET /admin/appliances?orderBy=name HTTP/1.1
Host: envy-10-97-160-2.devops:8443
User-Agent: sdpctl/dev/go
Accept: application/vnd.appgate.peer-v16+json
Authorization: Bearer REDACTED
Accept-Encoding: gzip
```

the value for Authorization header is now replaced with 'REDACTED'

based on https://github.com/appgate/sdp-api-client-go/pull/12

Internal issue: SA-19963