### PR TITLE
hide profile flag parsed Usage

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -184,8 +184,8 @@ func Execute() exitCode {
 	var currentProfile string
 	rFlag := pflag.NewFlagSet("", pflag.ContinueOnError)
 	rFlag.StringVarP(&currentProfile, "profile", "p", "", "")
+	rFlag.Usage = func() {}
 	rFlag.Parse(os.Args[1:])
-
 	root := NewCmdRoot(&currentProfile)
 	cmd, err := root.ExecuteC()
 	if err != nil {


### PR DESCRIPTION
Removed the extra

```
Usage of:
  -p, --profile string 
```
that was introduced when we added `--profile` root level flag.

diff:
```diff
--- aa	2022-09-26 08:56:32.079478535 +0200
+++ bb	2022-09-26 08:56:39.967461083 +0200
@@ -1,36 +1,34 @@
-> sdpctl --help
-Usage of :
-  -p, --profile string   
+> sdpctl --help                          
 © 2022 Appgate Cybersecurity, Inc.
 All rights reserved. Appgate is a trademark of Appgate Cybersecurity, Inc.
 https://www.appgate.com
 
 The official CLI tool for managing your Appgate SDP Collective.
 With sdpctl, you can list, backup and upgrade your Appgate SDP Appliances with a single command.
 
 Environment Variables:
   See 'sdpctl help environment' for the list of supported environment variables.
 
 Usage:
   sdpctl [command]
 
 Available Commands:
   appliance   interact with Appgate SDP Appliances
   completion  Generate shell completion scripts
   configure   Configure your Appgate SDP Collective
   help        Help about any command
   open        Open the web UI in your default browser
   profile     Handle configuration for more then one appgate sdp profile
   token       Perform actions related to token on the Appgate SDP Collective
 
 Flags:
       --api-version int   peer API version override
       --ci-mode           log to stderr instead of file and disable progress-bars
       --debug             Enable debug logging
   -h, --help              help for sdpctl
       --no-interactive    suppress interactive prompt with auto accept
       --no-verify         don't verify TLS on for this particular command, overriding settings from config file
   -p, --profile string    profile configuration to use
   -v, --version           version for sdpctl
 
 Use "sdpctl [command] --help" for more information about a command.

```