### PR TITLE
check canPrompt after  checking pre-existing token and credentials

### DIFF
--- a/pkg/auth/signin.go
+++ b/pkg/auth/signin.go
@@ -93,12 +93,6 @@ var ErrSignInNotSupported = errors.New("no TTY present, and missing required env
 // - Store primary controller version in config file
 // - Save config file to $SDPCTL_CONFIG_DIR
 func Signin(f *factory.Factory) error {
-	if !f.CanPrompt() {
-		if !hasRequiredEnv() {
-			return ErrSignInNotSupported
-		}
-	}
-
 	cfg := f.Config
 	client, err := f.APIClient(cfg)
 	if err != nil {
@@ -119,6 +113,12 @@ func Signin(f *factory.Factory) error {
 	if err == nil && cfg.ExpiredAtValid() && len(bearer) > 0 && cfg.Version > 0 {
 		return nil
 	}
+	if !f.CanPrompt() {
+		if !hasRequiredEnv() {
+			return ErrSignInNotSupported
+		}
+	}
+
 	minMax, err := GetMinMaxAPIVersion(f)
 	if err != nil {
 		return err

--- a/pkg/auth/signin_test.go
+++ b/pkg/auth/signin_test.go
@@ -135,6 +135,12 @@ func TestSignInNoPromptOrEnv(t *testing.T) {
 		Stdin:       os.Stdin,
 		StdErr:      os.Stderr,
 	}
+	registry := httpmock.NewRegistry(t)
+	defer registry.Teardown()
+	registry.Serve()
+	f.APIClient = func(c *configuration.Config) (*openapi.APIClient, error) {
+		return registry.Client, nil
+	}
 	err := Signin(f)
 	if err == nil {
 		t.Fatal("Expected err ErrSignInNotSupported")


### PR DESCRIPTION
this will allow us again again to combine sdpctl with, for example unix `watch` command