### PR TITLE
Fix possible race condition when preparing an upgrade image

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -608,8 +608,8 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 						queueContinue <- queueStruct{err: err}
 						return err
 					}
+					unwantedStatus = append(unwantedStatus, appliancepkg.UpgradeStatusIdle)
 				}
-				unwantedStatus = append(unwantedStatus, appliancepkg.UpgradeStatusIdle)
 				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, qs.appliance, wantedStatus, unwantedStatus, qs.tracker); err != nil {
 					queueContinue <- queueStruct{err: err}
 					return err

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
+	"github.com/appgate/sdpctl/pkg/appliance/change"
 	"github.com/appgate/sdpctl/pkg/cmdutil"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"
@@ -502,8 +503,6 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			}
 			// prepareReady is used for the status bars to mark them as ready if everything is successful.
 			prepareReady = []string{appliancepkg.UpgradeStatusReady, appliancepkg.UpgradeStatusSuccess}
-			// unwantedStatus is used to determine if the upgrade prepare has failed
-			unwantedStatus = []string{appliancepkg.UpgradeStatusFailed, appliancepkg.UpgradeStatusIdle}
 			// updateProgressBars is the container for the progress bars
 			updateProgressBars *tui.Progress
 		)
@@ -554,6 +553,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				}
 			}
 
+			unwantedStatus := []string{appliancepkg.UpgradeStatusFailed}
 			var t *tui.Tracker
 			if !opts.ciMode {
 				t = updateProgressBars.AddTracker(appliance.GetName(), "ready")
@@ -575,6 +575,8 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				if v == nil {
 					return nil
 				}
+				// unwantedStatus is used to determine if the upgrade prepare has failed
+				unwantedStatus := []string{appliancepkg.UpgradeStatusFailed}
 				qs := v.(queueStruct)
 				ctx, cancel := context.WithTimeout(ctx, opts.timeout)
 				defer cancel()
@@ -587,10 +589,27 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 					queueContinue <- queueStruct{err: err}
 					return err
 				}
-				if err := a.PrepareFileOn(ctx, remoteFilePath, qs.appliance.GetId(), opts.DevKeyring); err != nil {
+				changeID, err := a.PrepareFileOn(ctx, remoteFilePath, qs.appliance.GetId(), opts.DevKeyring)
+				if err != nil {
 					queueContinue <- queueStruct{err: err}
 					return err
 				}
+				if opts.Config.Version >= 15 {
+					t, err := opts.Config.GetBearTokenHeaderValue()
+					if err != nil {
+						queueContinue <- queueStruct{err: err}
+						return err
+					}
+					ac := change.ApplianceChange{
+						APIClient: a.APIClient,
+						Token:     t,
+					}
+					if _, err = ac.RetryUntilCompleted(ctx, changeID, qs.appliance.GetId()); err != nil {
+						queueContinue <- queueStruct{err: err}
+						return err
+					}
+				}
+				unwantedStatus = append(unwantedStatus, appliancepkg.UpgradeStatusIdle)
 				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, qs.appliance, wantedStatus, unwantedStatus, qs.tracker); err != nil {
 					queueContinue <- queueStruct{err: err}
 					return err
@@ -619,6 +638,8 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				}
 				ctx, cancel := context.WithDeadline(ctx, qs.deadline)
 				defer cancel()
+				// unwantedStatus is used to determine if the upgrade prepare has failed
+				unwantedStatus := []string{appliancepkg.UpgradeStatusFailed, appliancepkg.UpgradeStatusIdle}
 				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, qs.appliance, prepareReady, unwantedStatus, qs.tracker); err != nil {
 					errChan <- err
 					return

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -116,6 +116,22 @@ func TestUpgradePrepareCommand(t *testing.T) {
 					},
 				},
 				{
+					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/change/37bdc593-df27-49f8-9852-cb302214ee1f",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
+					},
+				},
+				{
+					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/change/493a0d78-772c-4a6d-a618-1fbfdf02ab68",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
+					},
+				},
+				{
 					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/upgrade",
 					Responder: func(rw http.ResponseWriter, r *http.Request) {
 						rw.Header().Set("Content-Type", "application/json")
@@ -180,6 +196,22 @@ func TestUpgradePrepareCommand(t *testing.T) {
 							rw.WriteHeader(http.StatusOK)
 							fmt.Fprint(rw, string(`{"id": "493a0d78-772c-4a6d-a618-1fbfdf02ab68" }`))
 						}
+					},
+				},
+				{
+					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/change/37bdc593-df27-49f8-9852-cb302214ee1f",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
+					},
+				},
+				{
+					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/change/493a0d78-772c-4a6d-a618-1fbfdf02ab68",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
 					},
 				},
 				{
@@ -256,6 +288,22 @@ func TestUpgradePrepareCommand(t *testing.T) {
 					},
 				},
 				{
+					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/change/37bdc593-df27-49f8-9852-cb302214ee1f",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
+					},
+				},
+				{
+					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/change/493a0d78-772c-4a6d-a618-1fbfdf02ab68",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
+					},
+				},
+				{
 					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/upgrade",
 					Responder: func(rw http.ResponseWriter, r *http.Request) {
 						rw.Header().Set("Content-Type", "application/json")
@@ -322,6 +370,22 @@ func TestUpgradePrepareCommand(t *testing.T) {
 							rw.WriteHeader(http.StatusOK)
 							fmt.Fprint(rw, string(`{"id": "493a0d78-772c-4a6d-a618-1fbfdf02ab68" }`))
 						}
+					},
+				},
+				{
+					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/change/37bdc593-df27-49f8-9852-cb302214ee1f",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
+					},
+				},
+				{
+					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/change/493a0d78-772c-4a6d-a618-1fbfdf02ab68",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
 					},
 				},
 				{
@@ -466,6 +530,22 @@ func TestUpgradePrepareCommand(t *testing.T) {
 					},
 				},
 				{
+					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/change/37bdc593-df27-49f8-9852-cb302214ee1f",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
+					},
+				},
+				{
+					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/change/493a0d78-772c-4a6d-a618-1fbfdf02ab68",
+					Responder: func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
+					},
+				},
+				{
 					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/upgrade",
 					Responder: func(rw http.ResponseWriter, r *http.Request) {
 						rw.Header().Set("Content-Type", "application/json")
@@ -500,8 +580,9 @@ func TestUpgradePrepareCommand(t *testing.T) {
 			in := io.NopCloser(stdin)
 			f := &factory.Factory{
 				Config: &configuration.Config{
-					Debug: false,
-					URL:   fmt.Sprintf("http://appgate.com:%d", registry.Port),
+					Debug:   false,
+					URL:     fmt.Sprintf("http://appgate.com:%d", registry.Port),
+					Version: 16,
 				},
 				IOOutWriter: stdout,
 				Stdin:       in,


### PR DESCRIPTION
This fixes a possible race condition where sdpctl would start polling for the upgrade status before the appliance starts the process, causing progress bars to fail with no error message.

The idle state is no longer set as an unwanted status while preparing until later in the upgrade process. On API version 15 and above, the idle status will be unwanted once the change request has been completed. On API versions below 15, the idle state will be set as unwanted after download of the upgrade image has completed.

Fixes: SA-20337