### PR TITLE
Auth, read from memory

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -225,6 +225,8 @@ func (c *Config) ClearBearer() error {
 	if err := keyring.DeleteBearer(h); err != nil {
 		return err
 	}
+	c.BearerToken = ""
+	c.ExpiresAt = ""
 	viper.Set("bearer", "")
 	viper.Set("expires_at", "")
 	return nil

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -80,12 +80,12 @@ func TestConfigCheckAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Config{
 				URL:         tt.fields.URL,
-				Provider:    tt.fields.Provider,
+				Provider:    &tt.fields.Provider,
 				Insecure:    tt.fields.Insecure,
 				Debug:       tt.fields.Debug,
 				Version:     tt.fields.Version,
-				BearerToken: tt.fields.BearerToken,
-				ExpiresAt:   tt.fields.ExpiresAt,
+				BearerToken: &tt.fields.BearerToken,
+				ExpiresAt:   &tt.fields.ExpiresAt,
 				DeviceID:    tt.fields.DeviceID,
 				PemFilePath: tt.fields.PemFilePath,
 			}
@@ -249,7 +249,7 @@ func TestClearCredentials(t *testing.T) {
 	)
 	cfg := Config{
 		URL:         fmt.Sprintf("https://%s", prefix),
-		BearerToken: bearer,
+		BearerToken: &bearer,
 	}
 	if err := keyring.SetUsername(prefix, username); err != nil {
 		t.Error("TEST FAIL: failed to set username", err)


### PR DESCRIPTION
reset current config values, not viper values.

Converted config values, bearer and expires_at to ptr to avoid future confusion in the subject.