### PR TITLE
defer lookup in config to RunE from Args:[]

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -148,12 +148,6 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			if opts.ciMode, err = cmd.Flags().GetBool("ci-mode"); err != nil {
 				return err
 			}
-
-			if opts.Config.Version <= 13 {
-				// Versions before v13 does not have dev-keyring functionality
-				opts.DevKeyring = false
-			}
-
 			return errs.ErrorOrNil()
 		},
 		RunE: func(c *cobra.Command, args []string) error {
@@ -266,6 +260,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	constraints, _ := version.NewConstraint(">= 5.5.0")
 	if constraints.Check(opts.targetVersion) {
 		autoScalingWarning = true
+	}
+	if opts.Config.Version <= 13 {
+		// Versions before v13 does not have dev-keyring functionality
+		opts.DevKeyring = false
 	}
 	if t, gws := appliancepkg.AutoscalingGateways(appliances); autoScalingWarning && len(gws) > 0 && !opts.NoInteractive {
 		msg, err := appliancepkg.ShowAutoscalingWarningMessage(t, gws)


### PR DESCRIPTION
the config has not been resolved properly when cmd.Args: func() is called, but it has been in RunE:

(keep in mind the usagee of the command annotation of updateAPIConfig where it resolve right before RunE in the upgrade commands)

This commit partially revert the changes added last friday ( commit  https://github.com/appgate/sdpctl/commit/95ba60f14a4fd3bbf73975e11da0ff82dfec7641 )