### PR TITLE
Gh action updates, resolve deprecation warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/staticcheck
           key: staticcheck-${{ github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,11 @@ jobs:
     name: "Static analysis"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: WillAbides/setup-go-faster@v1.7.0
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.19.x"
       - run: "GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.3.3"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ^1.19
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: |


### PR DESCRIPTION
bump gh action versions, resolves Warning message that we've seen in previous runs from "WillAbides/setup-go-faster@v1.7.0" and actions/checkout@v2


the error:

```bash


Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
