### PR TITLE
Option to disable keyring integration

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -99,6 +99,8 @@ Available Variables:
   SDPCTL_PROFILE:
     Description: Profile name to use
     Options:  See 'sdpctl profile list'
+  SDPCTL_NO_KEYRING:
+    Description: Disable keyring integration. Does not attempt to store anything in the os keychain.
   HTTP_PROXY:
     Description: HTTP Proxy for the client
 

--- a/pkg/auth/signin.go
+++ b/pkg/auth/signin.go
@@ -197,27 +197,27 @@ func Signin(f *factory.Factory) error {
 			return nil
 		}
 		return nil
-	} else {
-		prefix, err := cfg.KeyringPrefix()
-		if err != nil {
-			return err
-		}
-		keyringErrMessage := "[warning] To disable keyring integration, set environment variable SDPCTL_NO_KEYRING=true"
-		// if the bearer token can't be saved to the keychain, it will be exported as env variable
-		// and saved in the config file as fallback, this should only happened if the system does not
-		// support the keychain integration.
-		if err := keyring.SetBearer(prefix, *cfg.BearerToken); err != nil {
-			fmt.Fprintf(f.StdErr, "[warning] could not save token to keyring %s\n", err)
-			fmt.Fprintln(f.StdErr, keyringErrMessage)
-		}
+	}
 
-		// store username and password if any in keyring, in practice only applicable on local provider
-		if len(response.LoginOpts.GetUsername()) > 1 && len(response.LoginOpts.GetPassword()) > 1 {
-			if err := cfg.StoreCredentials(response.LoginOpts.GetUsername(), response.LoginOpts.GetPassword()); err != nil {
-				fmt.Fprintf(f.StdErr, "[warning] %s\n", err)
-				fmt.Fprintln(f.StdErr, keyringErrMessage)
-				return nil
-			}
+	prefix, err := cfg.KeyringPrefix()
+	if err != nil {
+		return err
+	}
+	keyringErrMessage := "[warning] To disable keyring integration, set environment variable SDPCTL_NO_KEYRING=true"
+	// if the bearer token can't be saved to the keychain, it will be exported as env variable
+	// and saved in the config file as fallback, this should only happened if the system does not
+	// support the keychain integration.
+	if err := keyring.SetBearer(prefix, *cfg.BearerToken); err != nil {
+		fmt.Fprintf(f.StdErr, "[warning] could not save token to keyring %s\n", err)
+		fmt.Fprintln(f.StdErr, keyringErrMessage)
+	}
+
+	// store username and password if any in keyring, in practice only applicable on local provider
+	if len(response.LoginOpts.GetUsername()) > 1 && len(response.LoginOpts.GetPassword()) > 1 {
+		if err := cfg.StoreCredentials(response.LoginOpts.GetUsername(), response.LoginOpts.GetPassword()); err != nil {
+			fmt.Fprintf(f.StdErr, "[warning] %s\n", err)
+			fmt.Fprintln(f.StdErr, keyringErrMessage)
+			return nil
 		}
 	}
 

--- a/pkg/auth/signin.go
+++ b/pkg/auth/signin.go
@@ -165,6 +165,9 @@ func Signin(f *factory.Factory) error {
 	case LocalProvider:
 		p = NewLocal(f)
 	case OidcProvider:
+		if os.Getenv("SDPCTL_NO_KEYRING") != "" {
+			return fmt.Errorf("%s provider does not work when environment variable SDPCTL_NO_KEYRING is set.", selectedProvider.GetType())
+		}
 		oidc := NewOpenIDConnect(f, client)
 		defer oidc.Close()
 		p = oidc

--- a/pkg/auth/signin_test.go
+++ b/pkg/auth/signin_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 
 	expect "github.com/Netflix/go-expect"
@@ -13,11 +14,13 @@ import (
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/httpmock"
+	"github.com/appgate/sdpctl/pkg/keyring"
+	"github.com/appgate/sdpctl/pkg/util"
 
 	"github.com/appgate/sdpctl/pkg/prompt"
 	pseudotty "github.com/creack/pty"
 	"github.com/hinshun/vt10x"
-	"github.com/zalando/go-keyring"
+	zkeyring "github.com/zalando/go-keyring"
 )
 
 var (
@@ -117,7 +120,7 @@ var (
                         }
                       ]
                     },
-                    "token": "string",
+                    "token": "VeryLongBearerTokenString",
                     "expires": "2019-08-24T14:15:22Z",
                     "messageOfTheDay": "Welcome to Appgate SDP."
                   }`))
@@ -147,6 +150,87 @@ func TestSignInNoPromptOrEnv(t *testing.T) {
 	}
 	if !errors.Is(ErrSignInNotSupported, err) {
 		t.Errorf("expected %s, got %s", ErrSignInNotSupported, err)
+	}
+}
+
+func TestSigninNoKeyringNoconfig(t *testing.T) {
+	zkeyring.MockInit()
+	registry := httpmock.NewRegistry(t)
+	httpStubs := []httpmock.Stub{
+		authenticationResponse,
+		identityProviderNames,
+		authorizationGET,
+	}
+	for _, v := range httpStubs {
+		registry.Register(v.URL, v.Responder)
+	}
+	defer registry.Teardown()
+	registry.Serve()
+	f := &factory.Factory{
+		Config: &configuration.Config{
+			Debug: false,
+			URL:   "http://localhost",
+		},
+		IOOutWriter: os.Stdout,
+		Stdin:       os.Stdin,
+		StdErr:      os.Stderr,
+	}
+	f.APIClient = func(c *configuration.Config) (*openapi.APIClient, error) {
+		return registry.Client, nil
+	}
+	environmentVariables := map[string]string{
+		"SDPCTL_USERNAME":   "bob",
+		"SDPCTL_PASSWORD":   "alice",
+		"SDPCTL_NO_KEYRING": "true",
+	}
+	for k, v := range environmentVariables {
+		t.Setenv(k, v)
+	}
+	dir := t.TempDir()
+	t.Setenv("SDPCTL_CONFIG_DIR", dir)
+
+	pty, tty, err := pseudotty.Open()
+	if err != nil {
+		t.Fatalf("failed to open pseudotty: %v", err)
+	}
+	term := vt10x.New(vt10x.WithWriter(tty))
+	c, err := expect.NewConsole(expect.WithStdin(pty), expect.WithStdout(term), expect.WithCloser(pty, tty))
+	if err != nil {
+		t.Fatalf("failed to create console: %v", err)
+	}
+
+	defer c.Close()
+
+	if err := Signin(f); err != nil {
+		t.Fatal(err)
+	}
+	configFile := filepath.Join(dir, "config.json")
+	if ok, err := util.FileExists(configFile); ok && err == nil {
+		t.Fatalf("found config file %s but did not expect it", configFile)
+	}
+
+	prefix, err := f.Config.KeyringPrefix()
+	if err != nil {
+		t.Fatal("could not check verify keyring")
+	}
+	// make sure its not in keyring,
+	// we will remove the env variable, if any to make sure we trigger
+	// the keyring
+	os.Unsetenv("SDPCTL_PASSWORD")
+	if _, err := keyring.GetPassword(prefix); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	os.Unsetenv("SDPCTL_USERNAME")
+	if _, err := keyring.GetUsername(prefix); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	os.Unsetenv("SDPCTL_BEARER")
+	if _, err := keyring.GetBearer(prefix); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if _, err := f.Config.GetBearTokenHeaderValue(); err != nil {
+		t.Fatalf("did not expect bearer token to be nil %s", err)
 	}
 }
 
@@ -292,7 +376,7 @@ func TestSignin(t *testing.T) {
 		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			keyring.MockInit()
+			zkeyring.MockInit()
 			registry := httpmock.NewRegistry(t)
 			for _, v := range tt.httpStubs {
 				registry.Register(v.URL, v.Responder)

--- a/pkg/auth/signin_test.go
+++ b/pkg/auth/signin_test.go
@@ -276,7 +276,20 @@ func TestSignin(t *testing.T) {
 				identityProviderNames,
 			},
 		},
-	}
+		{
+			name: "no keyring",
+			environmentVariables: map[string]string{
+				"SDPCTL_USERNAME":   "bob",
+				"SDPCTL_PASSWORD":   "alice",
+				"SDPCTL_NO_KEYRING": "true",
+			},
+			wantErr: false,
+			httpStubs: []httpmock.Stub{
+				authenticationResponse,
+				identityProviderNames,
+				authorizationGET,
+			},
+		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			keyring.MockInit()

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -21,9 +21,9 @@ type Config struct {
 	URL         string  `mapstructure:"url"`
 	Provider    *string `mapstructure:"provider"`
 	Insecure    bool    `mapstructure:"insecure"`
-	Debug       bool    `mapstructure:"debug"`       // http debug flag
-	Version     int     `mapstructure:"api_version"` // api peer interface version
-	BearerToken *string `mapstructure:"bearer"`      // current logged in user token
+	Debug       bool    `mapstructure:"debug"`         // http debug flag
+	Version     int     `mapstructure:"api_version"`   // api peer interface version
+	BearerToken *string `mapstructure:"bearer:squash"` // current logged in user token
 	ExpiresAt   *string `mapstructure:"expires_at"`
 	DeviceID    string  `mapstructure:"device_id"`
 	PemFilePath string  `mapstructure:"pem_filepath"`

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -44,8 +44,7 @@ func GetPassword(prefix string) (string, error) {
 func SetPassword(prefix, secret string) error {
 	err := setSecret(format(prefix, password), secret)
 	if err != nil && strings.Contains(err.Error(), secretMissing) {
-		os.Setenv("SDPCTL_PASSWORD", secret)
-		return nil
+		return os.Setenv("SDPCTL_PASSWORD", secret)
 	}
 	return err
 }
@@ -63,7 +62,7 @@ func GetBearer(prefix string) (string, error) {
 
 func SetBearer(prefix, secret string) error {
 	if err := setSecret(format(prefix, bearer), secret); err != nil {
-		os.Setenv("SDPCTL_BEARER", secret)
+		return os.Setenv("SDPCTL_BEARER", secret)
 	}
 	return nil
 }
@@ -75,7 +74,7 @@ func DeleteBearer(prefix string) error {
 		}
 	}
 	if _, ok := os.LookupEnv("SDPCTL_BEARER"); ok {
-		os.Unsetenv("SDPCTL_BEARER")
+		return os.Unsetenv("SDPCTL_BEARER")
 	}
 	return nil
 }
@@ -91,8 +90,7 @@ func SetRefreshToken(prefix, secret string) error {
 func SetUsername(prefix, secret string) error {
 	err := setSecret(format(prefix, username), secret)
 	if err != nil && strings.Contains(err.Error(), secretMissing) {
-		os.Setenv("SDPCTL_USERNAME", secret)
-		return nil
+		return os.Setenv("SDPCTL_USERNAME", secret)
 	}
 	return err
 }

--- a/pkg/keyring/keyring_darwin.go
+++ b/pkg/keyring/keyring_darwin.go
@@ -127,6 +127,9 @@ func SetPassword(prefix, secret string) error {
 }
 
 func GetBearer(prefix string) (string, error) {
+	if v, ok := os.LookupEnv("SDPCTL_BEARER"); ok {
+		return v, nil
+	}
 	token, err := QueryKeychain(format(prefix, bearer))
 	if err != nil {
 		return "", errors.New(fmt.Sprintf("failed to get bearer token from keychain: %s", err))


### PR DESCRIPTION
set environment variable `SDPCTL_NO_KEYRING=true` to disable OS keyring integration, suitable for automated builds.

example:
```python
#!/usr/bin/env python3
import os
from pathlib import Path
import shlex
import subprocess

s = "sdpctl appliance upgrade prepare --image https://your-appgate-image.source.com/appgate-999.img.zip --dev-keyring --no-interactive --force"
cmd = shlex.split(s)
print(s)
print(cmd)

cert = """\
-----BEGIN CERTIFICATE-----
.....
-----END CERTIFICATE-----
"""

config_dir = Path("/tmp/sdpctl-log")
config_dir.mkdir(exist_ok=True)
cert_path = config_dir / "cert.pem"
cert_path.write_text(cert)

env = os.environ.copy()
env.update(
    {
        "SDPCTL_USERNAME": "admin",
        "SDPCTL_PASSWORD": "admin",
        "SDPCTL_PEM_FILEPATH": str(cert_path),
        "SDPCTL_URL": "https://your.controller.com:8443/admin",
        "SDPCTL_CONFIG_DIR": str(config_dir), # only needed if care about the log file ouput dir
        "SDPCTL_LOG_LEVEL": "DEBUG",
        "SDPCTL_NO_KEYRING": "true", # does not attempt to read or save anything to OS keyring, no config.json will be generated.
    }
)
subprocess.run(cmd, env=env, check=True)

```