### PR TITLE
new command: sdpctl license prune

### DIFF
--- a/cmd/license/license.go
+++ b/cmd/license/license.go
@@ -1,0 +1,67 @@
+package license
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/spf13/cobra"
+)
+
+type licenseOpts struct {
+	Out        io.Writer
+	BaseURL    string
+	HTTPClient func() (*http.Client, error)
+}
+
+type customTransport struct {
+	token, accept, useragent string
+	underlyingTransport      http.RoundTripper
+}
+
+func (ct *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("Accept", ct.accept)
+	req.Header.Add("Authorization", ct.token)
+	req.Header.Add("User-Agent", ct.useragent)
+
+	return ct.underlyingTransport.RoundTrip(req)
+}
+
+// NewLicenseCmd return a new license subcommand
+func NewLicenseCmd(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:              "license",
+		TraverseChildren: true,
+	}
+
+	cfg := f.Config
+	opts := &licenseOpts{
+		Out:     f.IOOutWriter,
+		BaseURL: cfg.URL,
+		HTTPClient: func() (*http.Client, error) {
+			client, err := f.HTTPClient()
+			if err != nil {
+				return nil, err
+			}
+			parentTransport, err := f.HTTPTransport()
+			if err != nil {
+				return nil, err
+			}
+			token, err := cfg.GetBearTokenHeaderValue()
+			if err != nil {
+				return nil, err
+			}
+			client.Transport = &customTransport{
+				token:               token,
+				accept:              fmt.Sprintf("application/vnd.appgate.peer-v%d+json", cfg.Version),
+				useragent:           f.UserAgent,
+				underlyingTransport: parentTransport,
+			}
+			return client, nil
+		},
+	}
+	cmd.AddCommand(NewPruneCmd(opts))
+
+	return cmd
+}

--- a/cmd/license/license.go
+++ b/cmd/license/license.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +34,8 @@ func NewLicenseCmd(f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "license",
 		TraverseChildren: true,
+		Short:            docs.LicenseRootDoc.Short,
+		Long:             docs.LicenseRootDoc.Long,
 	}
 
 	cfg := f.Config

--- a/cmd/license/prune.go
+++ b/cmd/license/prune.go
@@ -6,13 +6,17 @@ import (
 	"net/http"
 
 	"github.com/appgate/sdpctl/pkg/api"
+	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/spf13/cobra"
 )
 
 // NewPruneCmd return a new license prune subcommand
 func NewPruneCmd(opts *licenseOpts) *cobra.Command {
 	return &cobra.Command{
-		Use: "prune",
+		Use:     "prune",
+		Short:   docs.LicensePruneDoc.Short,
+		Long:    docs.LicensePruneDoc.Long,
+		Example: docs.LicensePruneDoc.ExampleString(),
 		RunE: func(c *cobra.Command, args []string) error {
 			return pruneRun(c, args, opts)
 		},

--- a/cmd/license/prune.go
+++ b/cmd/license/prune.go
@@ -16,6 +16,7 @@ func NewPruneCmd(opts *licenseOpts) *cobra.Command {
 		Use: "prune",
 		Annotations: map[string]string{
 			"MinAPIVersion": "18",
+			"ErrorMessage":  "sdpctl license prune requires appliance version higher or equal to 6.1 with API Version 18",
 		},
 		Short:   docs.LicensePruneDoc.Short,
 		Long:    docs.LicensePruneDoc.Long,

--- a/cmd/license/prune.go
+++ b/cmd/license/prune.go
@@ -13,7 +13,10 @@ import (
 // NewPruneCmd return a new license prune subcommand
 func NewPruneCmd(opts *licenseOpts) *cobra.Command {
 	return &cobra.Command{
-		Use:     "prune",
+		Use: "prune",
+		Annotations: map[string]string{
+			"MinAPIVersion": "18",
+		},
 		Short:   docs.LicensePruneDoc.Short,
 		Long:    docs.LicensePruneDoc.Long,
 		Example: docs.LicensePruneDoc.ExampleString(),
@@ -42,8 +45,7 @@ func pruneRun(cmd *cobra.Command, args []string, opts *licenseOpts) error {
 		return errors.New("could not do license prune, not supported on your appliance version")
 	}
 	if response.StatusCode != http.StatusNoContent {
-		fmt.Fprintf(opts.Out, "Could not prune license got HTTP %d\n", response.StatusCode)
-		return nil
+		return fmt.Errorf("could not prune license got HTTP %d\n", response.StatusCode)
 	}
 	fmt.Fprintln(opts.Out, "users license pruned")
 	return nil

--- a/cmd/license/prune.go
+++ b/cmd/license/prune.go
@@ -1,0 +1,46 @@
+package license
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/appgate/sdpctl/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+// NewPruneCmd return a new license prune subcommand
+func NewPruneCmd(opts *licenseOpts) *cobra.Command {
+	return &cobra.Command{
+		Use: "prune",
+		RunE: func(c *cobra.Command, args []string) error {
+			return pruneRun(c, args, opts)
+		},
+	}
+}
+
+func pruneRun(cmd *cobra.Command, args []string, opts *licenseOpts) error {
+	client, err := opts.HTTPClient()
+	if err != nil {
+		return fmt.Errorf("could not resolve a HTTP client based on your current config %s", err)
+	}
+	requestURL := fmt.Sprintf("%s/license/users/prune", opts.BaseURL)
+	request, err := http.NewRequest(http.MethodDelete, requestURL, nil)
+	if err != nil {
+		return err
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return api.HTTPErrorResponse(response, err)
+	}
+	if response.StatusCode == http.StatusNotFound {
+		return errors.New("could not do license prune, not supported on your appliance version")
+	}
+	if response.StatusCode != http.StatusNoContent {
+		fmt.Fprintf(opts.Out, "Could not prune license got HTTP %d\n", response.StatusCode)
+		return nil
+	}
+	fmt.Fprintln(opts.Out, "users license pruned")
+	return nil
+}

--- a/cmd/license/prune_test.go
+++ b/cmd/license/prune_test.go
@@ -1,0 +1,105 @@
+package license
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/appgate/sdpctl/pkg/httpmock"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPruneCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		cli        string
+		httpStubs  []httpmock.Stub
+		wantErr    bool
+		wantErrOut *regexp.Regexp
+		wantOutput string
+	}{
+		{
+			name: "http 204",
+			httpStubs: []httpmock.Stub{
+				{
+					URL: "/license/users/prune",
+					Responder: func(rw http.ResponseWriter, r *http.Request) {
+						if r.Method == http.MethodDelete {
+							rw.WriteHeader(http.StatusNoContent)
+						}
+					},
+				},
+			},
+			wantErr:    false,
+			wantOutput: "users license pruned\n",
+		},
+		{
+			name: "unexpected http response",
+			httpStubs: []httpmock.Stub{
+				{
+					URL: "/license/users/prune",
+					Responder: func(rw http.ResponseWriter, r *http.Request) {
+						if r.Method == http.MethodDelete {
+							rw.WriteHeader(http.StatusOK)
+						}
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrOut: regexp.MustCompile(`could not prune license got HTTP 200`),
+		},
+		{
+			name: "not found",
+			httpStubs: []httpmock.Stub{
+				{
+					URL: "/license/users/prune",
+					Responder: func(rw http.ResponseWriter, r *http.Request) {
+						rw.WriteHeader(http.StatusNotFound)
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrOut: regexp.MustCompile(`could not do license prune, not supported on your appliance version`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := httpmock.NewRegistry(t)
+			for _, v := range tt.httpStubs {
+				registry.Register(v.URL, v.Responder)
+			}
+			defer registry.Teardown()
+			registry.Serve()
+			stdout := &bytes.Buffer{}
+			opts := &licenseOpts{
+				Out:     stdout,
+				BaseURL: fmt.Sprintf("http://127.0.0.1:%d", registry.Port),
+				HTTPClient: func() (*http.Client, error) {
+					return &http.Client{}, nil
+				},
+			}
+			cmd := NewPruneCmd(opts)
+			_, err := cmd.ExecuteC()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewPruneCmd() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.wantErrOut != nil {
+				if !tt.wantErrOut.MatchString(err.Error()) {
+					t.Fatalf("Expected output to match, got:\n%s\n expected: \n%s\n", tt.wantErrOut, err.Error())
+				}
+
+			}
+			got, err := io.ReadAll(stdout)
+			if err != nil {
+				t.Fatalf("unable to read stdout %s", err)
+			}
+			gotStr := string(got)
+			if diff := cmp.Diff(tt.wantOutput, gotStr); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/appgate/sdpctl/cmd/license"
 	cmdprofile "github.com/appgate/sdpctl/cmd/profile"
 	"github.com/appgate/sdpctl/cmd/token"
 	"github.com/hashicorp/go-multierror"
@@ -143,6 +144,7 @@ func NewCmdRoot(currentProfile *string) *cobra.Command {
 	rootCmd.AddCommand(cmdprofile.NewProfileCmd(f))
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(serviceusers.NewServiceUsersCMD(f))
+	rootCmd.AddCommand(license.NewLicenseCmd(f))
 	rootCmd.SetUsageTemplate(UsageTemplate())
 	rootCmd.SetHelpTemplate(HelpTemplate())
 	rootCmd.PersistentPreRunE = rootPersistentPreRunEFunc(f, cfg)

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -99,6 +99,9 @@ func CheckMinAPIVersionRestriction(cmd *cobra.Command, currentVersion int) error
 		if c.Annotations != nil {
 			if s, ok := c.Annotations["MinAPIVersion"]; ok {
 				if minVersion, err := strconv.Atoi(s); err == nil && currentVersion < minVersion {
+					if message, ok := c.Annotations["ErrorMessage"]; ok {
+						return errors.New(message)
+					}
 					return fmt.Errorf("Minimum API version %d is required to use the '%s' command. Current API version is %d", minVersion, c.Name(), currentVersion)
 				}
 			}

--- a/pkg/docs/license.go
+++ b/pkg/docs/license.go
@@ -9,7 +9,7 @@ var (
 	LicensePruneDoc = CommandDoc{
 		Short: "clear the license back (from 30) to 1 day.",
 		Long: `clear the license back (from 30) to 1 day.
-This command only works on appliances >= 6.1`,
+This command only works on appliances higher or equal to 6.1 (API Version 18)`,
 		Examples: []ExampleDoc{
 			{
 				Description: "",

--- a/pkg/docs/license.go
+++ b/pkg/docs/license.go
@@ -1,0 +1,20 @@
+package docs
+
+var (
+	LicenseRootDoc = CommandDoc{
+		Short: "interact with Appgate SDP License",
+		Long:  ``,
+	}
+
+	LicensePruneDoc = CommandDoc{
+		Short: "clear the license back (from 30) to 1 day.",
+		Long: `clear the license back (from 30) to 1 day.
+This command only works on appliances >= 6.1`,
+		Examples: []ExampleDoc{
+			{
+				Description: "",
+				Command:     "sdpctl license prune",
+			},
+		},
+	}
+)

--- a/pkg/factory/http.go
+++ b/pkg/factory/http.go
@@ -22,26 +22,30 @@ import (
 )
 
 type Factory struct {
-	HTTPClient   func() (*http.Client, error)
-	APIClient    func(c *configuration.Config) (*openapi.APIClient, error)
-	Appliance    func(c *configuration.Config) (*appliance.Appliance, error)
-	Token        func(c *configuration.Config) (*token.Token, error)
-	ServiceUsers func(c *configuration.Config) (*serviceusers.ServiceUsersAPI, error)
-	Config       *configuration.Config
-	IOOutWriter  io.Writer
-	Stdin        io.ReadCloser
-	StdErr       io.Writer
-	SpinnerOut   io.Writer
+	HTTPClient    func() (*http.Client, error)
+	HTTPTransport func() (*http.Transport, error)
+	APIClient     func(c *configuration.Config) (*openapi.APIClient, error)
+	Appliance     func(c *configuration.Config) (*appliance.Appliance, error)
+	Token         func(c *configuration.Config) (*token.Token, error)
+	ServiceUsers  func(c *configuration.Config) (*serviceusers.ServiceUsersAPI, error)
+	UserAgent     string
+	Config        *configuration.Config
+	IOOutWriter   io.Writer
+	Stdin         io.ReadCloser
+	StdErr        io.Writer
+	SpinnerOut    io.Writer
 }
 
 func New(appVersion string, config *configuration.Config) *Factory {
 	f := &Factory{}
 	f.Config = config
-	f.HTTPClient = httpClientFunc(f)                 // depends on config
-	f.APIClient = apiClientFunc(f, appVersion)       // depends on config
-	f.Appliance = applianceFunc(f, appVersion)       // depends on config
-	f.Token = tokenFunc(f, appVersion)               // depends on config
-	f.ServiceUsers = serviceUsersFunc(f, appVersion) // depends on config
+	f.UserAgent = "sdpctl/" + appVersion + "/go"
+	f.HTTPTransport = httpTransport(f)   // depends on config
+	f.HTTPClient = httpClientFunc(f)     // depends on config
+	f.APIClient = apiClientFunc(f)       // depends on config
+	f.Appliance = applianceFunc(f)       // depends on config
+	f.Token = tokenFunc(f)               // depends on config
+	f.ServiceUsers = serviceUsersFunc(f) // depends on config
 	f.IOOutWriter = os.Stdout
 	f.Stdin = os.Stdin
 	f.StdErr = os.Stderr
@@ -57,21 +61,21 @@ func (f *Factory) CanPrompt() bool {
 func (f *Factory) SetSpinnerOutput(o io.Writer) {
 	f.SpinnerOut = o
 }
+
 func (f *Factory) GetSpinnerOutput() func() io.Writer {
 	return func() io.Writer {
 		return f.SpinnerOut
 	}
 }
-func httpClientFunc(f *Factory) func() (*http.Client, error) {
-	return func() (*http.Client, error) {
+
+func httpTransport(f *Factory) func() (*http.Transport, error) {
+	return func() (*http.Transport, error) {
 		cfg := f.Config
 		timeout := 5
 		if cfg.Timeout > timeout {
 			timeout = cfg.Timeout
 		}
-
 		timeoutDuration := time.Duration(timeout)
-
 		rootCAs, _ := x509.SystemCertPool()
 		if rootCAs == nil {
 			rootCAs = x509.NewCertPool()
@@ -102,6 +106,23 @@ func httpClientFunc(f *Factory) func() (*http.Client, error) {
 			}
 			tr.Proxy = http.ProxyURL(proxyURL)
 		}
+		return tr, nil
+	}
+}
+
+func httpClientFunc(f *Factory) func() (*http.Client, error) {
+	return func() (*http.Client, error) {
+		cfg := f.Config
+		timeout := 5
+		if cfg.Timeout > timeout {
+			timeout = cfg.Timeout
+		}
+
+		timeoutDuration := time.Duration(timeout)
+		tr, err := f.HTTPTransport()
+		if err != nil {
+			return nil, err
+		}
 		c := &http.Client{
 			Transport: tr,
 			Timeout:   ((timeoutDuration * 2) * time.Second),
@@ -110,7 +131,7 @@ func httpClientFunc(f *Factory) func() (*http.Client, error) {
 	}
 }
 
-func apiClientFunc(f *Factory, appVersion string) func(c *configuration.Config) (*openapi.APIClient, error) {
+func apiClientFunc(f *Factory) func(c *configuration.Config) (*openapi.APIClient, error) {
 	return func(cfg *configuration.Config) (*openapi.APIClient, error) {
 		hc, err := f.HTTPClient()
 		if err != nil {
@@ -126,7 +147,7 @@ func apiClientFunc(f *Factory, appVersion string) func(c *configuration.Config) 
 				"Accept": fmt.Sprintf("application/vnd.appgate.peer-v%d+json", cfg.Version),
 			},
 			Debug:     cfg.Debug,
-			UserAgent: "sdpctl/" + appVersion + "/go",
+			UserAgent: f.UserAgent,
 			Servers: []openapi.ServerConfiguration{
 				{
 					URL: cfg.URL,
@@ -139,7 +160,7 @@ func apiClientFunc(f *Factory, appVersion string) func(c *configuration.Config) 
 	}
 }
 
-func getClients(f *Factory, appVersion string, cfg *configuration.Config) (*http.Client, *openapi.APIClient, error) {
+func getClients(f *Factory, cfg *configuration.Config) (*http.Client, *openapi.APIClient, error) {
 	httpClient, err := f.HTTPClient()
 	if err != nil {
 		return nil, nil, err
@@ -151,9 +172,9 @@ func getClients(f *Factory, appVersion string, cfg *configuration.Config) (*http
 	return httpClient, apiClient, nil
 }
 
-func applianceFunc(f *Factory, appVersion string) func(c *configuration.Config) (*appliance.Appliance, error) {
+func applianceFunc(f *Factory) func(c *configuration.Config) (*appliance.Appliance, error) {
 	return func(cfg *configuration.Config) (*appliance.Appliance, error) {
-		httpClient, apiClient, err := getClients(f, appVersion, cfg)
+		httpClient, apiClient, err := getClients(f, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -170,9 +191,9 @@ func applianceFunc(f *Factory, appVersion string) func(c *configuration.Config) 
 	}
 }
 
-func tokenFunc(f *Factory, appVersion string) func(c *configuration.Config) (*token.Token, error) {
+func tokenFunc(f *Factory) func(c *configuration.Config) (*token.Token, error) {
 	return func(cfg *configuration.Config) (*token.Token, error) {
-		httpClient, apiClient, err := getClients(f, appVersion, cfg)
+		httpClient, apiClient, err := getClients(f, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -189,9 +210,9 @@ func tokenFunc(f *Factory, appVersion string) func(c *configuration.Config) (*to
 	}
 }
 
-func serviceUsersFunc(f *Factory, appVersion string) func(c *configuration.Config) (*serviceusers.ServiceUsersAPI, error) {
+func serviceUsersFunc(f *Factory) func(c *configuration.Config) (*serviceusers.ServiceUsersAPI, error) {
 	return func(cfg *configuration.Config) (*serviceusers.ServiceUsersAPI, error) {
-		_, apiClient, err := getClients(f, appVersion, cfg)
+		_, apiClient, err := getClients(f, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/factory/http_test.go
+++ b/pkg/factory/http_test.go
@@ -1,13 +1,12 @@
 package factory
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/appgate/sdpctl/pkg/configuration"
 )
 
-func TestHttpClientTransportTLSFromConfig(t *testing.T) {
+func TestHttpTransportTLSFromConfig(t *testing.T) {
 	type args struct {
 		f *Factory
 	}
@@ -70,12 +69,13 @@ func TestHttpClientTransportTLSFromConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := httpClientFunc(tt.args.f)()
+			tr, err := httpTransport(tt.args.f)()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("got error %v", err)
+				return
 			}
-			if c != nil {
-				tr := c.Transport.(*http.Transport)
+
+			if tr != nil {
 				if tr.TLSClientConfig.InsecureSkipVerify != tt.wantInsecure {
 					t.Fatalf("got %v expected %v", tr.TLSClientConfig.InsecureSkipVerify, tt.wantInsecure)
 				}


### PR DESCRIPTION
new command: `sdpctl license prune`, clear the license back (from 30) to 1 day. only applicable on 6.1

Internal ticket: SA-20344