### PR TITLE
Force all controllers to upgrade on major or minor version

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -340,7 +340,10 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			}
 		}
 	}
-	forceAllControllerUpgrade := appliancepkg.NeedsMultiControllerUpgrade(upgradeStatuses, online, allOnlineControllers, isMajorOrMinorUpgrade)
+	forceAllControllerUpgrade, err := appliancepkg.NeedsMultiControllerUpgrade(upgradeStatuses, initialStats.GetData(), online, allOnlineControllers, isMajorOrMinorUpgrade)
+	if err != nil {
+		return err
+	}
 	if forceAllControllerUpgrade {
 		return errors.New("All Controllers need upgrading when doing major or minor version upgrade, but not all controllers are prepared for upgrade. Please prepare the remaining controllers before running 'upgrade complete' again.")
 	}

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -430,7 +430,7 @@ func TestPrintCompleteSummary(t *testing.T) {
 		additionalControllers []openapi.Appliance
 		logServersForwarders  []openapi.Appliance
 		chunks                [][]openapi.Appliance
-		skipped               []openapi.Appliance
+		skipped               []appliancepkg.SkipUpgrade
 		backup                []openapi.Appliance
 		backupDestination     string
 		toVersion             string
@@ -451,7 +451,7 @@ func TestPrintCompleteSummary(t *testing.T) {
 					{Name: "gateway-2"},
 				},
 			},
-			skipped:   []openapi.Appliance{},
+			skipped:   []appliancepkg.SkipUpgrade{},
 			toVersion: "5.5.4",
 			expect: `
 UPGRADE COMPLETE SUMMARY
@@ -502,12 +502,18 @@ Upgrade will be completed in steps:
 					},
 				},
 			},
-			skipped: []openapi.Appliance{
+			skipped: []appliancepkg.SkipUpgrade{
 				{
-					Name: "secondary-controller",
+					Appliance: openapi.Appliance{
+						Name: "secondary-controller",
+					},
+					Reason: "appliance is offline",
 				},
 				{
-					Name: "additional-controller",
+					Appliance: openapi.Appliance{
+						Name: "additional-controller",
+					},
+					Reason: "appliance is not prepared for upgrade",
 				},
 			},
 			backup: []openapi.Appliance{
@@ -546,8 +552,9 @@ Upgrade will be completed in steps:
 
 
 Appliances that will be skipped:
-  - secondary-controller
-  - additional-controller
+  - additional-controller: appliance is not prepared for upgrade
+  - secondary-controller: appliance is offline
+
 `,
 		},
 		{
@@ -570,12 +577,18 @@ Appliances that will be skipped:
 					},
 				},
 			},
-			skipped: []openapi.Appliance{
+			skipped: []appliancepkg.SkipUpgrade{
 				{
-					Name: "secondary-controller",
+					Appliance: openapi.Appliance{
+						Name: "secondary-controller",
+					},
+					Reason: "skip1",
 				},
 				{
-					Name: "additional-controller",
+					Appliance: openapi.Appliance{
+						Name: "additional-controller",
+					},
+					Reason: "skip2",
 				},
 			},
 			backup: []openapi.Appliance{
@@ -621,8 +634,9 @@ Upgrade will be completed in steps:
 
 
 Appliances that will be skipped:
-  - secondary-controller
-  - additional-controller
+  - additional-controller: skip2
+  - secondary-controller: skip1
+
 `,
 		},
 	}

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -338,6 +338,66 @@ func TestUpgradeCompleteCommand(t *testing.T) {
 			wantErr:    true,
 			wantErrOut: regexp.MustCompile("never switched partition"),
 		},
+		{
+			name: "controller major-minor guard unprepared controller",
+			cli:  "upgrade complete --backup=false --no-interactive",
+			httpStubs: []httpmock.Stub{
+				{
+					URL:       "/appliances",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/ha_appliance_list.json"),
+				},
+				{
+					URL:       "/stats/appliances",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/ha_stats_appliance.json"),
+				},
+				{
+					URL:       "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/upgrade",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/appliance_upgrade_status_ready.json"),
+				},
+				{
+					URL:       "/appliances/ed95fac8-9098-472b-b9f0-fe741881e2ca/upgrade",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/appliance_upgrade_status_idle.json"),
+				},
+				{
+					URL:       "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/upgrade",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/appliance_upgrade_status_ready.json"),
+				},
+			},
+			wantErr:    true,
+			wantErrOut: regexp.MustCompile("All Controllers need upgrading when doing major or minor version upgrade, but not all controllers are prepared for upgrade. Please prepare the remaining controllers before running 'upgrade complete' again."),
+		},
+		{
+			name: "controller major-minor guard mismatch version",
+			cli:  "upgrade complete --backup=false --no-interactive",
+			httpStubs: []httpmock.Stub{
+				{
+					URL:       "/appliances",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/ha_appliance_list.json"),
+				},
+				{
+					URL:       "/stats/appliances",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/ha_stats_appliance.json"),
+				},
+				{
+					URL:       "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/upgrade",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/appliance_upgrade_status_ready.json"),
+				},
+				{
+					URL: "/appliances/ed95fac8-9098-472b-b9f0-fe741881e2ca/upgrade",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "ready", "details": "appgate-5.5.0.img.zip" }`))
+					},
+				},
+				{
+					URL:       "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/upgrade",
+					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/appliance_upgrade_status_ready.json"),
+				},
+			},
+			wantErr:    true,
+			wantErrOut: regexp.MustCompile("Version mismatch on prepared Controllers. Controllers need to be prepared with the same version when doing a major or minor version upgrade."),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -233,7 +233,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	online, offline, _ := appliancepkg.FilterAvailable(Allappliances, initialStats.GetData())
 	for _, a := range offline {
 		skipAppliances = append(skipAppliances, appliancepkg.SkipUpgrade{
-			Reason:    "appliance is offline",
+			Reason:    appliancepkg.SkipReasonOffline,
 			Appliance: a,
 		})
 	}
@@ -244,7 +244,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	for _, f := range filtered {
 		skipAppliances = append(skipAppliances, appliancepkg.SkipUpgrade{
 			Appliance: f,
-			Reason:    "appliance was filtered using the '--include' or '--exclude' flag",
+			Reason:    appliancepkg.SkipReasonFiltered,
 		})
 	}
 
@@ -313,7 +313,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			if res, err := appliancepkg.CompareVersionsAndBuildNumber(opts.targetVersion, prepareVersion); err == nil && res >= 0 {
 				skipAppliances = append(skipAppliances, appliancepkg.SkipUpgrade{
 					Appliance: app,
-					Reason:    "appliance is already prepared for upgrade with a higher or equal version",
+					Reason:    appliancepkg.SkipReasonAlreadyPrepared,
 				})
 				continue
 			}
@@ -326,7 +326,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			errs = multierr.Append(errs, errors.New("No appliances to prepare for upgrade. All appliances may have been filtered or are already prepared. See the log for more details"))
 			if len(skipAppliances) > 0 {
 				for _, skip := range skipAppliances {
-					errs = multierr.Append(errs, fmt.Errorf("%s skipped: %s", skip.Appliance.GetName(), skip.Reason))
+					errs = multierr.Append(errs, skip)
 				}
 			}
 			return errs

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -289,16 +289,16 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}
 	}
 
+	upgradeStatuses, err := a.UpgradeStatusMap(ctx, appliances)
+	if err != nil {
+		return err
+	}
 	if !opts.forcePrepare {
 		var skip []appliancepkg.SkipUpgrade
 		appliances, skip = appliancepkg.CheckVersions(ctx, *initialStats, appliances, opts.targetVersion)
 		skipAppliances = append(skipAppliances, skip...)
 
 		postPrepared := []openapi.Appliance{}
-		upgradeStatuses, err := a.UpgradeStatusMap(ctx, appliances)
-		if err != nil {
-			return err
-		}
 		for _, app := range appliances {
 			us := upgradeStatuses[app.GetId()]
 			if us.Status != appliancepkg.UpgradeStatusReady {
@@ -338,7 +338,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		return err
 	}
 	majorOrMinorUpgrade := appliancepkg.IsMajorUpgrade(currentPrimaryControllerVersion, opts.targetVersion) || appliancepkg.IsMinorUpgrade(currentPrimaryControllerVersion, opts.targetVersion)
-	ctrlUpgradeWarning := appliancepkg.MultiControllerUpgradeWarning(Allappliances, appliances, majorOrMinorUpgrade)
+	ctrlUpgradeWarning := appliancepkg.MultiControllerUpgradeWarning(upgradeStatuses, Allappliances, appliances, majorOrMinorUpgrade)
 
 	log.Infof("The primary Controller is: %s and running %s", primaryController.GetName(), currentPrimaryControllerVersion.String())
 	log.Infof("Appliances will be prepared for upgrade to version: %s", opts.targetVersion.String())

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -338,7 +338,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		return err
 	}
 	majorOrMinorUpgrade := appliancepkg.IsMajorUpgrade(currentPrimaryControllerVersion, opts.targetVersion) || appliancepkg.IsMinorUpgrade(currentPrimaryControllerVersion, opts.targetVersion)
-	ctrlUpgradeWarning := appliancepkg.NeedsMultiControllerUpgrade(upgradeStatuses, Allappliances, appliances, majorOrMinorUpgrade)
+	ctrlUpgradeWarning, err := appliancepkg.NeedsMultiControllerUpgrade(upgradeStatuses, initialStats.GetData(), Allappliances, appliances, majorOrMinorUpgrade)
+	if err != nil {
+		return err
+	}
 
 	log.Infof("The primary Controller is: %s and running %s", primaryController.GetName(), currentPrimaryControllerVersion.String())
 	log.Infof("Appliances will be prepared for upgrade to version: %s", opts.targetVersion.String())

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -338,7 +338,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		return err
 	}
 	majorOrMinorUpgrade := appliancepkg.IsMajorUpgrade(currentPrimaryControllerVersion, opts.targetVersion) || appliancepkg.IsMinorUpgrade(currentPrimaryControllerVersion, opts.targetVersion)
-	ctrlUpgradeWarning := appliancepkg.MultiControllerUpgradeWarning(upgradeStatuses, Allappliances, appliances, majorOrMinorUpgrade)
+	ctrlUpgradeWarning := appliancepkg.NeedsMultiControllerUpgrade(upgradeStatuses, Allappliances, appliances, majorOrMinorUpgrade)
 
 	log.Infof("The primary Controller is: %s and running %s", primaryController.GetName(), currentPrimaryControllerVersion.String())
 	log.Infof("Appliances will be prepared for upgrade to version: %s", opts.targetVersion.String())

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -844,8 +844,6 @@ controller2    ✓         5.5.7+28767        6.0.0+29426
 gateway        ✓         5.5.7+28767        6.0.0+29426
 
 
-3. Delete upgrade image from Controller
-
 WARNING: This upgrade requires all controllers to be upgraded to the same version, but not all
 controllers are being prepared for upgrade.
 A partial major or minor controller upgrade is not supported. The upgrade will fail unless all

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -394,6 +394,22 @@ func TestUpgradePrepareCommand(t *testing.T) {
 					URL:       "/stats/appliances",
 					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/stats_appliance_5.5.1.json"),
 				},
+				{
+					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/upgrade",
+					Responder: func(rw http.ResponseWriter, r *http.Request) {
+						rw.Header().Set("Content-Type", "application/json")
+						rw.WriteHeader(http.StatusOK)
+						fmt.Fprint(rw, string(`{"status":"ready","details":"appgate-5.5.1-9876.img.zip"}`))
+					},
+				},
+				{
+					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/upgrade",
+					Responder: func(rw http.ResponseWriter, r *http.Request) {
+						rw.Header().Set("Content-Type", "application/json")
+						rw.WriteHeader(http.StatusOK)
+						fmt.Fprint(rw, string(`{"status":"ready","details":"appgate-5.5.1-9876.img.zip"}`))
+					},
+				},
 			},
 			wantErr:    true,
 			wantErrOut: regexp.MustCompile(`No appliances to prepare for upgrade. All appliances may have been filtered or are already prepared. See the log for more details`),

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -334,12 +334,14 @@ func controllerCount(appliances []openapi.Appliance) int {
 	return i
 }
 
-func MultiControllerUpgradeWarning(all, preparing []openapi.Appliance, majorOrMinor bool) bool {
+func MultiControllerUpgradeWarning(upgradeStatuses map[string]UpgradeStatusResult, all, preparing []openapi.Appliance, majorOrMinor bool) bool {
 	controllerCount := controllerCount(all)
 	controllerPrepareCount := 0
 	for _, a := range preparing {
 		if v, ok := a.GetControllerOk(); ok && v.GetEnabled() {
-			controllerPrepareCount++
+			if ugs := upgradeStatuses[a.GetId()]; ugs.Status == UpgradeStatusReady {
+				controllerPrepareCount++
+			}
 		}
 	}
 	return (controllerCount != controllerPrepareCount) && majorOrMinor

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -367,7 +367,7 @@ func NeedsMultiControllerUpgrade(upgradeStatuses map[string]UpgradeStatusResult,
 	}
 	if controllerCount != controllerPrepareCount {
 		for _, uv := range unpreparedCurrentVersions {
-			if !IsMajorUpgrade(uv, highestPreparedVersion) || !IsMinorUpgrade(uv, highestPreparedVersion) {
+			if v, _ := CompareVersionsAndBuildNumber(highestPreparedVersion, uv); v == 0 {
 				alreadySameVersion++
 			}
 		}

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -165,6 +165,17 @@ type SkipUpgrade struct {
 	Appliance openapi.Appliance
 }
 
+const (
+	SkipReasonNotPrepared     = "appliance is not prepared for upgrade"
+	SkipReasonOffline         = "appliance is offline"
+	SkipReasonFiltered        = "filtered using the '--include' and/or '--exclude' flag"
+	SkipReasonAlreadyPrepared = "appliance is already prepared for upgrade with a higher or equal version"
+)
+
+func (su SkipUpgrade) Error() string {
+	return fmt.Sprintf("%s: %s", su.Appliance.GetName(), su.Reason)
+}
+
 // CheckVersions will check if appliance versions are equal to the version being uploaded on all appliances
 // Returns a slice of appliances that are not equal, a slice of appliances that have the same version and an error
 func CheckVersions(ctx context.Context, stats openapi.StatsAppliancesList, appliances []openapi.Appliance, v *version.Version) ([]openapi.Appliance, []SkipUpgrade) {

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -334,7 +334,7 @@ func controllerCount(appliances []openapi.Appliance) int {
 	return i
 }
 
-func MultiControllerUpgradeWarning(upgradeStatuses map[string]UpgradeStatusResult, all, preparing []openapi.Appliance, majorOrMinor bool) bool {
+func NeedsMultiControllerUpgrade(upgradeStatuses map[string]UpgradeStatusResult, all, preparing []openapi.Appliance, majorOrMinor bool) bool {
 	controllerCount := controllerCount(all)
 	controllerPrepareCount := 0
 	for _, a := range preparing {

--- a/pkg/appliance/fixtures/ha_appliance_list.json
+++ b/pkg/appliance/fixtures/ha_appliance_list.json
@@ -1,0 +1,638 @@
+{
+    "data": [
+        {
+            "id": "4c07bc67-57ea-42dd-b702-c2d6c45419fc",
+            "name": "controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1",
+            "notes": "",
+            "created": "2021-11-02T14:09:46.904196Z",
+            "updated": "2021-11-02T14:58:46.820505Z",
+            "tags": [],
+            "activated": true,
+            "pendingCertificateRenewal": false,
+            "version": 14,
+            "hostname": "appgate.com",
+            "site": "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4",
+            "siteName": "Default Site",
+            "connectToPeersUsingClientPortWithSpa": true,
+            "clientInterface": {
+                "proxyProtocol": false,
+                "hostname": "appgate.com",
+                "httpsPort": 443,
+                "dtlsPort": 443,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "peerInterface": {
+                "hostname": "appgate.com",
+                "httpsPort": 444,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "networking": {
+                "hosts": [],
+                "nics": [
+                    {
+                        "enabled": true,
+                        "name": "eth0",
+                        "ipv4": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": [
+                                {
+                                    "address": "10.97.158.2",
+                                    "netmask": 26,
+                                    "snat": false
+                                }
+                            ]
+                        },
+                        "ipv6": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": []
+                        }
+                    }
+                ],
+                "dnsServers": [
+                    "1.1.1.1",
+                    "8.8.8.8"
+                ],
+                "dnsDomains": [],
+                "routes": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0,
+                        "gateway": "10.97.158.1"
+                    }
+                ]
+            },
+            "ntp": {
+                "servers": [
+                    {
+                        "hostname": "1.1.1.1"
+                    },
+                    {
+                        "hostname": "8.8.8.8"
+                    }
+                ]
+            },
+            "sshServer": {
+                "enabled": true,
+                "port": 22,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "passwordAuthentication": true
+            },
+            "snmpServer": {
+                "enabled": false,
+                "udpPort": 161,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "snmpd.conf": "rocommunity public default"
+            },
+            "healthcheckServer": {
+                "enabled": false,
+                "port": 5555,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "prometheusExporter": {
+                "enabled": false,
+                "port": 5556,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "ping": {
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "logServer": {
+                "enabled": false,
+                "retentionDays": 30
+            },
+            "controller": {
+                "enabled": true,
+                "database": {
+                    "location": "internal"
+                }
+            },
+            "gateway": {
+                "enabled": false,
+                "vpn": {
+                    "weight": 100,
+                    "allowDestinations": []
+                }
+            },
+            "logForwarder": {
+                "enabled": false,
+                "tcpClients": [],
+                "awsKineses": [],
+                "sites": []
+            },
+            "connector": {
+                "enabled": false,
+                "expressClients": [],
+                "advancedClients": []
+            },
+            "rsyslogDestinations": [],
+            "hostnameAliases": [
+                "10.97.158.2"
+            ]
+        },
+        {
+            "id": "ed95fac8-9098-472b-b9f0-fe741881e2ca",
+            "name": "controller2-ed95fac8-9098-472b-b9f0-fe741881e2ca-site1",
+            "notes": "",
+            "created": "2021-11-02T14:09:46.904196Z",
+            "updated": "2021-11-02T14:58:46.820505Z",
+            "tags": [],
+            "activated": true,
+            "pendingCertificateRenewal": false,
+            "version": 14,
+            "hostname": "cryptzone.com",
+            "site": "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4",
+            "siteName": "Default Site",
+            "connectToPeersUsingClientPortWithSpa": true,
+            "clientInterface": {
+                "proxyProtocol": false,
+                "hostname": "cryptzone.com",
+                "httpsPort": 443,
+                "dtlsPort": 443,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "peerInterface": {
+                "hostname": "cryptzone.com",
+                "httpsPort": 444,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "networking": {
+                "hosts": [],
+                "nics": [
+                    {
+                        "enabled": true,
+                        "name": "eth0",
+                        "ipv4": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": [
+                                {
+                                    "address": "10.97.158.3",
+                                    "netmask": 26,
+                                    "snat": false
+                                }
+                            ]
+                        },
+                        "ipv6": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": []
+                        }
+                    }
+                ],
+                "dnsServers": [
+                    "1.1.1.1",
+                    "8.8.8.8"
+                ],
+                "dnsDomains": [],
+                "routes": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0,
+                        "gateway": "10.97.158.1"
+                    }
+                ]
+            },
+            "ntp": {
+                "servers": [
+                    {
+                        "hostname": "1.1.1.1"
+                    },
+                    {
+                        "hostname": "8.8.8.8"
+                    }
+                ]
+            },
+            "sshServer": {
+                "enabled": true,
+                "port": 22,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "passwordAuthentication": true
+            },
+            "snmpServer": {
+                "enabled": false,
+                "udpPort": 161,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "snmpd.conf": "rocommunity public default"
+            },
+            "healthcheckServer": {
+                "enabled": false,
+                "port": 5555,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "prometheusExporter": {
+                "enabled": false,
+                "port": 5556,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "ping": {
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "logServer": {
+                "enabled": false,
+                "retentionDays": 30
+            },
+            "controller": {
+                "enabled": true,
+                "database": {
+                    "location": "internal"
+                }
+            },
+            "gateway": {
+                "enabled": false,
+                "vpn": {
+                    "weight": 100,
+                    "allowDestinations": []
+                }
+            },
+            "logForwarder": {
+                "enabled": false,
+                "tcpClients": [],
+                "awsKineses": [],
+                "sites": []
+            },
+            "connector": {
+                "enabled": false,
+                "expressClients": [],
+                "advancedClients": []
+            },
+            "rsyslogDestinations": [],
+            "hostnameAliases": [
+                "10.97.158.3"
+            ]
+        },
+        {
+            "id": "ee639d70-e075-4f01-596b-930d5f24f569",
+            "name": "gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1",
+            "notes": "",
+            "created": "2021-11-02T14:11:50.122299Z",
+            "updated": "2021-11-02T14:13:33.591830Z",
+            "tags": [],
+            "activated": true,
+            "pendingCertificateRenewal": false,
+            "version": 14,
+            "hostname": "gateway.devops",
+            "site": "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4",
+            "siteName": "Default Site",
+            "connectToPeersUsingClientPortWithSpa": true,
+            "clientInterface": {
+                "proxyProtocol": false,
+                "hostname": "gateway.devops",
+                "httpsPort": 443,
+                "dtlsPort": 443,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "peerInterface": {
+                "hostname": "gateway.devops",
+                "httpsPort": 444,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "networking": {
+                "hosts": [],
+                "nics": [
+                    {
+                        "enabled": true,
+                        "name": "eth0",
+                        "ipv4": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": true,
+                                "routers": true,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": [
+                                {
+                                    "address": "10.97.158.3",
+                                    "netmask": 26,
+                                    "snat": false
+                                }
+                            ]
+                        },
+                        "ipv6": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": true,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": []
+                        }
+                    },
+                    {
+                        "enabled": true,
+                        "name": "eth1",
+                        "ipv4": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": true,
+                                "routers": true,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": [
+                                {
+                                    "address": "10.97.219.66",
+                                    "netmask": 26,
+                                    "snat": false
+                                }
+                            ]
+                        },
+                        "ipv6": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": true,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": []
+                        }
+                    }
+                ],
+                "dnsServers": [
+                    "1.1.1.1",
+                    "8.8.8.8"
+                ],
+                "dnsDomains": [],
+                "routes": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0,
+                        "gateway": "10.97.158.1"
+                    }
+                ]
+            },
+            "ntp": {
+                "servers": [
+                    {
+                        "hostname": "0.ubuntu.pool.ntp.org"
+                    },
+                    {
+                        "hostname": "1.ubuntu.pool.ntp.org"
+                    },
+                    {
+                        "hostname": "2.ubuntu.pool.ntp.org"
+                    },
+                    {
+                        "hostname": "3.ubuntu.pool.ntp.org"
+                    }
+                ]
+            },
+            "sshServer": {
+                "enabled": true,
+                "port": 22,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "passwordAuthentication": true
+            },
+            "snmpServer": {
+                "enabled": false,
+                "allowSources": []
+            },
+            "healthcheckServer": {
+                "enabled": false,
+                "port": 5555,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "prometheusExporter": {
+                "enabled": false,
+                "port": 5556,
+                "allowSources": []
+            },
+            "ping": {
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "logServer": {
+                "enabled": false,
+                "retentionDays": 30
+            },
+            "controller": {
+                "enabled": false,
+                "database": {
+                    "location": "internal"
+                }
+            },
+            "gateway": {
+                "enabled": true,
+                "vpn": {
+                    "weight": 100,
+                    "allowDestinations": [
+                        {
+                            "nic": "eth1"
+                        }
+                    ]
+                }
+            },
+            "logForwarder": {
+                "enabled": false,
+                "tcpClients": [],
+                "awsKineses": [],
+                "sites": []
+            },
+            "connector": {
+                "enabled": false,
+                "expressClients": [],
+                "advancedClients": []
+            },
+            "rsyslogDestinations": [],
+            "hostnameAliases": []
+        }
+    ],
+    "range": "0-2/2",
+    "orderBy": "name",
+    "descending": false,
+    "filterBy": []
+}

--- a/pkg/appliance/fixtures/ha_stats_appliance.json
+++ b/pkg/appliance/fixtures/ha_stats_appliance.json
@@ -1,0 +1,172 @@
+{
+    "name": "appliances",
+    "creationDate": "2021-11-26T14:27:45.474641Z",
+    "refreshInterval": 1,
+    "data": [
+        {
+            "id": "4c07bc67-57ea-42dd-b702-c2d6c45419fc",
+            "name": "controller-da0375f6-0b28-4248-bd54-a933c4c39008-site1",
+            "online": true,
+            "version": "5.3.4-24950",
+            "state": "multi_controller_ready",
+            "volumeNumber": 2,
+            "status": "healthy",
+            "controller": {
+                "status": "healthy",
+                "details": "Database size is 12 MB"
+            },
+            "logServer": {
+                "status": "healthy",
+                "details": "100% of shards are active."
+            },
+            "logForwarder": {
+                "status": "n/a"
+            },
+            "gateway": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "connector": {
+                "status": "n/a"
+            },
+            "portal": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "appliance": {
+                "status": "healthy"
+            },
+            "cpu": 0.8,
+            "memory": 48.8,
+            "disk": 1.2,
+            "network": {
+                "busiestNic": "eth0",
+                "dropin": 0,
+                "dropout": 0,
+                "rxSpeed": "0.26 Kbps",
+                "txSpeed": "0.26 Kbps",
+                "ips": {
+                    "eth0": [
+                        "10.97.144.2"
+                    ]
+                }
+            },
+            "upgrade": {
+                "status": "idle"
+            }
+        },
+        {
+            "id": "ed95fac8-9098-472b-b9f0-fe741881e2ca",
+            "name": "controller2-ed95fac8-9098-472b-b9f0-fe741881e2ca-site1",
+            "online": true,
+            "version": "5.3.4-24950",
+            "state": "multi_controller_ready",
+            "volumeNumber": 2,
+            "status": "healthy",
+            "controller": {
+                "status": "healthy",
+                "details": "Database size is 12 MB"
+            },
+            "logServer": {
+                "status": "healthy",
+                "details": "100% of shards are active."
+            },
+            "logForwarder": {
+                "status": "n/a"
+            },
+            "gateway": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "connector": {
+                "status": "n/a"
+            },
+            "portal": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "appliance": {
+                "status": "healthy"
+            },
+            "cpu": 0.8,
+            "memory": 48.8,
+            "disk": 1.2,
+            "network": {
+                "busiestNic": "eth0",
+                "dropin": 0,
+                "dropout": 0,
+                "rxSpeed": "0.26 Kbps",
+                "txSpeed": "0.26 Kbps",
+                "ips": {
+                    "eth0": [
+                        "10.97.144.3"
+                    ]
+                }
+            },
+            "upgrade": {
+                "status": "idle"
+            }
+        },
+        {
+            "id": "ee639d70-e075-4f01-596b-930d5f24f569",
+            "name": "gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1",
+            "online": true,
+            "version": "5.3.4-24950",
+            "state": "appliance_ready",
+            "volumeNumber": 1,
+            "status": "healthy",
+            "controller": {
+                "status": "n/a"
+            },
+            "logServer": {
+                "status": "n/a"
+            },
+            "logForwarder": {
+                "status": "n/a"
+            },
+            "gateway": {
+                "status": "healthy",
+                "numberOfSessions": 0
+            },
+            "connector": {
+                "status": "n/a"
+            },
+            "portal": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "appliance": {
+                "status": "healthy",
+                "details": "cz-ffwd: forwarding logs to envy-10-97-144-2.devops:443"
+            },
+            "cpu": 0.7,
+            "memory": 7.8,
+            "disk": 4.9,
+            "network": {
+                "busiestNic": "eth0",
+                "dropin": 27,
+                "dropout": 0,
+                "rxSpeed": "96.0 bps",
+                "txSpeed": "76.8 bps",
+                "ips": {
+                    "eth0": [
+                        "10.97.144.3"
+                    ],
+                    "eth1": [
+                        "10.97.205.66"
+                    ]
+                }
+            },
+            "upgrade": {
+                "status": "idle"
+            }
+        }
+    ],
+    "controllerCount": 1,
+    "gatewayCount": 1,
+    "applianceCount": 2,
+    "logServerCount": 1,
+    "logForwarderCount": 0,
+    "connectorCount": 0,
+    "portalCount": 0
+}


### PR DESCRIPTION
This will prevent users from doing partial upgrade of controllers when the new version is a major or minor version upgrade (patch upgrades are ok). Doing this is unsupported and may break the system.

The PR includes a few steps for preventing this kind of unsupported upgrade:
- if any controllers are excluded while preparing a major or minor upgrade, a warning will get printed in the prepare summary.
- If running `upgrade complete` while having one or more controllers unprepared for upgrade, the complete will return an error.
- If running `upgrade complete` with all controllers prepared, but with different version, the complete will return a "version mismatch" error

Additional changes made:
- Upgrade and prepare summaries now lists appliances as skipped if they are either offline, filtered using the `--include` or `exclude` flag or unprepared for upgrade.

Fixes SA-20219