### PR TITLE
Upgrade error is aware of which command is run

### DIFF
--- a/cmd/appliance/upgrade/cancel.go
+++ b/cmd/appliance/upgrade/cancel.go
@@ -94,7 +94,7 @@ func upgradeCancelRun(cmd *cobra.Command, args []string, opts *upgradeCancelOpti
 	}
 	opts.ciMode = ciFlag
 
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), appliancepkg.Caller, cmd.CalledAs())
 	filter := util.ParseFilteringFlags(cmd.Flags(), opts.defaultfilter)
 	stats, _, err := a.Stats(ctx)
 	if err != nil {

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -147,6 +147,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	ctx = context.WithValue(ctx, appliancepkg.Caller, cmd.CalledAs())
 	filter := util.ParseFilteringFlags(cmd.Flags(), opts.defaultFilter)
 	rawAppliances, err := a.List(ctx, nil)
 	if err != nil {

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -196,6 +196,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	spinnerOut := opts.SpinnerOut()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	ctx = context.WithValue(ctx, appliancepkg.Caller, cmd.CalledAs())
 	if a.UpgradeStatusWorker == nil {
 		a.UpgradeStatusWorker = &appliancepkg.UpgradeStatus{
 			Appliance: a,


### PR DESCRIPTION
This fixes the error when waiting for the correct upgrade status. If the correct upgrade status isn't reached, the error message would be `Upgrade failed...` even though the error occured when preparing or cancelling.