### PR TITLE
Get controller hostname from config

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -478,17 +478,14 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	}
 
 	// Step 2
-	primaryControllerRealHostname, err := appliancepkg.GetRealHostname(*primaryController)
-	if err != nil {
-		return err
-	}
-	remoteFilePath := fmt.Sprintf("controller://%s/%s", primaryControllerRealHostname, opts.filename)
+	primaryControllerHostname := primaryController.GetHostname()
+	remoteFilePath := fmt.Sprintf("controller://%s/%s", primaryControllerHostname, opts.filename)
 	// NOTE: Backwards compatibility with appliances older than API version 13.
 	// Appliances before API version require that the peer port be passed explicitly as part of the download URL.
 	// Insert the peer port into the URL if necessary.
 	if opts.Config.Version < 13 {
 		if v, ok := primaryController.GetPeerInterfaceOk(); ok {
-			remoteFilePath = fmt.Sprintf("controller://%s:%d/%s", primaryControllerRealHostname, int(v.GetHttpsPort()), opts.filename)
+			remoteFilePath = fmt.Sprintf("controller://%s:%d/%s", primaryControllerHostname, int(v.GetHttpsPort()), opts.filename)
 		}
 	}
 


### PR DESCRIPTION
Use the controllers configured hostname when using `--host-on-controller` flag.