### PR TITLE
clear provider on configure

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -178,7 +178,8 @@ func (c *Config) ClearCredentials() error {
 	}
 	c.BearerToken = ""
 	c.ExpiresAt = ""
-	keys := []string{"bearer", "expires_at"}
+	c.Provider = ""
+	keys := []string{"bearer", "expires_at", "provider"}
 	allKeys := viper.AllKeys()
 	for _, k := range keys {
 		if util.InSlice(k, allKeys) {


### PR DESCRIPTION
If re-configuring an existing sdpctl profile, the provider setting in the configuration would remain the same as the previous configuration. This prevents the prompt for selecting a provider to not appear after re-configuration.

This fix will clear the provider key in the configuration when `sdpctl configure` is executed, making it possible to select IDP provider again after re-configuration.