### PR TITLE
Add circuit breaker when polling for backup status in case of network errors

### DIFF
--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -225,6 +225,7 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 				}
 				return err
 			}
+			networkErrors = 0
 			log.WithFields(log.Fields{
 				"appliance": applianceID,
 				"backup_id": backupID,

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -18,6 +18,7 @@ import (
 	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/appgate/sdpctl/pkg/appliance/backup"
+	"github.com/appgate/sdpctl/pkg/cmdutil"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/filesystem"
 	"github.com/appgate/sdpctl/pkg/prompt"
@@ -220,7 +221,7 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 				if errors.Is(err, context.DeadlineExceeded) {
 					networkErrors++
 					if networkErrors >= 5 {
-						return backoff.Permanent(err)
+						return backoff.Permanent(cmdutil.ErrNetworkError)
 					}
 				}
 				return err

--- a/pkg/appliance/backup/backup.go
+++ b/pkg/appliance/backup/backup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
@@ -60,7 +61,9 @@ const (
 )
 
 func (b *Backup) Status(ctx context.Context, applianceID, backupID string) (*openapi.AppliancesIdBackupBackupIdStatusGet200Response, error) {
-	status, response, err := b.APIClient.ApplianceBackupApi.AppliancesIdBackupBackupIdStatusGet(ctx, applianceID, backupID).Authorization(b.Token).Execute()
+	timeoutCTX, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	status, response, err := b.APIClient.ApplianceBackupApi.AppliancesIdBackupBackupIdStatusGet(timeoutCTX, applianceID, backupID).Authorization(b.Token).Execute()
 	if err != nil {
 		return nil, api.HTTPErrorResponse(response, err)
 	}

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -11,4 +11,6 @@ var (
 	ErrCommandTimeout = errors.New("Command timed out")
 	// ErrMissingTTY is used when no TTY is available
 	ErrMissingTTY = errors.New("no TTY present")
+	// ErrNetworkError is used when a command encounters multiple timeouts on a request, which we will presume is a network error
+	ErrNetworkError = errors.New("Failed to communicate with SDP Collective. Bad connection")
 )


### PR DESCRIPTION
This will check for network errors when polling the status of an initiated backup by using a timeout context. The timeout for each request is set to 5 seconds. If a request times out 5 consecutive times, it will be considered a permanent error and result in the a command error.

The network error counter will be reset if the status polling request is successful before reaching the 5 counter threshold.

Fixes: SA-20059