### PR TITLE
Fix tracker error spamming on multi-line failure reasons

### DIFF
--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -69,7 +69,7 @@ func (u *UpgradeStatus) upgradeStatus(ctx context.Context, appliance openapi.App
 			if util.InSlice(s, undesiredStatuses) {
 				if tracker != nil {
 					// send error details for tracker
-					tracker.Update(s + " - " + details)
+					tracker.Fail(s + " - " + details)
 				}
 				return backoff.Permanent(fmt.Errorf("Upgrade failed on %s - %s", name, details))
 			}

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -37,6 +37,7 @@ func (p *Progress) AddTracker(name, endMsg string) *Tracker {
 		current:      "waiting",
 		endMsg:       endMsg,
 		statusReport: make(chan string, 1),
+		failReason:   make(chan string, 1),
 	}
 
 	t.mu.Lock()


### PR DESCRIPTION
This fixes an issue where the progress trackers would start spamming the CLI when upgrade prepare fails and the failure reason has line breaks.

Failure reasons are now sanitized before shown in the tracker. Only the first line in the failure details are shown in the tracker and any trailing special characters, such as ':', are removed. The full failure details are printed as errors once the command exits with errors.

This also introduces a dedicated channel and method for sending failure details for the tracker to show.