### PR TITLE
Backup message field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/adrg/xdg v0.4.0
-	github.com/appgate/sdp-api-client-go v1.0.7-0.20220922063833-c6674a166809
+	github.com/appgate/sdp-api-client-go v1.0.7-0.20221011125012-1200fe22152c
 	github.com/billgraziano/dpapi v0.4.0
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cheynewallace/tabby v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/appgate/sdp-api-client-go v1.0.7-0.20220921090843-92e6a2da4337 h1:KrG
 github.com/appgate/sdp-api-client-go v1.0.7-0.20220921090843-92e6a2da4337/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20220922063833-c6674a166809 h1:KmykleCLNB29f67i4S6yUsn8cuhrufGCxNFjM5j9Bx8=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20220922063833-c6674a166809/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221011125012-1200fe22152c h1:dqR14HEyYAmJaEGavQoHEZ7rZbwxadYvhoxpDB8y1vM=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221011125012-1200fe22152c/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -226,7 +226,7 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 			}).Info("backup status")
 			message := status.GetStatus()
 			if len(status.GetMessage()) > 0 {
-				message = message + " " + status.GetMessage()
+				message = message + " - " + status.GetMessage()
 			}
 			tracker.Update(message)
 			if status.GetStatus() != backup.Done {


### PR DESCRIPTION
Include the backup message field when doing backup, only applicable on newer appliance version, omited if appliance < 6.0.2
depends on https://github.com/appgate/sdp-api-client-go/pull/14 

Internal ticket: SA-20243
[![asciicast](https://asciinema.org/a/Rp54O8Eyv0m1dqOBrzVs6DAUr.svg)](https://asciinema.org/a/Rp54O8Eyv0m1dqOBrzVs6DAUr)