### PR TITLE
Better UX when filtering

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -211,7 +211,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 		toBackup = append(toBackup, *primaryController)
 	}
 
-	allAppliances := appliancepkg.FilterAppliances(rawAppliances, filter)
+	allAppliances, _ := appliancepkg.FilterAppliances(rawAppliances, filter)
 	initialStats, _, err := a.Stats(ctx)
 	if err != nil {
 		return err

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -211,7 +211,10 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 		toBackup = append(toBackup, *primaryController)
 	}
 
-	allAppliances, _ := appliancepkg.FilterAppliances(rawAppliances, filter)
+	allAppliances, _, err := appliancepkg.FilterAppliances(rawAppliances, filter)
+	if err != nil {
+		return err
+	}
 	initialStats, _, err := a.Stats(ctx)
 	if err != nil {
 		return err

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -235,7 +235,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			Appliance: a,
 		})
 	}
-	appliances, filtered := appliancepkg.FilterAppliances(online, filter)
+	appliances, filtered, err := appliancepkg.FilterAppliances(online, filter)
+	if err != nil {
+		return err
+	}
 	for _, f := range filtered {
 		skipAppliances = append(skipAppliances, appliancepkg.SkipUpgrade{
 			Appliance: f,

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -251,10 +251,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			var errs *multierr.Error
 			if len(skipAppliances) > 0 {
 				for _, skip := range skipAppliances {
-					errs = multierr.Append(fmt.Errorf("%s skipped: %s", skip.Appliance.GetName(), skip.Reason), errs)
+					errs = multierr.Append(errs, fmt.Errorf("%s skipped: %s", skip.Appliance.GetName(), skip.Reason))
 				}
 			}
-			errs = multierr.Append(errors.New("No appliances to prepare for upgrade. The filter query may be invalid. See the log for more details."), errs)
+			errs = multierr.Append(errs, errors.New("No appliances to prepare for upgrade. The filter query may be invalid. See the log for more details."))
 			return errs
 		}
 	}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -217,7 +217,6 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	if len(opts.actualHostname) > 0 {
 		host = opts.actualHostname
 	}
-	filteredAppliances := appliancepkg.FilterAppliances(Allappliances, filter)
 
 	primaryController, err := appliancepkg.FindPrimaryController(Allappliances, host, true)
 	if err != nil {
@@ -229,13 +228,21 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		return err
 	}
 	skipAppliances := []appliancepkg.SkipUpgrade{}
-	appliances, offline, _ := appliancepkg.FilterAvailable(filteredAppliances, initialStats.GetData())
+	online, offline, _ := appliancepkg.FilterAvailable(Allappliances, initialStats.GetData())
 	for _, a := range offline {
 		skipAppliances = append(skipAppliances, appliancepkg.SkipUpgrade{
 			Reason:    "appliance is offline",
 			Appliance: a,
 		})
 	}
+	appliances, filtered := appliancepkg.FilterAppliances(online, filter)
+	for _, f := range filtered {
+		skipAppliances = append(skipAppliances, appliancepkg.SkipUpgrade{
+			Appliance: f,
+			Reason:    "appliance was filtered using the '--include' or '--exclude' flag",
+		})
+	}
+
 	if !opts.forcePrepare {
 		var skip []appliancepkg.SkipUpgrade
 		appliances, skip = appliancepkg.CheckVersions(ctx, *initialStats, appliances, targetVersion)
@@ -247,7 +254,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 					errs = multierr.Append(fmt.Errorf("%s skipped: %s", skip.Appliance.GetName(), skip.Reason), errs)
 				}
 			}
-			errs = multierr.Append(errors.New("No appliances to prepare for upgrade."), errs)
+			errs = multierr.Append(errors.New("No appliances to prepare for upgrade. The filter query may be invalid. See the log for more details."), errs)
 			return errs
 		}
 	}

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -29,7 +29,10 @@ func (a *Appliance) List(ctx context.Context, filter map[string]map[string]strin
 	if err != nil {
 		return nil, api.HTTPErrorResponse(response, err)
 	}
-	result, _ := FilterAppliances(appliances.GetData(), filter)
+	result, _, err := FilterAppliances(appliances.GetData(), filter)
+	if err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -29,7 +29,8 @@ func (a *Appliance) List(ctx context.Context, filter map[string]map[string]strin
 	if err != nil {
 		return nil, api.HTTPErrorResponse(response, err)
 	}
-	return FilterAppliances(appliances.GetData(), filter), nil
+	result, _ := FilterAppliances(appliances.GetData(), filter)
+	return result, nil
 }
 
 // Get return a single appliance based on applianceID

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -158,7 +158,10 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 		}
 
 		if !reflect.DeepEqual(nullFilter, opts.FilterFlag) {
-			res, _ := FilterAppliances(appliances, opts.FilterFlag)
+			res, _, err := FilterAppliances(appliances, opts.FilterFlag)
+			if err != nil {
+				return nil, err
+			}
 			toBackup = append(toBackup, res...)
 		}
 	}
@@ -367,9 +370,12 @@ func BackupPrompt(appliances []openapi.Appliance, preSelected []openapi.Applianc
 	}
 
 	// Filter out all but Controllers, LogServers and Portals
-	appliances, _ = FilterAppliances(appliances, map[string]map[string]string{
+	appliances, _, err := FilterAppliances(appliances, map[string]map[string]string{
 		"include": {"function": strings.Join([]string{FunctionController, FunctionLogServer, FunctionPortal}, FilterDelimiter)},
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	for _, a := range appliances {
 		selectorName := appendFunctions(a)
@@ -397,11 +403,14 @@ func BackupPrompt(appliances []openapi.Appliance, preSelected []openapi.Applianc
 	}
 	log.WithField("appliances", selected).Info("selected appliances for backup")
 
-	result, _ := FilterAppliances(appliances, map[string]map[string]string{
+	result, _, err := FilterAppliances(appliances, map[string]map[string]string{
 		"include": {
 			"name": strings.Join(selected, FilterDelimiter),
 		},
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	return result, nil
 }

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -158,7 +158,8 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 		}
 
 		if !reflect.DeepEqual(nullFilter, opts.FilterFlag) {
-			toBackup = append(toBackup, FilterAppliances(appliances, opts.FilterFlag)...)
+			res, _ := FilterAppliances(appliances, opts.FilterFlag)
+			toBackup = append(toBackup, res...)
 		}
 	}
 
@@ -366,7 +367,7 @@ func BackupPrompt(appliances []openapi.Appliance, preSelected []openapi.Applianc
 	}
 
 	// Filter out all but Controllers, LogServers and Portals
-	appliances = FilterAppliances(appliances, map[string]map[string]string{
+	appliances, _ = FilterAppliances(appliances, map[string]map[string]string{
 		"include": {"function": strings.Join([]string{FunctionController, FunctionLogServer, FunctionPortal}, FilterDelimiter)},
 	})
 
@@ -396,7 +397,7 @@ func BackupPrompt(appliances []openapi.Appliance, preSelected []openapi.Applianc
 	}
 	log.WithField("appliances", selected).Info("selected appliances for backup")
 
-	result := FilterAppliances(appliances, map[string]map[string]string{
+	result, _ := FilterAppliances(appliances, map[string]map[string]string{
 		"include": {
 			"name": strings.Join(selected, FilterDelimiter),
 		},

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -432,9 +432,9 @@ func FilterAppliances(appliances []openapi.Appliance, filter map[string]map[stri
 	// apply normal filter
 	if len(filter["include"]) > 0 {
 		include = applyApplianceFilter(include, filter["include"])
-		for _, i := range include {
-			delete(notInclude, i.GetId())
-		}
+	}
+	for _, i := range include {
+		delete(notInclude, i.GetId())
 	}
 
 	// apply exclusion filter
@@ -449,8 +449,16 @@ func FilterAppliances(appliances []openapi.Appliance, filter map[string]map[stri
 	}
 
 	for _, a := range notInclude {
-		exclude = append(exclude, a)
+		exclude = AppendUniqueAppliance(exclude, a)
 	}
+
+	// Sort results by name
+	sort.SliceStable(include, func(i, j int) bool {
+		return include[i].GetName() < include[j].GetName()
+	})
+	sort.SliceStable(exclude, func(i, j int) bool {
+		return exclude[i].GetName() < exclude[j].GetName()
+	})
 
 	return include, exclude
 }

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -561,8 +561,22 @@ func TestFilterAndExclude(t *testing.T) {
 		args         args
 		want         []openapi.Appliance
 		wantFiltered []openapi.Appliance
+		wantErr      bool
 	}
-	tests := []testStruct{}
+	tests := []testStruct{
+		{
+			name: "invalid regex error",
+			args: args{
+				appliances: []openapi.Appliance{},
+				filter: map[string]map[string]string{
+					"include": {
+						"name": "*",
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
 	for word, value := range keywords {
 		tests = append(tests, testStruct{
 			name: fmt.Sprintf("filter by %s", word),
@@ -612,7 +626,10 @@ func TestFilterAndExclude(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, filtered := FilterAppliances(tt.args.appliances, tt.args.filter)
+			got, filtered, err := FilterAppliances(tt.args.appliances, tt.args.filter)
+			if !tt.wantErr && err != nil {
+				t.Errorf("FilterAppliances() = %v", err)
+			}
 			if !cmp.Equal(got, tt.want) {
 				t.Errorf("FilterAppliances() = %v", cmp.Diff(got, tt.want))
 			}

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -557,9 +557,10 @@ func TestFilterAndExclude(t *testing.T) {
 		"function":  "logserver",
 	}
 	type testStruct struct {
-		name string
-		args args
-		want []openapi.Appliance
+		name         string
+		args         args
+		want         []openapi.Appliance
+		wantFiltered []openapi.Appliance
 	}
 	tests := []testStruct{}
 	for word, value := range keywords {
@@ -580,6 +581,10 @@ func TestFilterAndExclude(t *testing.T) {
 			want: []openapi.Appliance{
 				mockControllers["primaryController"],
 			},
+			wantFiltered: []openapi.Appliance{
+				mockControllers["gateway"],
+				mockControllers["secondaryController"],
+			},
 		})
 		tests = append(tests, testStruct{
 			name: fmt.Sprintf("filter by %s", word),
@@ -596,16 +601,23 @@ func TestFilterAndExclude(t *testing.T) {
 				},
 			},
 			want: []openapi.Appliance{
-				mockControllers["secondaryController"],
 				mockControllers["gateway"],
+				mockControllers["secondaryController"],
+			},
+			wantFiltered: []openapi.Appliance{
+				mockControllers["primaryController"],
 			},
 		})
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := FilterAppliances(tt.args.appliances, tt.args.filter); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FilterAppliances() = %v, want %v", got, tt.want)
+			got, filtered := FilterAppliances(tt.args.appliances, tt.args.filter)
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("FilterAppliances() = %v", cmp.Diff(got, tt.want))
+			}
+			if !cmp.Equal(filtered, tt.wantFiltered) {
+				t.Errorf("FilterAppliances() = %v", cmp.Diff(filtered, tt.wantFiltered))
 			}
 		})
 	}

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -604,7 +604,7 @@ func TestFilterAndExclude(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FilterAppliances(tt.args.appliances, tt.args.filter); !reflect.DeepEqual(got, tt.want) {
+			if got, _ := FilterAppliances(tt.args.appliances, tt.args.filter); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("FilterAppliances() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
The filtering feature will now catch errors that occur due to invalid regex query string and return.

In case all appliances are filtered before showing the upgrade prepare summary, the command will now exit, printing a general error that there are no appliances to prepare for upgrade, as well as listing why each of the appliances was skipped.

The filter will also be applied after excluding all offline appliances, meaning offline appliances will never accidentally be included when using the filtering flags.

Fixes SA-20523