### PR TITLE
distinguish profile credentials with same hostname

### DIFF
--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -187,7 +187,7 @@ var ErrPlatformNotSupported = errors.New("Provider with OpenID Connect is not su
 
 func (o OpenIDConnect) signin(ctx context.Context, loginOpts openapi.LoginRequest, provider openapi.IdentityProvidersNamesGet200ResponseDataInner) (*signInResponse, error) {
 	authenticator := NewAuth(o.Client)
-	prefix, err := o.Factory.Config.GetHost()
+	prefix, err := o.Factory.Config.KeyringPrefix()
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,6 @@ func (o OpenIDConnect) signin(ctx context.Context, loginOpts openapi.LoginReques
 			}
 			return response, nil
 		}
-
 	}
 
 	mux := http.NewServeMux()

--- a/pkg/auth/signin.go
+++ b/pkg/auth/signin.go
@@ -186,7 +186,7 @@ func Signin(f *factory.Factory) error {
 	// use the original auth request expires_at value instead of the value from authorization since they can be different
 	// depending on the provider type.
 	cfg.ExpiresAt = response.Expires.String()
-	host, err := cfg.GetHost()
+	prefix, err := cfg.KeyringPrefix()
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func Signin(f *factory.Factory) error {
 	// if the bearer token can't be saved to the keychain, it will be exported as env variable
 	// and saved in the config file as fallback, this should only happened if the system does not
 	// support the keychain integration.
-	if err := keyring.SetBearer(host, cfg.BearerToken); err != nil {
+	if err := keyring.SetBearer(prefix, cfg.BearerToken); err != nil {
 		return err
 	}
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -144,12 +144,12 @@ func (c *Config) CheckAuth() bool {
 
 func (c *Config) ExpiredAtValid() bool {
 	layout := "2006-01-02 15:04:05.999999999 -0700 MST"
-	d, err := time.Parse(layout, c.ExpiresAt)
+	t1, err := time.Parse(layout, c.ExpiresAt)
 	if err != nil {
 		return false
 	}
-	t1 := time.Now()
-	return t1.Add(-time.Hour * 2).Before(d)
+	now := time.Now().Add(-time.Hour * 2)
+	return t1.After(now)
 }
 
 func (c *Config) LoadCredentials() (*Credentials, error) {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestConfigCheckAuth(t *testing.T) {
 	zkeyring.MockInit()
+	dir := t.TempDir()
+	t.Setenv("SDPCTL_CONFIG_DIR", dir)
 	if err := keyring.SetBearer("controller.appgate.com", "abc123456789"); err != nil {
 		t.Fatalf("unable to mock keyring in TestConfigCheckAuth() %v", err)
 	}
@@ -235,6 +237,8 @@ func TestNormalizeURL(t *testing.T) {
 
 func TestClearCredentials(t *testing.T) {
 	zkeyring.MockInit()
+	dir := t.TempDir()
+	t.Setenv("SDPCTL_CONFIG_DIR", dir)
 	var (
 		prefix   = "test-unit.devops"
 		username = "user"


### PR DESCRIPTION
since we introduced profiles, we can have multiple configs with the same hostname.

to differentiate them apart, we append the profile name to the hostname that will be used to compute the hashcode value.

this value will be used as a integer prefix in the keyring.

This do break backwards compatibility somewhat, however its a minor inconvenience since it only mean the user need to re-authenticate one more time after they update sdpctl after that, it will work as expected.