### PR TITLE
FIX: bug where progress bars would hang in a waiting state under certain conditions

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -254,22 +254,6 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		})
 	}
 
-	if !opts.forcePrepare {
-		var skip []appliancepkg.SkipUpgrade
-		appliances, skip = appliancepkg.CheckVersions(ctx, *initialStats, appliances, opts.targetVersion)
-		skipAppliances = append(skipAppliances, skip...)
-		if len(appliances) <= 0 {
-			var errs *multierr.Error
-			if len(skipAppliances) > 0 {
-				for _, skip := range skipAppliances {
-					errs = multierr.Append(errs, fmt.Errorf("%s skipped: %s", skip.Appliance.GetName(), skip.Reason))
-				}
-			}
-			errs = multierr.Append(errs, errors.New("No appliances to prepare for upgrade. The filter query may be invalid. See the log for more details."))
-			return errs
-		}
-	}
-
 	if hasLowDiskSpace := appliancepkg.HasLowDiskSpace(initialStats.GetData()); len(hasLowDiskSpace) > 0 {
 		appliancepkg.PrintDiskSpaceWarningMessage(opts.Out, hasLowDiskSpace)
 		if !opts.NoInteractive {
@@ -304,6 +288,50 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		fmt.Fprintf(opts.Out, "\n%s\n", msg)
 		if err := prompt.AskConfirmation(); err != nil {
 			return err
+		}
+	}
+
+	if !opts.forcePrepare {
+		var skip []appliancepkg.SkipUpgrade
+		appliances, skip = appliancepkg.CheckVersions(ctx, *initialStats, appliances, opts.targetVersion)
+		skipAppliances = append(skipAppliances, skip...)
+
+		postPrepared := []openapi.Appliance{}
+		upgradeStatuses, err := a.UpgradeStatusMap(ctx, appliances)
+		if err != nil {
+			return err
+		}
+		for _, app := range appliances {
+			us := upgradeStatuses[app.GetId()]
+			if us.Status != appliancepkg.UpgradeStatusReady {
+				postPrepared = append(postPrepared, app)
+				continue
+			}
+			prepareVersion, err := appliancepkg.ParseVersionString(us.Details)
+			if err != nil {
+				postPrepared = append(postPrepared, app)
+				continue
+			}
+			if res, err := appliancepkg.CompareVersionsAndBuildNumber(opts.targetVersion, prepareVersion); err == nil && res >= 0 {
+				skipAppliances = append(skipAppliances, appliancepkg.SkipUpgrade{
+					Appliance: app,
+					Reason:    "appliance is already prepared for upgrade with a higher or equal version",
+				})
+				continue
+			}
+			postPrepared = append(postPrepared, app)
+		}
+		appliances = postPrepared
+
+		if len(appliances) <= 0 {
+			var errs *multierr.Error
+			errs = multierr.Append(errs, errors.New("No appliances to prepare for upgrade. All appliances may have been filtered or are already prepared. See the log for more details."))
+			if len(skipAppliances) > 0 {
+				for _, skip := range skipAppliances {
+					errs = multierr.Append(errs, fmt.Errorf("%s skipped: %s", skip.Appliance.GetName(), skip.Reason))
+				}
+			}
+			return errs
 		}
 	}
 
@@ -542,20 +570,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			if err != nil {
 				log.WithError(err).WithField("applianceID", appliance.GetId()).Debug("Failed to determine current upgrade status")
 			}
-			details := status.GetDetails()
-			var preparedVersion *version.Version
-			if len(details) > 0 {
-				preparedVersion, err = appliancepkg.ParseVersionString(details)
-				if err != nil {
-					log.WithError(err).Warn("Failed to determine currently prepared version")
-				}
-			}
-			if versionCheck, err := appliancepkg.CompareVersionsAndBuildNumber(opts.targetVersion, preparedVersion); err == nil && versionCheck <= 0 {
+			if status.GetStatus() != appliancepkg.UpgradeStatusReady {
 				log.WithFields(log.Fields{
-					"uploadVersion":   opts.targetVersion.String(),
-					"preparedVersion": preparedVersion.String(),
-					"appliance":       appliance.GetName(),
-				}).Info("an older version is already prepared on the appliance. cancelling before proceeding")
+					"appliance": appliance.GetName(),
+				}).Info("another version is already prepared on the appliance. cancelling before proceeding")
 				if err := a.UpgradeCancel(ctx, appliance.GetId()); err != nil {
 					errs = multierr.Append(errs, err)
 				}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -572,7 +572,8 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			}
 			if status.GetStatus() != appliancepkg.UpgradeStatusReady {
 				log.WithFields(log.Fields{
-					"appliance": appliance.GetName(),
+					"appliance":      appliance.GetName(),
+					"upgrade_status": status.GetStatus(),
 				}).Info("another version is already prepared on the appliance. cancelling before proceeding")
 				if err := a.UpgradeCancel(ctx, appliance.GetId()); err != nil {
 					errs = multierr.Append(errs, err)
@@ -585,7 +586,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			unwantedStatus := []string{appliancepkg.UpgradeStatusFailed}
 			var t *tui.Tracker
 			if !opts.ciMode {
-				t = updateProgressBars.AddTracker(appliance.GetName(), "ready")
+				t = updateProgressBars.AddTracker(appliance.GetName(), status.GetStatus())
 				go t.Watch(prepareReady, unwantedStatus)
 			}
 

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -136,7 +136,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 					Responder: func(rw http.ResponseWriter, r *http.Request) {
 						rw.Header().Set("Content-Type", "application/json")
 						rw.WriteHeader(http.StatusOK)
-						fmt.Fprint(rw, string(`{"status":"ready","details":"appgate-5.5.1-9876.img.zip"}`))
+						fmt.Fprint(rw, string(`{"status":"idle","details":"appgate-5.5.1-9876.img.zip"}`))
 					},
 				},
 				{
@@ -144,7 +144,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 					Responder: func(rw http.ResponseWriter, r *http.Request) {
 						rw.Header().Set("Content-Type", "application/json")
 						rw.WriteHeader(http.StatusOK)
-						fmt.Fprint(rw, string(`{"status":"ready","details":"appgate-5.5.1-9876.img.zip"}`))
+						fmt.Fprint(rw, string(`{"status":"idle","details":"appgate-5.5.1-9876.img.zip"}`))
 					},
 				},
 			},
@@ -219,7 +219,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 					Responder: func(rw http.ResponseWriter, r *http.Request) {
 						rw.Header().Set("Content-Type", "application/json")
 						rw.WriteHeader(http.StatusOK)
-						fmt.Fprint(rw, string(`{"status":"ready","details":"appgate-5.5.1-9876.img.zip"}`))
+						fmt.Fprint(rw, string(`{"status":"idle","details":"appgate-5.5.1-9876.img.zip"}`))
 					},
 				},
 				{
@@ -227,7 +227,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 					Responder: func(rw http.ResponseWriter, r *http.Request) {
 						rw.Header().Set("Content-Type", "application/json")
 						rw.WriteHeader(http.StatusOK)
-						fmt.Fprint(rw, string(`{"status":"ready","details":"appgate-5.5.1-9876.img.zip"}`))
+						fmt.Fprint(rw, string(`{"status":"idle","details":"appgate-5.5.1-9876.img.zip"}`))
 					},
 				},
 			},
@@ -325,94 +325,9 @@ func TestUpgradePrepareCommand(t *testing.T) {
 			wantErrOut: regexp.MustCompile(`--image is mandatory`),
 		},
 		{
-			name: "timeout flag",
-			cli:  "upgrade prepare --image './testdata/appgate-5.5.1-9876.img.zip' --timeout 0s",
-			askStubs: func(as *prompt.AskStubber) {
-				as.StubOne(true) // peer_warning message
-				as.StubOne(true) // upgrade_confirm
-			},
-			httpStubs: []httpmock.Stub{
-				{
-					URL:       "/appliances",
-					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/appliance_list.json"),
-				},
-				{
-					URL:       "/stats/appliances",
-					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/stats_appliance.json"),
-				},
-				{
-					URL:       "/files/appgate-5.5.1-9876.img.zip",
-					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/upgrade_status_file.json"),
-				},
-				{
-					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/upgrade/prepare",
-					Responder: func(rw http.ResponseWriter, r *http.Request) {
-						if r.Method == http.MethodGet {
-							httpmock.JSONResponse("../../../pkg/appliance/fixtures/upgrade_status_file.json")
-							return
-						}
-						if r.Method == http.MethodPost {
-							rw.Header().Set("Content-Type", "application/json")
-							rw.WriteHeader(http.StatusOK)
-							fmt.Fprint(rw, string(`{"id": "37bdc593-df27-49f8-9852-cb302214ee1f" }`))
-						}
-					},
-				},
-				{
-					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/upgrade/prepare",
-					Responder: func(rw http.ResponseWriter, r *http.Request) {
-						if r.Method == http.MethodGet {
-							httpmock.JSONResponse("../../../pkg/appliance/fixtures/upgrade_status_file.json")
-							return
-						}
-						if r.Method == http.MethodPost {
-							rw.Header().Set("Content-Type", "application/json")
-							rw.WriteHeader(http.StatusOK)
-							fmt.Fprint(rw, string(`{"id": "493a0d78-772c-4a6d-a618-1fbfdf02ab68" }`))
-						}
-					},
-				},
-				{
-					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/change/37bdc593-df27-49f8-9852-cb302214ee1f",
-					Responder: func(w http.ResponseWriter, r *http.Request) {
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
-					},
-				},
-				{
-					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/change/493a0d78-772c-4a6d-a618-1fbfdf02ab68",
-					Responder: func(w http.ResponseWriter, r *http.Request) {
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						fmt.Fprint(w, string(`{"status": "completed", "result": "success"}`))
-					},
-				},
-				{
-					URL: "/appliances/ee639d70-e075-4f01-596b-930d5f24f569/upgrade",
-					Responder: func(rw http.ResponseWriter, r *http.Request) {
-						rw.Header().Set("Content-Type", "application/json")
-						rw.WriteHeader(http.StatusOK)
-						fmt.Fprint(rw, string(`{"status":"ready","details":"appgate-5.5.1-9876.img.zip"}`))
-					},
-				},
-				{
-					URL: "/appliances/4c07bc67-57ea-42dd-b702-c2d6c45419fc/upgrade",
-					Responder: func(rw http.ResponseWriter, r *http.Request) {
-						rw.Header().Set("Content-Type", "application/json")
-						rw.WriteHeader(http.StatusOK)
-						fmt.Fprint(rw, string(`{"status":"ready","details":"appgate-5.5.1-9876.img.zip"}`))
-					},
-				},
-			},
-			wantErr:    false,
-			wantErrOut: regexp.MustCompile("WARNING: timeout is less than the allowed minimum. Using default timeout instead: 30m0s"),
-		},
-		{
 			name: "disagree with peer warning",
 			cli:  "upgrade prepare --image './testdata/appgate-5.5.1-9876.img.zip'",
 			askStubs: func(s *prompt.AskStubber) {
-				s.StubOne(true)  // auto-scaling warning
 				s.StubOne(false) // peer_warning message
 			},
 			httpStubs: []httpmock.Stub{
@@ -432,7 +347,6 @@ func TestUpgradePrepareCommand(t *testing.T) {
 			name: "no prepare confirmation",
 			cli:  "upgrade prepare --image './testdata/appgate-5.5.1-9876.img.zip'",
 			askStubs: func(s *prompt.AskStubber) {
-				s.StubOne(true)  // peer_warning message
 				s.StubOne(false) // upgrade_confirm
 			},
 			httpStubs: []httpmock.Stub{
@@ -468,6 +382,9 @@ func TestUpgradePrepareCommand(t *testing.T) {
 		{
 			name: "prepare same version",
 			cli:  "upgrade prepare --image './testdata/appgate-5.5.1-12345.img.zip'",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne(true)
+			},
 			httpStubs: []httpmock.Stub{
 				{
 					URL:       "/appliances",
@@ -479,7 +396,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrOut: regexp.MustCompile(`No appliances to prepare for upgrade.`),
+			wantErrOut: regexp.MustCompile(`No appliances to prepare for upgrade. All appliances may have been filtered or are already prepared. See the log for more details.`),
 		},
 		{
 			name: "force prepare same version",

--- a/pkg/appliance/fixtures/stats_appliance.json
+++ b/pkg/appliance/fixtures/stats_appliance.json
@@ -106,8 +106,7 @@
                 }
             },
             "upgrade": {
-                "status": "ready",
-                "details": "appgate-5.4.5-26552-release.img.zip"
+                "status": "idle"
             }
         }
     ],


### PR DESCRIPTION
This fixes an issue where the progress bars would hang in a waiting state when sdpctl tries to prepare appliances that are already prepared with the same version or higher than the one being uploaded.

The command tries to identify which appliances are already prepared earlier and skips if an appliance is:
- already prepared with a upgrade image of the same or higher version than the one being uploaded
- the appliance has upgrade status 'ready'

Any appliance that do not meet those two criteria will be prepared. Those which are not in an 'idle' upgrade status will be cancelled automatically before preparing the new image.

Note that this requires #340 to already be merged.