### PR TITLE
Root flag prompt signin

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -267,6 +267,11 @@ func logOutput(cmd *cobra.Command, f *factory.Factory, cfg *configuration.Config
 
 func rootPersistentPreRunEFunc(f *factory.Factory, cfg *configuration.Config) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+
+		if value, err := cmd.Flags().GetBool("no-interactive"); err == nil && value {
+			f.DisablePrompt(value)
+		}
+
 		logLevel := strings.ToLower(util.Getenv("SDPCTL_LOG_LEVEL", "info"))
 
 		switch logLevel {
@@ -336,6 +341,7 @@ func rootPersistentPreRunEFunc(f *factory.Factory, cfg *configuration.Config) fu
 					}
 				}
 			}
+
 			if err := auth.Signin(f); err != nil {
 				result = multierror.Append(result, err)
 				return result

--- a/pkg/auth/local.go
+++ b/pkg/auth/local.go
@@ -21,7 +21,7 @@ func NewLocal(f *factory.Factory) *Local {
 
 func (l Local) signin(ctx context.Context, loginOpts openapi.LoginRequest, provider openapi.IdentityProvidersNamesGet200ResponseDataInner) (*signInResponse, error) {
 	cfg := l.Factory.Config
-
+	canPrompt := l.Factory.CanPrompt()
 	client, err := l.Factory.APIClient(cfg)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func (l Local) signin(ctx context.Context, loginOpts openapi.LoginRequest, provi
 		return nil, err
 	}
 
-	if len(credentials.Username) <= 0 {
+	if len(credentials.Username) <= 0 && canPrompt {
 		err := prompt.SurveyAskOne(&survey.Input{
 			Message: "Username:",
 		}, &credentials.Username, survey.WithValidator(survey.Required))
@@ -40,7 +40,7 @@ func (l Local) signin(ctx context.Context, loginOpts openapi.LoginRequest, provi
 			return nil, err
 		}
 	}
-	if len(credentials.Password) <= 0 {
+	if len(credentials.Password) <= 0 && canPrompt {
 		err := prompt.SurveyAskOne(&survey.Password{
 			Message: "Password:",
 		}, &credentials.Password, survey.WithValidator(survey.Required))

--- a/pkg/factory/http.go
+++ b/pkg/factory/http.go
@@ -42,6 +42,7 @@ type Factory struct {
 	Stdin        io.ReadCloser
 	StdErr       io.Writer
 	SpinnerOut   io.Writer
+	neverPrompt  bool
 }
 
 func New(appVersion string, config *configuration.Config) *Factory {
@@ -63,7 +64,14 @@ func New(appVersion string, config *configuration.Config) *Factory {
 	return f
 }
 
+func (f *Factory) DisablePrompt(v bool) {
+	f.neverPrompt = v
+}
+
 func (f *Factory) CanPrompt() bool {
+	if f.neverPrompt {
+		return false
+	}
 	return cmdutil.IsTTYRead(f.Stdin) && cmdutil.IsTTY(f.StdErr)
 }
 


### PR DESCRIPTION
bind  root level flag `--no-interactive` flag to factory as a attribute, to allow us to check downstream if we can use it.