### PR TITLE
Fix misalignment of flags in documentation

### DIFF
--- a/docs/assets/guide.js
+++ b/docs/assets/guide.js
@@ -39,7 +39,12 @@ function highlightCode() {
           break;
       }
     }
-    code.innerHTML = lines.join("\n").trim();
+
+    // trim the new line characters in the beginning
+    while(lines.length > 0 && !lines[0]) {
+      lines.shift();
+    }
+    code.innerHTML = lines.join("\n");
   }
 }
 


### PR DESCRIPTION
from

```
--api-version int   Peer API version override
      --ci-mode           Log to stderr instead of file and disable progress-bars
      --debug             Enable debug logging
      --no-interactive    Suppress interactive prompt with auto accept
      --no-verify         Don't verify TLS on for the given command, overriding settings from config file
  -p, --profile string    Profile configuration to use
```
  
to

```
      --api-version int   Peer API version override
      --ci-mode           Log to stderr instead of file and disable progress-bars
      --debug             Enable debug logging
      --no-interactive    Suppress interactive prompt with auto accept
      --no-verify         Don't verify TLS on for the given command, overriding settings from config file
  -p, --profile string    Profile configuration to use
```