### PR TITLE
FIX: clear auth token when running signin

### DIFF
--- a/pkg/auth/signin.go
+++ b/pkg/auth/signin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/appgate/sdpctl/pkg/keyring"
 	"github.com/appgate/sdpctl/pkg/prompt"
 	"github.com/pkg/browser"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -107,11 +108,10 @@ func Signin(f *factory.Factory) error {
 		DeviceId:     cfg.DeviceID,
 	}
 
-	// if we already have a valid bearer token, we will continue without
-	// without any additional checks.
-	bearer, err := cfg.GetBearTokenHeaderValue()
-	if err == nil && cfg.ExpiredAtValid() && len(bearer) > 0 && cfg.Version > 0 {
-		return nil
+	// If there's an existing bearer token present, we will clear it and renew the authentication
+	if err := cfg.ClearBearer(); err != nil {
+		// not a fatal error
+		log.WithError(err).Warn("failed to delete auth token")
 	}
 	if !f.CanPrompt() {
 		if !hasRequiredEnv() {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -196,6 +196,17 @@ func (c *Config) ClearCredentials() error {
 	return nil
 }
 
+func (c *Config) ClearBearer() error {
+	h, err := c.GetHost()
+	if err != nil {
+		return err
+	}
+	if err := keyring.DeleteBearer(h); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *Config) StoreCredentials(username, password string) error {
 	h, err := c.GetHost()
 	if err != nil {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -204,6 +204,8 @@ func (c *Config) ClearBearer() error {
 	if err := keyring.DeleteBearer(h); err != nil {
 		return err
 	}
+	viper.Set("bearer", "")
+	viper.Set("expires_at", "")
 	return nil
 }
 

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/viper"
 	zkeyring "github.com/zalando/go-keyring"
 )
 
@@ -76,8 +75,6 @@ func DeleteBearer(prefix string) error {
 	if _, ok := os.LookupEnv("SDPCTL_BEARER"); ok {
 		os.Unsetenv("SDPCTL_BEARER")
 	}
-	viper.Set("bearer", "")
-	viper.Set("expires_at", "")
 	return nil
 }
 

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/viper"
 	zkeyring "github.com/zalando/go-keyring"
 )
 
@@ -63,6 +64,20 @@ func SetBearer(prefix, secret string) error {
 	if err := setSecret(format(prefix, bearer), secret); err != nil {
 		os.Setenv("SDPCTL_BEARER", secret)
 	}
+	return nil
+}
+
+func DeleteBearer(prefix string) error {
+	if err := deleteSecret(format(prefix, bearer)); err != nil {
+		if err != zkeyring.ErrNotFound {
+			return err
+		}
+	}
+	if _, ok := os.LookupEnv("SDPCTL_BEARER"); ok {
+		os.Unsetenv("SDPCTL_BEARER")
+	}
+	viper.Set("bearer", "")
+	viper.Set("expires_at", "")
 	return nil
 }
 

--- a/pkg/keyring/keyring_darwin.go
+++ b/pkg/keyring/keyring_darwin.go
@@ -130,6 +130,26 @@ func SetBearer(prefix, secret string) error {
 	return nil
 }
 
+func DeleteBearer(prefix string) error {
+	key := format(prefix, bearer)
+	if _, err := QueryKeychain(key); err == nil {
+		item := keychain.NewItem()
+		item.SetSecClass(keychain.SecClassGenericPassword)
+		item.SetService(keyringService)
+		item.SetAccount(key)
+		err := keychain.DeleteItem(item)
+		if err != nil {
+			return errors.New("failed to delete credential from keychain")
+		}
+	}
+	if _, ok := os.LookupEnv("SDPCTL_BEARER"); ok {
+		os.Unsetenv("SDPCTL_BEARER")
+	}
+	viper.Set("bearer", "")
+	viper.Set("expires_at", "")
+	return nil
+}
+
 func SetUsername(prefix, secret string) error {
 	err := AddKeychain(format(prefix, username), secret)
 	if err != nil {

--- a/pkg/keyring/keyring_darwin.go
+++ b/pkg/keyring/keyring_darwin.go
@@ -145,8 +145,6 @@ func DeleteBearer(prefix string) error {
 	if _, ok := os.LookupEnv("SDPCTL_BEARER"); ok {
 		os.Unsetenv("SDPCTL_BEARER")
 	}
-	viper.Set("bearer", "")
-	viper.Set("expires_at", "")
 	return nil
 }
 

--- a/pkg/keyring/keyring_windows.go
+++ b/pkg/keyring/keyring_windows.go
@@ -125,8 +125,6 @@ func DeleteBearer(prefix string) error {
 	if _, ok := os.LookupEnv("SDPCTL_BEARER"); ok {
 		os.Unsetenv("SDPCTL_BEARER")
 	}
-	viper.Set("bearer", "")
-	viper.Set("expires_at", "")
 	return nil
 }
 

--- a/pkg/keyring/keyring_windows.go
+++ b/pkg/keyring/keyring_windows.go
@@ -116,6 +116,20 @@ func SetBearer(prefix, secret string) error {
 	return saveEncryptedFile(bearer, prefix, secret)
 }
 
+func DeleteBearer(prefix string) error {
+	if err := deleteSecret(format(prefix, bearer)); err != nil {
+		if err != zkeyring.ErrNotFound {
+			return err
+		}
+	}
+	if _, ok := os.LookupEnv("SDPCTL_BEARER"); ok {
+		os.Unsetenv("SDPCTL_BEARER")
+	}
+	viper.Set("bearer", "")
+	viper.Set("expires_at", "")
+	return nil
+}
+
 func GetRefreshToken(prefix string) (string, error) {
 	return getSecretFile(refreshToken, prefix)
 }


### PR DESCRIPTION
Clear any old token that is currently stored when running `configure signin`. This prevents sdpctl from trying to use any token that is being stored, even though it has expired. In effect, the `configure signin` command will now always renew the authentication.

Fixes: SA-20111

e2e ok: https://got-testrail.agi.appgate.com/index.php?/plans/view/1060763