### PR TITLE
Check backup file result before trying to download

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/adrg/xdg v0.4.0
-	github.com/appgate/sdp-api-client-go v1.0.7-0.20220905142808-43e1f52bd4f6
+	github.com/appgate/sdp-api-client-go v1.0.7-0.20220922063833-c6674a166809
 	github.com/billgraziano/dpapi v0.4.0
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cheynewallace/tabby v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,10 @@ github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPp
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20220905142808-43e1f52bd4f6 h1:gPg7nIy23/ycvwsBOVy8vtRqj0EebaTgF08lfBsN2z8=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20220905142808-43e1f52bd4f6/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20220921090843-92e6a2da4337 h1:KrGAEt5L1Iq0Olviy7qvAFzQ2M1FXBcI4L35+PY+pA4=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20220921090843-92e6a2da4337/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20220922063833-c6674a166809 h1:KmykleCLNB29f67i4S6yUsn8cuhrufGCxNFjM5j9Bx8=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20220922063833-c6674a166809/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -223,7 +223,7 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 			log.WithFields(log.Fields{
 				"appliance": applianceID,
 				"backup_id": backupID,
-				"status":    status,
+				"status":    status.GetStatus(),
 			}).Info("backup status")
 
 			if status.GetStatus() != backup.Done {

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -246,12 +246,15 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 		if err := retryStatus(ctx, b.applianceID, b.backupID); err != nil {
 			return b, err
 		}
-		result, output, err := backupAPI.Result(ctx, b.applianceID, b.backupID)
-		if err != nil {
-			return b, err
-		}
-		if result != backup.Success {
-			return b, errors.New(output)
+		if opts.Config.Version >= 17 {
+			// Check for backup result and output implemented in API version 17
+			result, output, err := backupAPI.Result(ctx, b.applianceID, b.backupID)
+			if err != nil {
+				return b, err
+			}
+			if result != backup.Success {
+				return b, errors.New(output)
+			}
 		}
 		log.WithFields(f).Infof("starting download for backup id %s", b.backupID)
 		file, err := backupAPI.Download(ctx, b.applianceID, b.backupID)

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -246,6 +246,13 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 		if err := retryStatus(ctx, b.applianceID, b.backupID); err != nil {
 			return b, err
 		}
+		result, output, err := backupAPI.Result(ctx, b.applianceID, b.backupID)
+		if err != nil {
+			return b, err
+		}
+		if result != backup.Success {
+			return b, errors.New(output)
+		}
 		log.WithFields(f).Infof("starting download for backup id %s", b.backupID)
 		file, err := backupAPI.Download(ctx, b.applianceID, b.backupID)
 		if err != nil {

--- a/pkg/appliance/backup/backup.go
+++ b/pkg/appliance/backup/backup.go
@@ -59,18 +59,10 @@ const (
 	Failure    string = "failure"
 )
 
-func (b *Backup) Status(ctx context.Context, applianceID, backupID string) (string, error) {
+func (b *Backup) Status(ctx context.Context, applianceID, backupID string) (*openapi.AppliancesIdBackupBackupIdStatusGet200Response, error) {
 	status, response, err := b.APIClient.ApplianceBackupApi.AppliancesIdBackupBackupIdStatusGet(ctx, applianceID, backupID).Authorization(b.Token).Execute()
 	if err != nil {
-		return "", api.HTTPErrorResponse(response, err)
+		return nil, api.HTTPErrorResponse(response, err)
 	}
-	return status.GetStatus(), nil
-}
-
-func (b *Backup) Result(ctx context.Context, applianceID, backupID string) (string, string, error) {
-	status, response, err := b.APIClient.ApplianceBackupApi.AppliancesIdBackupBackupIdStatusGet(ctx, applianceID, backupID).Authorization(b.Token).Execute()
-	if err != nil {
-		return "", "", api.HTTPErrorResponse(response, err)
-	}
-	return status.GetResult(), status.GetOutput(), nil
+	return status, nil
 }

--- a/pkg/appliance/backup/backup.go
+++ b/pkg/appliance/backup/backup.go
@@ -55,6 +55,8 @@ const (
 	// https://github.com/appgate/sdp-api-specification/blob/0cae2de511a135ca1c29beb89fe9d38e83ffc4f1/appliance_backup.yml#L87-L88
 	Processing string = "processing"
 	Done       string = "done"
+	Success    string = "success"
+	Failure    string = "failure"
 )
 
 func (b *Backup) Status(ctx context.Context, applianceID, backupID string) (string, error) {
@@ -63,4 +65,12 @@ func (b *Backup) Status(ctx context.Context, applianceID, backupID string) (stri
 		return "", api.HTTPErrorResponse(response, err)
 	}
 	return status.GetStatus(), nil
+}
+
+func (b *Backup) Result(ctx context.Context, applianceID, backupID string) (string, string, error) {
+	status, response, err := b.APIClient.ApplianceBackupApi.AppliancesIdBackupBackupIdStatusGet(ctx, applianceID, backupID).Authorization(b.Token).Execute()
+	if err != nil {
+		return "", "", api.HTTPErrorResponse(response, err)
+	}
+	return status.GetResult(), status.GetOutput(), nil
 }

--- a/pkg/appliance/fixtures/appliance_backup_status_done.json
+++ b/pkg/appliance/fixtures/appliance_backup_status_done.json
@@ -1,5 +1,6 @@
 {
     "encoding": "utf-8",
-    "output": "string",
+    "output": "",
+    "result": "success",
     "status": "done"
 }

--- a/pkg/appliance/fixtures/appliance_backup_status_failed.json
+++ b/pkg/appliance/fixtures/appliance_backup_status_failed.json
@@ -1,0 +1,6 @@
+{
+    "encoding": "utf-8",
+    "output": "something went wrong",
+    "result": "failure",
+    "status": "done"
+}


### PR DESCRIPTION
If the generation of the backup file fails for some reason, sdpctl would not know about it and try to download the file even if it fails on the server.

This implements a check for the result of the backup file generation, implemented in API version 17, to prevent the backup command from trying to download failed backup files.

Fixes SA-19909