### PR TITLE
re-use token in all commands if it exists.

### DIFF
--- a/cmd/configure/signin.go
+++ b/cmd/configure/signin.go
@@ -38,6 +38,12 @@ func NewSigninCmd(f *factory.Factory) *cobra.Command {
 }
 
 func signinRun(cmd *cobra.Command, args []string, opts *signinOptions) error {
+	cfg := opts.f.Config
+	// If there's an existing bearer token present, we will clear it and renew the authentication
+	if err := cfg.ClearBearer(); err != nil {
+		// not a fatal error
+		log.WithError(err).Warn("failed to delete auth token")
+	}
 	if err := auth.Signin(opts.f); err != nil {
 		return err
 	}

--- a/pkg/auth/signin.go
+++ b/pkg/auth/signin.go
@@ -15,7 +15,6 @@ import (
 	"github.com/appgate/sdpctl/pkg/keyring"
 	"github.com/appgate/sdpctl/pkg/prompt"
 	"github.com/pkg/browser"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -108,10 +107,9 @@ func Signin(f *factory.Factory) error {
 		DeviceId:     cfg.DeviceID,
 	}
 
-	// If there's an existing bearer token present, we will clear it and renew the authentication
-	if err := cfg.ClearBearer(); err != nil {
-		// not a fatal error
-		log.WithError(err).Warn("failed to delete auth token")
+	bearer, err := cfg.GetBearTokenHeaderValue()
+	if err == nil && cfg.ExpiredAtValid() && len(bearer) > 0 && cfg.Version > 0 {
+		return nil
 	}
 	if !f.CanPrompt() {
 		if !hasRequiredEnv() {


### PR DESCRIPTION
only clear the bearer token explicitly if the user runs `sdpctl configure signin`


https://github.com/appgate/sdpctl/pull/295 introduces forcefully clear berarer token on all commands, but this don't make sense since we want to re-use it if it exists and is valid instead of doing the re-auth on all commands, if we want to re-auth on every command we should never store bearer token or refresher and the user will be prompted all the time.