### PR TITLE
skip write error on api version update

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -317,7 +317,9 @@ func rootPersistentPreRunEFunc(f *factory.Factory, cfg *configuration.Config) fu
 					viper.Set("api_version", minMax.Max)
 					f.Config.Version = int(minMax.Max)
 					if err := viper.WriteConfig(); err != nil {
-						fmt.Fprintf(f.StdErr, "[error] %s\n", err)
+						if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+							fmt.Fprintf(f.StdErr, "[error] %s\n", err)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This error would normally only be triggered if running sdpctl with a headless environment (such as only configured with environment variable) the program works fine without updating the config file.

we will only show error if we do not get 'Config File "config" Not Found %dir'