### PR TITLE
indent prepare summary tables

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -776,7 +776,7 @@ func showPrepareUpgradeMessage(f string, prepareVersion *version.Version, applia
 		}
 	}
 	at.Print()
-	data.ApplianceTable = abuf.String()
+	data.ApplianceTable = util.PrefixStringLines(abuf.String(), " ", 2)
 
 	if len(skip) > 0 {
 		bbuf := &bytes.Buffer{}
@@ -801,7 +801,7 @@ func showPrepareUpgradeMessage(f string, prepareVersion *version.Version, applia
 			}
 		}
 		bt.Print()
-		data.SkipTable = bbuf.String()
+		data.SkipTable = util.PrefixStringLines(bbuf.String(), " ", 2)
 	}
 
 	tpl := template.Must(template.New("").Parse(prepareUpgradeMessage))

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -724,19 +724,19 @@ func Test_showPrepareUpgradeMessage(t *testing.T) {
 1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
 2. Prepare upgrade on the following appliances:
 
-Appliance      Online    Current version    Prepare version
----------      ------    ---------------    ---------------
-controller1    ✓         5.5.7+28767        6.0.0+29426
-controller2    ✓         5.5.7+28767        6.0.0+29426
-gateway        ✓         5.5.7+28767        6.0.0+29426
+  Appliance      Online    Current version    Prepare version
+  ---------      ------    ---------------    ---------------
+  controller1    ✓         5.5.7+28767        6.0.0+29426
+  controller2    ✓         5.5.7+28767        6.0.0+29426
+  gateway        ✓         5.5.7+28767        6.0.0+29426
 
 
 The following appliances will be skipped:
 
-Appliance      Online    Current version    Reason
----------      ------    ---------------    ------
-controller3    ⨯         5.5.7+28767        appliance is offline
-gateway2       ✓         6.0.0+29426        version is already greater or equal to prepare version
+  Appliance      Online    Current version    Reason
+  ---------      ------    ---------------    ------
+  controller3    ⨯         5.5.7+28767        appliance is offline
+  gateway2       ✓         6.0.0+29426        version is already greater or equal to prepare version
 
 `,
 		},
@@ -784,11 +784,11 @@ gateway2       ✓         6.0.0+29426        version is already greater or equa
 1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
 2. Prepare upgrade on the following appliances:
 
-Appliance      Online    Current version    Prepare version
----------      ------    ---------------    ---------------
-controller1    ✓         5.5.7+28767        6.0.0+29426
-controller2    ✓         5.5.7+28767        6.0.0+29426
-gateway        ✓         5.5.7+28767        6.0.0+29426
+  Appliance      Online    Current version    Prepare version
+  ---------      ------    ---------------    ---------------
+  controller1    ✓         5.5.7+28767        6.0.0+29426
+  controller2    ✓         5.5.7+28767        6.0.0+29426
+  gateway        ✓         5.5.7+28767        6.0.0+29426
 
 `,
 		},
@@ -837,11 +837,11 @@ gateway        ✓         5.5.7+28767        6.0.0+29426
 1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
 2. Prepare upgrade on the following appliances:
 
-Appliance      Online    Current version    Prepare version
----------      ------    ---------------    ---------------
-controller1    ✓         5.5.7+28767        6.0.0+29426
-controller2    ✓         5.5.7+28767        6.0.0+29426
-gateway        ✓         5.5.7+28767        6.0.0+29426
+  Appliance      Online    Current version    Prepare version
+  ---------      ------    ---------------    ---------------
+  controller1    ✓         5.5.7+28767        6.0.0+29426
+  controller2    ✓         5.5.7+28767        6.0.0+29426
+  gateway        ✓         5.5.7+28767        6.0.0+29426
 
 
 WARNING: This upgrade requires all controllers to be upgraded to the same version, but not all


### PR DESCRIPTION
Indent appliance tables in the prepare summary. Indent is using 2 spaces.

Fixes SA-20326