### PR TITLE
Upgrade status error messages 

### DIFF
--- a/cmd/appliance/resolve_name_test.go
+++ b/cmd/appliance/resolve_name_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
+	"github.com/appgate/sdpctl/pkg/cmdutil"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/httpmock"
@@ -111,14 +112,15 @@ func TestNewResolveNameCmdJSON(t *testing.T) {
 
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
-
-			_, err := cmd.ExecuteC()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("NewResolveNameCmd() error = %v, wantErr %v", err, tt.wantErr)
+			cmd.SetErr(stdout)
+			exitCode := cmdutil.ExecuteCommand(cmd)
+			if (exitCode != cmdutil.ExitOK) != tt.wantErr {
+				t.Fatalf("NewResolveNameCmd() ExitCode = %v, wantErr %v", exitCode, tt.wantErr)
 			}
-			if err != nil && tt.wantErrOut != nil {
-				if !tt.wantErrOut.MatchString(err.Error()) {
-					t.Errorf("Expected output to match, got:\n%s\n expected: \n%s\n", tt.wantErrOut, err.Error())
+			if tt.wantErrOut != nil {
+				if !tt.wantErrOut.MatchString(stdout.String()) {
+					t.Logf("FOO ERROR\n%q\n", stdout.String())
+					t.Errorf("Expected output to match, got:\n%s\n expected: \n%s\n", tt.wantErrOut, stdout.String())
 				}
 				return
 			}

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -612,7 +612,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				}
 				logEntry.Info("Install the downloaded upgrade image to the other partition")
 				if !SwitchPartition {
-					if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(context.WithValue(ctx, appliancepkg.UpgradeStatusGetErrorMessage, "applying upgrade"), i, []string{appliancepkg.UpgradeStatusSuccess}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
+					if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, i, []string{appliancepkg.UpgradeStatusSuccess}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
 						return fmt.Errorf("%s %w", i.GetName(), err)
 					}
 					status, err := a.UpgradeStatusRetry(ctx, i.GetId())
@@ -626,7 +626,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 						log.WithField("appliance", i.GetName()).Info("Switching partition")
 					}
 				}
-				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, i, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
+				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(context.WithValue(ctx, appliancepkg.UpgradeStatusGetErrorMessage, "switching partition"), i, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
 					return fmt.Errorf("%s %w", i.GetName(), err)
 				}
 				if err := a.ApplianceStats.WaitForApplianceState(ctx, i, appliancepkg.StatReady, t); err != nil {

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -606,11 +606,11 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				if !util.InSlice(i.GetName(), toReboot) {
 					err := backoff.Retry(func() error {
 						err := a.UpgradeComplete(ctx, i.GetId(), SwitchPartition)
-					if err != nil {
-						logEntry.Warnf("Attempting to run upgrade complete %s", err)
-						return err
-					}
-					return nil
+						if err != nil {
+							logEntry.Warnf("Attempting to run upgrade complete %s", err)
+							return err
+						}
+						return nil
 					}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
 					if err != nil {
 						return fmt.Errorf("Could not complete upgrade on %s %w", i.GetName(), err)

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -551,7 +551,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			}
 			msg := "Upgrading primary Controller, installing and rebooting..."
 			logEntry.WithField("want", appliancepkg.StatReady).Info(msg)
-			if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(context.WithValue(ctx, appliancepkg.UpgradeStatusGetErrorMessage, msg), controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
+			if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(context.WithValue(ctx, appliancepkg.PrimaryUpgrade, true), controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
 				return err
 			}
 			if err := a.ApplianceStats.WaitForApplianceState(ctx, controller, appliancepkg.StatReady, t); err != nil {
@@ -632,7 +632,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 						log.WithField("appliance", i.GetName()).Info("Switching partition")
 					}
 				}
-				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(context.WithValue(ctx, appliancepkg.UpgradeStatusGetErrorMessage, "switching partition"), i, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
+				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, i, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
 					return fmt.Errorf("%s %w", i.GetName(), err)
 				}
 				if err := a.ApplianceStats.WaitForApplianceState(ctx, i, appliancepkg.StatReady, t); err != nil {
@@ -723,7 +723,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			if err != nil {
 				return err
 			}
-			if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(context.WithValue(ctx, appliancepkg.UpgradeStatusGetErrorMessage, "applying upgrade"), controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
+			if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(context.WithValue(ctx, appliancepkg.PrimaryUpgrade, "applying upgrade"), controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
 				log.WithFields(f).WithError(err).Error("The Controller never reached desired upgrade status")
 				return err
 			}

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -611,7 +611,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 					if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, i, []string{appliancepkg.UpgradeStatusSuccess}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
 						return fmt.Errorf("%s %w", i.GetName(), err)
 					}
-					status, err := a.UpgradeStatus(ctx, i.GetId())
+					status, err := a.UpgradeStatusRetry(ctx, i.GetId())
 					if err != nil {
 						return fmt.Errorf("%s %w", i.GetName(), err)
 					}

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -549,7 +549,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			if err := a.UpgradeComplete(ctx, controller.GetId(), true); err != nil {
 				return err
 			}
-			msg := "Waiting for the primary Controller to reach desired state"
+			msg := "Upgrading primary Controller, installing and rebooting..."
 			logEntry.WithField("want", appliancepkg.StatReady).Info(msg)
 			if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(context.WithValue(ctx, appliancepkg.UpgradeStatusGetErrorMessage, msg), controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
 				return err

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -548,7 +548,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			if err := a.UpgradeComplete(ctx, controller.GetId(), true); err != nil {
 				return err
 			}
-			msg := "Waiting for the primary Controller to reach a wanted state"
+			msg := "Waiting for the primary Controller to reach desired state"
 			logEntry.WithField("want", appliancepkg.StatReady).Info(msg)
 			if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(context.WithValue(ctx, appliancepkg.UpgradeStatusGetErrorMessage, msg), controller, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
 				return err

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/appliance/change"
 	"github.com/appgate/sdpctl/pkg/configuration"
@@ -658,8 +659,15 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			close(upgradeChan)
 		}()
 		if err := g.Wait(); err != nil {
-			log.WithError(err).Error(err.Error())
-			return fmt.Errorf("Error during upgrade of an appliance %w", err)
+			if ae, ok := err.(*api.Error); ok {
+				for _, e := range ae.Errors {
+					log.Error(e)
+				}
+			} else {
+				log.Error(err)
+			}
+
+			return err
 		}
 		return nil
 	}
@@ -791,7 +799,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	for index, chunk := range chunks {
 		fmt.Fprintf(opts.Out, "\n[%s] Upgrading additional appliances (Batch %d / %d):\n", time.Now().Format(time.RFC3339), index+1, chunkLength)
 		if err := batchUpgrade(ctx, chunk, false); err != nil {
-			return fmt.Errorf("Failed during upgrade of additional appliances %w", err)
+			return err
 		}
 	}
 

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -609,24 +609,24 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				logEntry.Info("Install the downloaded upgrade image to the other partition")
 				if !SwitchPartition {
 					if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, i, []string{appliancepkg.UpgradeStatusSuccess}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
-						return err
+						return fmt.Errorf("%s %w", i.GetName(), err)
 					}
 					status, err := a.UpgradeStatus(ctx, i.GetId())
 					if err != nil {
-						return err
+						return fmt.Errorf("%s %w", i.GetName(), err)
 					}
 					if status.GetStatus() == appliancepkg.UpgradeStatusSuccess {
 						if err := a.UpgradeSwitchPartition(ctx, i.GetId()); err != nil {
-							return err
+							return fmt.Errorf("%s %w", i.GetName(), err)
 						}
 						log.WithField("appliance", i.GetName()).Info("Switching partition")
 					}
 				}
 				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, i, []string{appliancepkg.UpgradeStatusIdle}, []string{appliancepkg.UpgradeStatusFailed}, t); err != nil {
-					return err
+					return fmt.Errorf("%s %w", i.GetName(), err)
 				}
 				if err := a.ApplianceStats.WaitForApplianceState(ctx, i, appliancepkg.StatReady, t); err != nil {
-					return err
+					return fmt.Errorf("%s %w", i.GetName(), err)
 				}
 
 				s, _, err := a.Stats(ctx)

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -605,7 +605,12 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				}
 				if !util.InSlice(i.GetName(), toReboot) {
 					err := backoff.Retry(func() error {
-						return a.UpgradeComplete(ctx, i.GetId(), SwitchPartition)
+						err := a.UpgradeComplete(ctx, i.GetId(), SwitchPartition)
+					if err != nil {
+						logEntry.Warnf("Attempting to run upgrade complete %s", err)
+						return err
+					}
+					return nil
 					}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
 					if err != nil {
 						return fmt.Errorf("Could not complete upgrade on %s %w", i.GetName(), err)

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -216,6 +216,16 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	if err != nil {
 		return err
 	}
+
+	token, err := opts.Config.GetBearTokenHeaderValue()
+	if err != nil {
+		return err
+	}
+	ac := change.ApplianceChange{
+		APIClient: a.APIClient,
+		Token:     token,
+	}
+
 	if len(opts.actualHostname) > 0 {
 		host = opts.actualHostname
 	}
@@ -628,16 +638,8 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 					return err
 				}
 				if opts.Config.Version >= 15 {
-					t, err := opts.Config.GetBearTokenHeaderValue()
+					c, err := ac.RetryUntilCompleted(ctx, changeID, qs.appliance.GetId())
 					if err != nil {
-						queueContinue <- queueStruct{err: err}
-						return err
-					}
-					ac := change.ApplianceChange{
-						APIClient: a.APIClient,
-						Token:     t,
-					}
-					if _, err = ac.RetryUntilCompleted(ctx, changeID, qs.appliance.GetId()); err != nil {
 						queueContinue <- queueStruct{err: err}
 						return err
 					}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -643,6 +643,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 						queueContinue <- queueStruct{err: err}
 						return err
 					}
+					log.Infof("prepare image change %s %s %s", c.GetResult(), c.GetStatus(), c.GetDetails())
 					unwantedStatus = append(unwantedStatus, appliancepkg.UpgradeStatusIdle)
 				}
 				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, qs.appliance, wantedStatus, unwantedStatus, qs.tracker); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,226 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/appgate/sdpctl/pkg/api"
+	"github.com/appgate/sdpctl/pkg/cmdutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+)
+
+func TestCommandErrorHandling(t *testing.T) {
+	type args struct {
+		cmd *cobra.Command
+	}
+	tests := []struct {
+		name         string
+		args         args
+		want         exitCode
+		wantedOutput string
+	}{
+		{
+			name: "test no error",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return nil }},
+			},
+			want: exitOK,
+		},
+		{
+			name: "auth error",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return ErrExitAuth }},
+			},
+			want: exitAuth,
+			wantedOutput: `1 error occurred:
+	* no authentication
+
+
+`,
+		},
+		{
+			name: "execution canceled by user",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return cmdutil.ErrExecutionCanceledByUser }},
+			},
+			want: exitCancel,
+			wantedOutput: `1 error occurred:
+	* Cancelled by user
+
+
+`,
+		},
+		{
+			name: "context DeadlineExceeded error",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+					return context.DeadlineExceeded
+				}},
+			},
+			want: exitError,
+			wantedOutput: `2 errors occurred:
+	* context deadline exceeded
+	* Command timed out
+
+
+`,
+		},
+		{
+			name: "ssl error",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+					return x509.UnknownAuthorityError{}
+				}},
+			},
+			want: exitError,
+			wantedOutput: `2 errors occurred:
+	* x509: certificate signed by unknown authority
+	* Trust the certificate or import a PEM file using 'sdpctl configure --pem=<path/to/pem>'
+
+
+`,
+		},
+		{
+			name: "test wrapped api error",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+					response := &http.Response{StatusCode: 500}
+					response.Body = io.NopCloser(strings.NewReader(`{
+                        "id": "abc",
+                        "message": "internal error message"
+                    }`))
+					ae := api.HTTPErrorResponse(response, errors.New("foobar"))
+					return fmt.Errorf("hello world %w", ae)
+				}},
+			},
+			want: exitError,
+			wantedOutput: `2 errors occurred:
+	* internal error message
+	* hello world HTTP 500 - foobar
+
+
+`,
+		},
+		{
+			name: "http 503 no json response body",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+					response := &http.Response{StatusCode: http.StatusBadGateway}
+					response.Body = io.NopCloser(strings.NewReader(`<html>
+                    <head>
+                      <title>502 Bad Gateway</title>
+                    </head>
+                    <body>
+                      <center>
+                        <h1>502 Bad Gateway</h1>
+                      </center>
+                      <hr>
+                      <center>nginx</center>
+                    </body>
+                    </html>`))
+					return api.HTTPErrorResponse(response, errors.New("502 Bad Gateway"))
+				}},
+			},
+			want: exitError,
+			wantedOutput: `1 error occurred:
+	* HTTP 502 - 502 Bad Gateway
+
+
+`,
+		},
+		{
+			name: "api error",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+					response := &http.Response{StatusCode: 500}
+					response.Body = io.NopCloser(strings.NewReader(`{
+		                        "id": "abc",
+		                        "message": "internal error message",
+		                        "errors": [
+		                            {
+		                                "field": "field 1",
+		                                "message": "hello"
+		                            },
+		                            {
+		                                "field": "field 2",
+		                                "message": "world"
+		                            }
+		                        ]
+		                    }`))
+					return api.HTTPErrorResponse(response, errors.New("foobar"))
+				}},
+			},
+			want: exitError,
+			wantedOutput: `3 errors occurred:
+	* internal error message
+	* field 1 hello
+	* field 2 world
+
+
+`,
+		},
+		{
+			name: "nested multierror",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+					var result error
+					result = multierror.Append(result, errors.New("aa"))
+					result = multierror.Append(result, errors.New("bb"))
+
+					return result
+				}},
+			},
+			want: exitError,
+			wantedOutput: `2 errors occurred:
+	* aa
+	* bb
+
+
+`,
+		},
+		{
+			name: "wrapped multierror",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+					var result error
+					result = multierror.Append(result, errors.New("golang"))
+					result = multierror.Append(result, errors.New("python"))
+
+					return fmt.Errorf("root message %w", result)
+				}},
+			},
+			want: exitError,
+			wantedOutput: `2 errors occurred:
+	* golang
+	* python
+
+
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			cmd := tt.args.cmd
+			cmd.SetOut(io.Discard)
+			cmd.SilenceErrors = true
+			cmd.SetErr(stdout)
+			if got := executeCommand(tt.args.cmd); got != tt.want {
+				t.Errorf("executeCommand() = %+v, want %+v", got, tt.want)
+			}
+
+			if diff := cmp.Diff(tt.wantedOutput, stdout.String()); diff != "" {
+				t.Fatalf("Diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/api/apiutil_test.go
+++ b/pkg/api/apiutil_test.go
@@ -46,7 +46,7 @@ func TestHTTPErrorResponse(t *testing.T) {
 				},
 				err: errors.New("cc"),
 			},
-			errorString: "1 error occurred:\n\t* cc\n\n",
+			errorString: "HTTP 400 - cc",
 		},
 		{
 			name: "HTTP 400 invalid json format",
@@ -81,7 +81,7 @@ func TestHTTPErrorResponse(t *testing.T) {
 				},
 				err: errors.New("cc"),
 			},
-			errorString: "3 errors occurred:\n\t* internal error message\n\t* field 1 hello\n\t* field 2 world\n\n",
+			errorString: "HTTP 400 - cc",
 		},
 		{
 			name: "HTTP 422 expected json format no errors array",
@@ -95,7 +95,7 @@ func TestHTTPErrorResponse(t *testing.T) {
 				},
 				err: errors.New("cc"),
 			},
-			errorString: "1 error occurred:\n\t* internal error message\n\n",
+			errorString: "HTTP 422 - cc",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
+	"github.com/cenkalti/backoff/v4"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -68,6 +69,19 @@ func (a *Appliance) UpgradeStatus(ctx context.Context, applianceID string) (*ope
 	return status, nil
 }
 
+func (a *Appliance) UpgradeStatusRetry(ctx context.Context, applianceID string) (*openapi.AppliancesIdUpgradeDelete200Response, error) {
+	var status *openapi.AppliancesIdUpgradeDelete200Response
+	err := backoff.Retry(func() error {
+		s, err := a.UpgradeStatus(ctx, applianceID)
+		if err != nil {
+			return err
+		}
+		status = s
+		return nil
+	}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
+	return status, err
+}
+
 type UpgradeStatusResult struct {
 	Status, Details, Name string
 }
@@ -82,7 +96,7 @@ func (a *Appliance) UpgradeStatusMap(ctx context.Context, appliances []openapi.A
 	for _, appliance := range appliances {
 		i := appliance
 		g.Go(func() error {
-			status, err := a.UpgradeStatus(ctx, i.GetId())
+			status, err := a.UpgradeStatusRetry(ctx, i.GetId())
 			if err != nil {
 				return fmt.Errorf("Could not read status of %s %w", i.GetId(), err)
 			}

--- a/pkg/appliance/change/change.go
+++ b/pkg/appliance/change/change.go
@@ -35,6 +35,12 @@ func (ac *ApplianceChange) RetryUntilCompleted(ctx context.Context, changeID, ap
 		if change.GetStatus() == "running" {
 			return errors.New("Change is still running, retry")
 		}
+		if change.GetResult() == "failure" {
+			if v, ok := change.GetDetailsOk(); ok && len(*v) > 0 {
+				return backoff.Permanent(fmt.Errorf("unable to apply change %s", *v))
+			}
+			return backoff.Permanent(fmt.Errorf("appliance change failed %s %s", change.GetResult(), change.GetDetails()))
+		}
 		if change.GetResult() != "success" && change.GetStatus() == "completed" {
 			return fmt.Errorf("Got result %s and status %s", change.GetResult(), change.GetStatus())
 		}

--- a/pkg/appliance/change/change.go
+++ b/pkg/appliance/change/change.go
@@ -37,9 +37,9 @@ func (ac *ApplianceChange) RetryUntilCompleted(ctx context.Context, changeID, ap
 		}
 		if change.GetResult() == "failure" {
 			if v, ok := change.GetDetailsOk(); ok && len(*v) > 0 {
-				return backoff.Permanent(fmt.Errorf("unable to apply change %s", *v))
+				return backoff.Permanent(fmt.Errorf("unable to apply on appliance id %s change %s", applianceID, *v))
 			}
-			return backoff.Permanent(fmt.Errorf("appliance change failed %s %s", change.GetResult(), change.GetDetails()))
+			return backoff.Permanent(fmt.Errorf("appliance change failed on appliance id %s %s %s", applianceID, change.GetResult(), change.GetDetails()))
 		}
 		if change.GetResult() != "success" && change.GetStatus() == "completed" {
 			return fmt.Errorf("Got result %s and status %s", change.GetResult(), change.GetStatus())

--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -68,7 +68,7 @@ func (u *UpgradeStatus) upgradeStatus(ctx context.Context, appliance openapi.App
 					// send error details for tracker
 					tracker.Fail(s + " - " + details)
 				}
-				return backoff.Permanent(fmt.Errorf("Upgrade failed on %s - %s", name, details))
+				return backoff.Permanent(fmt.Errorf("Upgrade failed on %s %s %s", name, s, details))
 			}
 			if util.InSlice(s, desiredStatuses) {
 				logEntry.Info("Reached wanted upgrade status")

--- a/pkg/auth/mfa_test.go
+++ b/pkg/auth/mfa_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/appgate/sdpctl/pkg/httpmock"
 	"github.com/google/go-cmp/cmp"
 )
@@ -401,9 +402,18 @@ func TestAuthInitializeOTP(t *testing.T) {
 				t.Errorf("Auth.InitializeOTP() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if err != nil && tt.wantErr && !strings.Contains(err.Error(), "name may not be null") {
+			found := false
+			if ae, ok := err.(*api.Error); ok {
+				for _, e := range ae.Errors {
+					if strings.Contains(e.Error(), "name may not be null") {
+						found = true
+					}
+				}
+			}
+			if err != nil && tt.wantErr && !found {
 				t.Fatalf("Invalid error message, got %s", err)
 			}
+
 			if got.GetType() != tt.typeMethod {
 				t.Fatalf("Expected %s, got %s", tt.typeMethod, got.GetType())
 			}

--- a/pkg/cmdutil/execute.go
+++ b/pkg/cmdutil/execute.go
@@ -1,0 +1,93 @@
+package cmdutil
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/appgate/sdpctl/pkg/api"
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+)
+
+type ExitCode int
+
+var ErrExitAuth = errors.New("no authentication")
+
+const (
+	ExitOK     ExitCode = 0
+	ExitError  ExitCode = 1
+	ExitCancel ExitCode = 2
+	ExitAuth   ExitCode = 4
+)
+
+func ExecuteCommand(cmd *cobra.Command) ExitCode {
+	cmd, err := cmd.ExecuteC()
+	if err != nil {
+		var result *multierror.Error
+
+		if we := errors.Unwrap(err); we != nil {
+			// if the command return a api error, (api.HTTPErrorResponse) for example HTTP 400-599, we will
+			// resolve each nested error and convert them to multierror to prettify it for the user in a list view.
+			if ae, ok := we.(*api.Error); ok {
+				for _, e := range ae.Errors {
+					result = multierror.Append(result, e)
+				}
+			}
+			// Unwrap error and check if we have a nested multierr
+			// if we do, we will make the errors flat for 1 level
+			// otherwise, append error to new multierr list
+			if merr, ok := we.(*multierror.Error); ok {
+				for _, e := range merr.Errors {
+					result = multierror.Append(result, e)
+				}
+			} else {
+				result = multierror.Append(result, err)
+			}
+		} else {
+			if ae, ok := err.(*api.Error); ok {
+				for _, e := range ae.Errors {
+					result = multierror.Append(result, e)
+				}
+			} else {
+				result = multierror.Append(result, err)
+			}
+		}
+
+		// if error is DeadlineExceeded, add custom ErrCommandTimeout
+		if errors.Is(err, context.DeadlineExceeded) {
+			result = multierror.Append(result, ErrCommandTimeout)
+		}
+
+		// if we during any request get a SSL error, (un-trusted certificate) error, prompt the user to import the pem file.
+		var sslErr x509.UnknownAuthorityError
+		if errors.As(err, &sslErr) {
+			result = multierror.Append(result, errors.New("Trust the certificate or import a PEM file using 'sdpctl configure --pem=<path/to/pem>'"))
+		}
+
+		// print all multierrors to stderr, then return correct exitcode based on error type
+		if result.ErrorOrNil() == nil {
+			result = multierror.Append(result, err)
+		}
+		fmt.Fprintln(cmd.ErrOrStderr(), result.ErrorOrNil())
+
+		if errors.Is(err, ErrExitAuth) {
+			return ExitAuth
+		}
+		if errors.Is(err, ErrExecutionCanceledByUser) {
+			return ExitCancel
+		}
+		// only show usage prompt if we get invalid args / flags
+		errorString := err.Error()
+		if strings.Contains(errorString, "arg(s)") || strings.Contains(errorString, "flag") || strings.Contains(errorString, "command") {
+			fmt.Fprintln(cmd.ErrOrStderr())
+			fmt.Fprintln(cmd.ErrOrStderr(), cmd.UsageString())
+			return ExitError
+		}
+
+		return ExitError
+	}
+	return ExitOK
+}

--- a/pkg/cmdutil/execute_test.go
+++ b/pkg/cmdutil/execute_test.go
@@ -1,4 +1,4 @@
-package cmd
+package cmdutil
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/appgate/sdpctl/pkg/api"
-	"github.com/appgate/sdpctl/pkg/cmdutil"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
@@ -25,7 +25,7 @@ func TestCommandErrorHandling(t *testing.T) {
 	tests := []struct {
 		name         string
 		args         args
-		want         exitCode
+		want         ExitCode
 		wantedOutput string
 	}{
 		{
@@ -33,14 +33,14 @@ func TestCommandErrorHandling(t *testing.T) {
 			args: args{
 				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return nil }},
 			},
-			want: exitOK,
+			want: ExitOK,
 		},
 		{
 			name: "auth error",
 			args: args{
 				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return ErrExitAuth }},
 			},
-			want: exitAuth,
+			want: ExitAuth,
 			wantedOutput: `1 error occurred:
 	* no authentication
 
@@ -50,9 +50,9 @@ func TestCommandErrorHandling(t *testing.T) {
 		{
 			name: "execution canceled by user",
 			args: args{
-				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return cmdutil.ErrExecutionCanceledByUser }},
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return ErrExecutionCanceledByUser }},
 			},
-			want: exitCancel,
+			want: ExitCancel,
 			wantedOutput: `1 error occurred:
 	* Cancelled by user
 
@@ -66,7 +66,7 @@ func TestCommandErrorHandling(t *testing.T) {
 					return context.DeadlineExceeded
 				}},
 			},
-			want: exitError,
+			want: ExitError,
 			wantedOutput: `2 errors occurred:
 	* context deadline exceeded
 	* Command timed out
@@ -81,7 +81,7 @@ func TestCommandErrorHandling(t *testing.T) {
 					return x509.UnknownAuthorityError{}
 				}},
 			},
-			want: exitError,
+			want: ExitError,
 			wantedOutput: `2 errors occurred:
 	* x509: certificate signed by unknown authority
 	* Trust the certificate or import a PEM file using 'sdpctl configure --pem=<path/to/pem>'
@@ -102,7 +102,7 @@ func TestCommandErrorHandling(t *testing.T) {
 					return fmt.Errorf("hello world %w", ae)
 				}},
 			},
-			want: exitError,
+			want: ExitError,
 			wantedOutput: `2 errors occurred:
 	* internal error message
 	* hello world HTTP 500 - foobar
@@ -130,7 +130,7 @@ func TestCommandErrorHandling(t *testing.T) {
 					return api.HTTPErrorResponse(response, errors.New("502 Bad Gateway"))
 				}},
 			},
-			want: exitError,
+			want: ExitError,
 			wantedOutput: `1 error occurred:
 	* HTTP 502 - 502 Bad Gateway
 
@@ -159,7 +159,7 @@ func TestCommandErrorHandling(t *testing.T) {
 					return api.HTTPErrorResponse(response, errors.New("foobar"))
 				}},
 			},
-			want: exitError,
+			want: ExitError,
 			wantedOutput: `3 errors occurred:
 	* internal error message
 	* field 1 hello
@@ -179,7 +179,7 @@ func TestCommandErrorHandling(t *testing.T) {
 					return result
 				}},
 			},
-			want: exitError,
+			want: ExitError,
 			wantedOutput: `2 errors occurred:
 	* aa
 	* bb
@@ -198,7 +198,7 @@ func TestCommandErrorHandling(t *testing.T) {
 					return fmt.Errorf("root message %w", result)
 				}},
 			},
-			want: exitError,
+			want: ExitError,
 			wantedOutput: `2 errors occurred:
 	* golang
 	* python
@@ -214,7 +214,7 @@ func TestCommandErrorHandling(t *testing.T) {
 			cmd.SetOut(io.Discard)
 			cmd.SilenceErrors = true
 			cmd.SetErr(stdout)
-			if got := executeCommand(tt.args.cmd); got != tt.want {
+			if got := ExecuteCommand(tt.args.cmd); got != tt.want {
 				t.Errorf("executeCommand() = %+v, want %+v", got, tt.want)
 			}
 


### PR DESCRIPTION
This PR improves error message overall, mainly during upgrade complete.

- append retry on requests that we've seen fail, for various reasons.
- Get spinner upgrade/status error message from context value
- error messages during barchupgrade now include appliance name in the error message
- appliance/change now return earlier if we get "failure" in response body
- mitigate logging nested mutlierr string to logfile

fixes internal issue: SA-20430