### PR TITLE
Return error when command fails to get a configured hostname for the primary controller

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -39,23 +39,23 @@ import (
 )
 
 type prepareUpgradeOptions struct {
-	Config           *configuration.Config
-	Out              io.Writer
-	Appliance        func(c *configuration.Config) (*appliancepkg.Appliance, error)
-	SpinnerOut       func() io.Writer
-	debug            bool
-	NoInteractive    bool
-	image            string
-	DevKeyring       bool
-	remoteImage      bool
-	filename         string
-	timeout          time.Duration
-	defaultFilter    map[string]map[string]string
-	hostOnController bool
-	forcePrepare     bool
-	ciMode           bool
-	actualHostname   string
-	targetVersion    *version.Version
+	Config                *configuration.Config
+	Out                   io.Writer
+	Appliance             func(c *configuration.Config) (*appliancepkg.Appliance, error)
+	SpinnerOut            func() io.Writer
+	debug                 bool
+	NoInteractive         bool
+	image                 string
+	DevKeyring            bool
+	remoteImage           bool
+	filename              string
+	timeout               time.Duration
+	defaultFilter         map[string]map[string]string
+	hostOnController      bool
+	forcePrepare          bool
+	ciMode                bool
+	primaryControllerHost string
+	targetVersion         *version.Version
 }
 
 // NewPrepareUpgradeCmd return a new prepare upgrade command
@@ -168,7 +168,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 	flags.BoolVar(&opts.DevKeyring, "dev-keyring", false, "Use the development keyring to verify the upgrade image")
 	flags.Int("throttle", 5, "Upgrade is done in batches using a throttle value. You can control the throttle using this flag")
 	flags.BoolVar(&opts.hostOnController, "host-on-controller", false, "Use the primary Controller as image host when uploading from remote source")
-	flags.StringVar(&opts.actualHostname, "actual-hostname", "", "If the actual hostname is different from that which you are connecting to the appliance admin API, this flag can be used for setting the actual hostname")
+	flags.StringVar(&opts.primaryControllerHost, "actual-hostname", "", "If the actual hostname is different from that which you are connecting to the appliance admin API, this flag can be used for setting the actual hostname")
 	flags.BoolVar(&opts.forcePrepare, "force", false, "Force prepare of upgrade on appliances even though the version uploaded is the same or lower than the version already running on the appliance")
 
 	return prepareCmd
@@ -212,10 +212,6 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	if err != nil {
 		return err
 	}
-	host, err := opts.Config.GetHost()
-	if err != nil {
-		return err
-	}
 
 	token, err := opts.Config.GetBearTokenHeaderValue()
 	if err != nil {
@@ -226,11 +222,13 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		Token:     token,
 	}
 
-	if len(opts.actualHostname) > 0 {
-		host = opts.actualHostname
+	if len(opts.primaryControllerHost) <= 0 {
+		if opts.primaryControllerHost, err = opts.Config.GetHost(); err != nil {
+			return err
+		}
 	}
 
-	primaryController, err := appliancepkg.FindPrimaryController(Allappliances, host, true)
+	primaryController, err := appliancepkg.FindPrimaryController(Allappliances, opts.primaryControllerHost, true)
 	if err != nil {
 		return err
 	}
@@ -528,14 +526,13 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	}
 
 	// Step 2
-	primaryControllerHostname := primaryController.GetHostname()
-	remoteFilePath := fmt.Sprintf("controller://%s/%s", primaryControllerHostname, opts.filename)
+	remoteFilePath := fmt.Sprintf("controller://%s/%s", opts.primaryControllerHost, opts.filename)
 	// NOTE: Backwards compatibility with appliances older than API version 13.
 	// Appliances before API version require that the peer port be passed explicitly as part of the download URL.
 	// Insert the peer port into the URL if necessary.
 	if opts.Config.Version < 13 {
 		if v, ok := primaryController.GetPeerInterfaceOk(); ok {
-			remoteFilePath = fmt.Sprintf("controller://%s:%d/%s", primaryControllerHostname, int(v.GetHttpsPort()), opts.filename)
+			remoteFilePath = fmt.Sprintf("controller://%s:%d/%s", opts.primaryControllerHost, int(v.GetHttpsPort()), opts.filename)
 		}
 	}
 
@@ -690,6 +687,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}(&wg, errChan)
 
 		for err := range errChan {
+			log.WithError(err).Error("Error while preparing")
 			errs = multierr.Append(err, errs)
 		}
 

--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -79,7 +79,7 @@ func (u *UpgradeStatus) upgradeStatus(ctx context.Context, appliance openapi.App
 		details := status.GetDetails()
 		if v, ok := status.GetStatusOk(); ok {
 			s = *v
-			logEntry.WithField("current", s).Debug("Received upgrade status")
+			logEntry.WithField("current", s).Debug("Received status")
 			if tracker != nil {
 				tracker.Update(s)
 			}
@@ -88,10 +88,12 @@ func (u *UpgradeStatus) upgradeStatus(ctx context.Context, appliance openapi.App
 					// send error details for tracker
 					tracker.Fail(s + " - " + details)
 				}
-				return backoff.Permanent(fmt.Errorf("Upgrade failed on %s %s %s", name, s, details))
+				err := fmt.Errorf("Upgrade failed on %s %s %s", name, s, details)
+				logEntry.WithError(err).WithFields(log.Fields{"status": s, "details": details}).Error("Got unwanted status")
+				return backoff.Permanent(err)
 			}
 			if util.InSlice(s, desiredStatuses) {
-				logEntry.Info("Reached wanted upgrade status")
+				logEntry.Info("Reached wanted status")
 				return nil
 			}
 		}


### PR DESCRIPTION
This fixes an error that occur if the command, for some reason, fails to fetch a configured hostname for the primary controller, rendering it impossible for the appliances to know where to download the upgrade image from.