### PR TITLE
sdpctl configure without any interactive prompt

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -1,6 +1,7 @@
 package configure
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -18,18 +19,21 @@ import (
 )
 
 type configureOptions struct {
-	Config *configuration.Config
-	PEM    string
-	Out    io.Writer
-	StdErr io.Writer
+	Config    *configuration.Config
+	PEM       string
+	Out       io.Writer
+	StdErr    io.Writer
+	CanPrompt bool
+	URL       string
 }
 
 // NewCmdConfigure return a new Configure command
 func NewCmdConfigure(f *factory.Factory) *cobra.Command {
 	opts := configureOptions{
-		Config: f.Config,
-		Out:    f.IOOutWriter,
-		StdErr: f.StdErr,
+		Config:    f.Config,
+		Out:       f.IOOutWriter,
+		StdErr:    f.StdErr,
+		CanPrompt: f.CanPrompt(),
 	}
 	cmd := &cobra.Command{
 		Use: "configure",
@@ -39,6 +43,32 @@ func NewCmdConfigure(f *factory.Factory) *cobra.Command {
 		Short:   docs.ConfigureDocs.Short,
 		Long:    docs.ConfigureDocs.Long,
 		Example: docs.ConfigureDocs.ExampleString(),
+		Args: func(cmd *cobra.Command, args []string) error {
+			noInteractive, err := cmd.Flags().GetBool("no-interactive")
+			if err != nil {
+				return err
+			}
+			switch len(args) {
+			case 0:
+				if noInteractive || !opts.CanPrompt {
+					return errors.New("can't prompt, You need to provide all arguments, for example 'sdpctl configure appgate.controller.com'")
+				}
+				q := &survey.Input{
+					Message: "Enter the url for the controller API (example https://appgate.controller.com/admin)",
+					Default: opts.Config.URL,
+				}
+
+				err := prompt.SurveyAskOne(q, &opts.URL, survey.WithValidator(survey.Required))
+				if err != nil {
+					return err
+				}
+			case 1:
+				opts.URL = args[0]
+			default:
+				return fmt.Errorf("accepts at most %d arg(s), received %d", 1, len(args))
+			}
+			return nil
+		},
 		RunE: func(c *cobra.Command, args []string) error {
 			return configRun(c, args, &opts)
 		},
@@ -52,16 +82,9 @@ func NewCmdConfigure(f *factory.Factory) *cobra.Command {
 }
 
 func configRun(cmd *cobra.Command, args []string, opts *configureOptions) error {
-	q := &survey.Input{
-		Message: "Enter the url for the controller API (example https://appgate.controller.com/admin)",
-		Default: opts.Config.URL,
+	if len(opts.URL) < 1 {
+		return errors.New("missing URL for appgate sdp controller")
 	}
-	var URL string
-	err := prompt.SurveyAskOne(q, &URL, survey.WithValidator(survey.Required))
-	if err != nil {
-		return err
-	}
-
 	if len(opts.PEM) > 0 {
 		opts.PEM = filesystem.AbsolutePath(opts.PEM)
 		if ok, err := util.FileExists(opts.PEM); err != nil || !ok {
@@ -69,9 +92,9 @@ func configRun(cmd *cobra.Command, args []string, opts *configureOptions) error 
 		}
 		viper.Set("pem_filepath", opts.PEM)
 	}
-	u, err := configuration.NormalizeURL(URL)
+	u, err := configuration.NormalizeURL(opts.URL)
 	if err != nil {
-		return fmt.Errorf("could not determine URL for %s %s", URL, err)
+		return fmt.Errorf("could not determine URL for %s %s", opts.URL, err)
 	}
 	viper.Set("url", u)
 	opts.Config.URL = u
@@ -79,7 +102,7 @@ func configRun(cmd *cobra.Command, args []string, opts *configureOptions) error 
 
 	h, err := opts.Config.GetHost()
 	if err != nil {
-		return fmt.Errorf("could not determine hostname for %s %s", URL, err)
+		return fmt.Errorf("could not determine hostname for %s %s", opts.URL, err)
 	}
 	if err := network.ValidateHostnameUniqueness(h); err != nil {
 		fmt.Fprintln(opts.StdErr, err.Error())

--- a/cmd/configure/configure_test.go
+++ b/cmd/configure/configure_test.go
@@ -21,7 +21,7 @@ func TestConfigCmd(t *testing.T) {
 	defer viper.Reset()
 	dir, err := os.MkdirTemp("", "sdpctl_test")
 	if err != nil {
-		t.Fatalf("cant create temp dir %s", err)
+		t.Fatalf("can't create temp dir %s", err)
 	}
 	defer os.RemoveAll(dir)
 	viper.AddConfigPath(dir)
@@ -49,7 +49,7 @@ func TestConfigCmd(t *testing.T) {
 		StdErr:      pty,
 	}
 	cmd := NewCmdConfigure(f)
-
+	cmd.PersistentFlags().Bool("no-interactive", false, "suppress interactive prompt with auto accept")
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 
@@ -92,7 +92,7 @@ func TestConfigCmdWithPemFile(t *testing.T) {
 	defer viper.Reset()
 	dir, err := os.MkdirTemp("", "sdpctl_test")
 	if err != nil {
-		t.Fatalf("cant create temp dir %s", err)
+		t.Fatalf("can't create temp dir %s", err)
 	}
 	defer os.RemoveAll(dir)
 	viper.AddConfigPath(dir)
@@ -120,6 +120,7 @@ func TestConfigCmdWithPemFile(t *testing.T) {
 		StdErr:      pty,
 	}
 	cmd := NewCmdConfigure(f)
+	cmd.PersistentFlags().Bool("no-interactive", false, "suppress interactive prompt with auto accept")
 	cmd.SetArgs([]string{"--pem", "testdata/cert.pem"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
@@ -171,7 +172,7 @@ func TestConfigCmdWithExistingAddr(t *testing.T) {
 	defer viper.Reset()
 	dir, err := os.MkdirTemp("", "sdpctl_test*")
 	if err != nil {
-		t.Fatalf("cant create temp dir %s", err)
+		t.Fatalf("can't create temp dir %s", err)
 	}
 	defer os.RemoveAll(dir)
 	configPath := filepath.Join(dir, "config.json")
@@ -217,7 +218,7 @@ func TestConfigCmdWithExistingAddr(t *testing.T) {
 		StdErr:      pty,
 	}
 	cmd := NewCmdConfigure(f)
-
+	cmd.PersistentFlags().Bool("no-interactive", false, "suppress interactive prompt with auto accept")
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 

--- a/pkg/docs/configure.go
+++ b/pkg/docs/configure.go
@@ -12,6 +12,10 @@ See 'sdpctl help environment' for more information on using environment variable
 				Command:     "sdpctl configure",
 			},
 			{
+				Description: "configuration, no interactive",
+				Command:     "sdpctl configure appgate.controller.com",
+			},
+			{
 				Description: "configure sdpctl using a custom certificate file",
 				Command:     "sdpctl configure --pem=/path/to/pem",
 			},


### PR DESCRIPTION
add support to run `sdpctl configure` without being prompted. Now support running for example

```bash
sdpctl configure controller.appgate.com
sdpctl.configure controller.appgate.com --pem /path/to/cert.pem
```

configure also now provides better error handling when running without any stdin/out
for example:

```bash

sdpctl configure < /dev/null
1 error occurred:
	* can't prompt, You need to provide all arguments, for example 'sdpctl configure appgate.controller.com'
```