### PR TITLE
Timeout limit subprocess

### DIFF
--- a/cmd/configure/signin.go
+++ b/cmd/configure/signin.go
@@ -3,6 +3,7 @@ package configure
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/appgate/sdpctl/pkg/auth"
 	"github.com/appgate/sdpctl/pkg/docs"
@@ -41,10 +42,17 @@ func NewSigninCmd(f *factory.Factory) *cobra.Command {
 }
 
 func signinRun(cmd *cobra.Command, args []string, opts *signinOptions) error {
+	if len(os.Getenv("SDPCTL_NO_KEYRING")) > 0 {
+		fmt.Fprintf(opts.StdErr, "the %s command has no effect when using SDPCTL_NO_KEYRING\n", cmd.CalledAs())
+		fmt.Fprintln(opts.StdErr, "When the keyring integration is disabled, you must provide credentials for each command call.")
+		return nil
+	}
+
 	cfg := opts.f.Config
 	// If there's an existing bearer token present, we will clear it and renew the authentication
 	if err := cfg.ClearBearer(); err != nil {
 		// not a fatal error
+		fmt.Fprintln(opts.StdErr, err)
 		fmt.Fprintln(opts.StdErr, auth.KeyringWarningMessage)
 		log.WithError(err).Warn("Failed to delete auth token")
 	}

--- a/cmd/configure/signin.go
+++ b/cmd/configure/signin.go
@@ -2,6 +2,7 @@ package configure
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/appgate/sdpctl/pkg/auth"
 	"github.com/appgate/sdpctl/pkg/docs"
@@ -12,13 +13,15 @@ import (
 )
 
 type signinOptions struct {
-	f *factory.Factory
+	f      *factory.Factory
+	StdErr io.Writer
 }
 
 // NewSigninCmd return a new signin command
 func NewSigninCmd(f *factory.Factory) *cobra.Command {
 	opts := signinOptions{
-		f: f,
+		f:      f,
+		StdErr: f.StdErr,
 	}
 	var signinCmd = &cobra.Command{
 		Use: "signin",
@@ -42,6 +45,7 @@ func signinRun(cmd *cobra.Command, args []string, opts *signinOptions) error {
 	// If there's an existing bearer token present, we will clear it and renew the authentication
 	if err := cfg.ClearBearer(); err != nil {
 		// not a fatal error
+		fmt.Fprintln(opts.StdErr, auth.KeyringWarningMessage)
 		log.WithError(err).Warn("Failed to delete auth token")
 	}
 	if err := auth.Signin(opts.f); err != nil {

--- a/pkg/auth/signin.go
+++ b/pkg/auth/signin.go
@@ -82,6 +82,8 @@ func GetMinMaxAPIVersion(f *factory.Factory) (*MinMax, error) {
 	return nil, errors.New("Could not automatically determine api version to use")
 }
 
+var KeyringWarningMessage = "[warning] Could not integrate with system keyring. To disable keyring integration, set environment variable SDPCTL_NO_KEYRING=true"
+
 var ErrSignInNotSupported = errors.New("No TTY present, and missing required environment variables to authenticate")
 
 // Signin support interactive signin if a valid TTY is present, otherwise it requires environment variables to authenticate,
@@ -216,20 +218,20 @@ func Signin(f *factory.Factory) error {
 	if err != nil {
 		return err
 	}
-	keyringErrMessage := "[warning] To disable keyring integration, set environment variable SDPCTL_NO_KEYRING=true"
+
 	// if the bearer token can't be saved to the keychain, it will be exported as env variable
 	// and saved in the config file as fallback, this should only happened if the system does not
 	// support the keychain integration.
 	if err := keyring.SetBearer(prefix, *cfg.BearerToken); err != nil {
 		fmt.Fprintf(f.StdErr, "[warning] could not save token to keyring %s\n", err)
-		fmt.Fprintln(f.StdErr, keyringErrMessage)
+		fmt.Fprintln(f.StdErr, KeyringWarningMessage)
 	}
 
 	// store username and password if any in keyring, in practice only applicable on local provider
 	if len(response.LoginOpts.GetUsername()) > 1 && len(response.LoginOpts.GetPassword()) > 1 {
 		if err := cfg.StoreCredentials(response.LoginOpts.GetUsername(), response.LoginOpts.GetPassword()); err != nil {
 			fmt.Fprintf(f.StdErr, "[warning] %s\n", err)
-			fmt.Fprintln(f.StdErr, keyringErrMessage)
+			fmt.Fprintln(f.StdErr, KeyringWarningMessage)
 			return nil
 		}
 	}

--- a/pkg/auth/signin_test.go
+++ b/pkg/auth/signin_test.go
@@ -363,16 +363,16 @@ func TestSigninNoKeyringNoconfig(t *testing.T) {
 	// we will remove the env variable, if any to make sure we trigger
 	// the keyring
 	os.Unsetenv("SDPCTL_PASSWORD")
-	if _, err := keyring.GetPassword(prefix); err == nil {
-		t.Fatal("expected error, got nil")
+	if _, err := keyring.GetPassword(prefix); err != nil {
+		t.Errorf("expected nil, got err %s", err)
 	}
 	os.Unsetenv("SDPCTL_USERNAME")
-	if _, err := keyring.GetUsername(prefix); err == nil {
-		t.Fatal("expected error, got nil")
+	if _, err := keyring.GetUsername(prefix); err != nil {
+		t.Errorf("expected nil, got err %s", err)
 	}
 	os.Unsetenv("SDPCTL_BEARER")
-	if _, err := keyring.GetBearer(prefix); err == nil {
-		t.Fatal("expected error, got nil")
+	if _, err := keyring.GetBearer(prefix); err != nil {
+		t.Errorf("expected nil, got err %s", err)
 	}
 
 	if _, err := f.Config.GetBearTokenHeaderValue(); err != nil {

--- a/pkg/keyring/format.go
+++ b/pkg/keyring/format.go
@@ -1,7 +1,10 @@
 package keyring
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/appgate/sdpctl/pkg/hashcode"
 	zkeyring "github.com/zalando/go-keyring"
@@ -15,18 +18,66 @@ const (
 	refreshToken   = "refreshToken"
 )
 
+// ErrKeyringTimeOut is returned when the keyring operation takes too long to complete.
+var ErrKeyringTimeOut = errors.New("keyring: timeout")
+
+// keyringTimeout max time for a keyring syscall
+var keyringTimeout = time.Second * 5
+
+func runWithTimeout(task func() error) error {
+	if len(os.Getenv("SDPCTL_NO_KEYRING")) > 0 {
+		return nil
+	}
+
+	ch := make(chan error)
+	go func() {
+		ch <- task()
+	}()
+
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(keyringTimeout):
+		return ErrKeyringTimeOut
+	}
+}
+
 func format(prefix, value string) string {
 	return fmt.Sprintf("%d.%s", hashcode.String(prefix), value)
 }
 
 func getSecret(key string) (string, error) {
-	return zkeyring.Get(keyringService, key)
+	if len(os.Getenv("SDPCTL_NO_KEYRING")) > 0 {
+		return "", nil
+	}
+	ch := make(chan struct {
+		response string
+		err      error
+	})
+	go func() {
+		v, err := zkeyring.Get(keyringService, key)
+		ch <- struct {
+			response string
+			err      error
+		}{v, err}
+	}()
+
+	select {
+	case result := <-ch:
+		return result.response, result.err
+	case <-time.After(keyringTimeout):
+		return "", ErrKeyringTimeOut
+	}
 }
 
 func setSecret(key, value string) error {
-	return zkeyring.Set(keyringService, key, value)
+	return runWithTimeout(func() error {
+		return zkeyring.Set(keyringService, key, value)
+	})
 }
 
 func deleteSecret(key string) error {
-	return zkeyring.Delete(keyringService, key)
+	return runWithTimeout(func() error {
+		return zkeyring.Delete(keyringService, key)
+	})
 }

--- a/pkg/keyring/format_test.go
+++ b/pkg/keyring/format_test.go
@@ -1,0 +1,84 @@
+package keyring
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func init() {
+	// overwrite timeout in test only
+	keyringTimeout = time.Millisecond * 500
+}
+func TestRunWithTimeout(t *testing.T) {
+	type args struct {
+		task func() error
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		wantErr              bool
+		wantTimeOutErr       bool
+		environmentVariables map[string]string
+	}{
+		{
+			name: "timeout reached",
+			args: args{
+				task: func() error {
+					time.Sleep(keyringTimeout + 2*time.Second)
+					return nil
+				},
+			},
+			wantErr:        true,
+			wantTimeOutErr: true,
+		},
+		{
+			name: "no error",
+			args: args{
+				task: func() error {
+					return nil
+				},
+			},
+			wantErr:        false,
+			wantTimeOutErr: false,
+		},
+		{
+			name: "normal error",
+			args: args{
+				task: func() error {
+					return errors.New("a error")
+				},
+			},
+			wantErr:        true,
+			wantTimeOutErr: false,
+		},
+		{
+			name: "environment variable SDPCTL_NO_KEYRING set",
+			args: args{
+				task: func() error {
+					time.Sleep(keyringTimeout + 10*time.Second)
+					return nil
+				},
+			},
+			environmentVariables: map[string]string{
+				"SDPCTL_NO_KEYRING": "true",
+			},
+			wantErr:        false,
+			wantTimeOutErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.environmentVariables {
+				t.Setenv(k, v)
+			}
+			err := runWithTimeout(tt.args.task)
+			if (err != nil) != tt.wantErr && errors.Is(err, ErrKeyringTimeOut) && !tt.wantTimeOutErr {
+				t.Fatalf("got timeout error, did not expect it %s", err)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runWithTimeout() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Set a fixed timeout of  5 seconds on zalando/go-keyring/go-keyring operations, this only effect linux systems.