### PR TITLE
Refine actual hostname flag

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -198,7 +198,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	if len(opts.actualHostname) > 0 {
 		controlHost = opts.actualHostname
 	}
-	primaryController, err := appliancepkg.FindPrimaryController(rawAppliances, controlHost)
+	primaryController, err := appliancepkg.FindPrimaryController(rawAppliances, controlHost, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -210,7 +210,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	}
 	filteredAppliances := appliancepkg.FilterAppliances(Allappliances, filter)
 
-	primaryController, err := appliancepkg.FindPrimaryController(Allappliances, host)
+	primaryController, err := appliancepkg.FindPrimaryController(Allappliances, host, false)
 	if err != nil {
 		return err
 	}

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -140,6 +140,11 @@ The `upgrade complete` command will run until all appliances that are part of th
 2. Any additional controllers will be upgraded one at a time. If there are no additional controllers in the SDP Collective, this step will be skipped.
 3. Any remaining appliances will be upgraded. The remaining appliances will be split up into batches to ensure high availability during the upgrade process. The number of batches depends on how many appliances are left to upgrade and the size of each batch depends on how many sites are set up in the collective. Each appliance in a batch will need to be completed before the next batch is going to be processed.
 
+Note that the primary controller hostname need to resolve to an unique ip-adress for the upgrade to complete successfully. In case you are connecting to the primary controller through a load balancer, or similar that does not resolve to a unique ip-adress, you can use the `--actual-hostname` flag when completing the upgrade.
+```bash
+$ sdpctl appliance upgrade complete --actual-hostname=<actual controller hostname>
+```
+
 As with the other upgrade commands, the `--include` and `--exclude` flags can be used to gain further control of the upgrade completion.
 ```bash
 $ # upgrade only controllers

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -121,7 +121,7 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 		}
 
 		if opts.PrimaryFlag || opts.NoInteractive {
-			pc, err := FindPrimaryController(appliances, hostname)
+			pc, err := FindPrimaryController(appliances, hostname, false)
 			if err != nil {
 				log.Warn("failed to determine primary controller")
 			} else {

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -280,7 +280,7 @@ func GetApplianceVersion(appliance openapi.Appliance, stats openapi.StatsApplian
 
 // FindPrimaryController The given hostname should match one of the controller's actual admin hostname.
 // Hostnames should be compared in a case insensitive way.
-func FindPrimaryController(appliances []openapi.Appliance, hostname string) (*openapi.Appliance, error) {
+func FindPrimaryController(appliances []openapi.Appliance, hostname string, validate bool) (*openapi.Appliance, error) {
 	controllers := make([]openapi.Appliance, 0)
 	type details struct {
 		ID        string
@@ -325,8 +325,10 @@ func FindPrimaryController(appliances []openapi.Appliance, hostname string) (*op
 		)
 	}
 	if candidate != nil {
-		if err := ValidateHostname(*candidate, hostname); err != nil {
-			return nil, err
+		if validate {
+			if err := ValidateHostname(*candidate, hostname); err != nil {
+				return nil, err
+			}
 		}
 		return candidate, nil
 	}

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -154,6 +154,7 @@ func TestFindPrimaryController(t *testing.T) {
 	type args struct {
 		appliances []openapi.Appliance
 		hostname   string
+		validate   bool
 	}
 	tests := []struct {
 		name    string
@@ -190,6 +191,7 @@ func TestFindPrimaryController(t *testing.T) {
 					},
 				},
 				hostname: "appgate.com",
+				validate: true,
 			},
 			want: &openapi.Appliance{
 				Name: "primary controller",
@@ -202,6 +204,39 @@ func TestFindPrimaryController(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "no hostname",
+			args: args{
+				appliances: []openapi.Appliance{
+					{
+						Name: "primary controller",
+						Id:   openapi.PtrString("one"),
+						Controller: &openapi.ApplianceAllOfController{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "localhost",
+						},
+					},
+					{
+						Name: "secondary controller with log server",
+						Id:   openapi.PtrString("two"),
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "localhost",
+						},
+						Controller: &openapi.ApplianceAllOfController{
+							Enabled: openapi.PtrBool(true),
+						},
+						LogServer: &openapi.ApplianceAllOfLogServer{
+							Enabled: openapi.PtrBool(true),
+						},
+					},
+				},
+				hostname: "appgate.com",
+				validate: true,
+			},
+			wantErr: true,
 		},
 		{
 			name: "no hit",
@@ -235,6 +270,7 @@ func TestFindPrimaryController(t *testing.T) {
 					},
 				},
 				hostname: "appgate.com",
+				validate: true,
 			},
 			want:    nil,
 			wantErr: true,
@@ -242,7 +278,7 @@ func TestFindPrimaryController(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FindPrimaryController(tt.args.appliances, tt.args.hostname)
+			got, err := FindPrimaryController(tt.args.appliances, tt.args.hostname, tt.args.validate)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FindPrimaryController() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This is a refinement of the usage of the  `--actual-hostname` flag, motivated by a support case. The main difference is that the hostname will not be validated to resolve to a single IP-address when backing up or preparing anymore. The validation code will only execute when running `appliance upgrade complete` which is the only case where it is needed.

Additionally, I've added documentation about why and how to use the flag.