### PR TITLE
periodic version checking

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -99,6 +99,9 @@ Available Variables:
     Options:  See 'sdpctl profile list'
   SDPCTL_NO_KEYRING:
     Description: Disable keyring integration. Does not attempt to store anything in the os keychain.
+  SDPCTL_DISABLE_VERSION_CHECK:
+    Description: Disable version checking when running commands
+    Options: true, false
   HTTP_PROXY:
     Description: HTTP Proxy for the client
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -300,11 +300,10 @@ func rootPersistentPreRunEFunc(f *factory.Factory, cfg *configuration.Config) fu
 		if err != nil {
 			return err
 		}
-		meta, err := cfg.CheckForUpdate(f.StdErr, client, version)
+		cfg, err = cfg.CheckForUpdate(f.StdErr, client, version)
 		if err != nil {
 			log.WithError(err).Info("version check result")
 		}
-		viper.Set("meta", meta)
 		if err := viper.WriteConfig(); err != nil {
 			if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 				fmt.Fprintf(f.StdErr, "[error] %s\n", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -301,8 +301,13 @@ func rootPersistentPreRunEFunc(f *factory.Factory, cfg *configuration.Config) fu
 		}
 
 		// Check for new sdpctl version
-		if err := cfg.CheckForUpdate(f.IOOutWriter, version); err != nil {
+		meta, err := cfg.CheckForUpdate(f.StdErr, version)
+		if err != nil {
 			log.WithError(err).Info("version check result")
+		}
+		viper.Set("meta", meta)
+		if err := viper.WriteConfig(); err != nil {
+			return err
 		}
 
 		return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	version         string = "dev"
+	version         string = "0.0.0-dev"
 	commit          string
 	buildDate       string
 	longDescription string = `The official CLI tool for managing your Collective.`
@@ -299,6 +299,12 @@ func rootPersistentPreRunEFunc(f *factory.Factory, cfg *configuration.Config) fu
 		if err := configuration.CheckMinAPIVersionRestriction(cmd, cfg.Version); err != nil {
 			return err
 		}
+
+		// Check for new sdpctl version
+		if err := cfg.CheckForUpdate(f.IOOutWriter, version); err != nil {
+			log.WithError(err).Info("version check result")
+		}
+
 		return nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/vbauerster/mpb/v7 v7.5.3
 	github.com/zalando/go-keyring v0.2.2
+	golang.org/x/net v0.7.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.5.0
 )
@@ -63,7 +64,6 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
-	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -299,13 +299,12 @@ func (c *Config) CheckForUpdate(out io.Writer, current string) (Meta, error) {
 	}
 
 	// Check if version check has already been done today
-	yesterday := time.Now().AddDate(0, 0, -1)
 	lastCheck, err := time.Parse(time.RFC3339Nano, c.Meta.LastChecked)
-	if err != nil {
-		return c.Meta, err
-	}
-	if !lastCheck.Before(yesterday) {
-		return c.Meta, errors.New("version check already done today")
+	if err == nil {
+        yesterday := time.Now().AddDate(0, 0, -1)
+		if !lastCheck.Before(yesterday) {
+			return c.Meta, errors.New("version check already done today")
+		}
 	}
 
 	// Perform version check

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -22,23 +22,19 @@ import (
 	"golang.org/x/net/context"
 )
 
-type Meta struct {
-	DisableVersionCheck bool   `mapstructure:"disable_version_check" json:"disable_version_check"`
-	LastChecked         string `mapstructure:"last_checked" json:"last_checked"`
-}
-
 type Config struct {
-	URL         string  `mapstructure:"url"`
-	Provider    *string `mapstructure:"provider"`
-	Insecure    bool    `mapstructure:"insecure"`
-	Debug       bool    `mapstructure:"debug"`         // http debug flag
-	Version     int     `mapstructure:"api_version"`   // api peer interface version
-	BearerToken *string `mapstructure:"bearer:squash"` // current logged in user token
-	ExpiresAt   *string `mapstructure:"expires_at"`
-	DeviceID    string  `mapstructure:"device_id"`
-	PemFilePath string  `mapstructure:"pem_filepath"`
-	Timeout     int     // HTTP timeout, not supported in the config file.
-	Meta        Meta    `mapstructure:"meta"`
+	URL                 string  `mapstructure:"url"`
+	Provider            *string `mapstructure:"provider"`
+	Insecure            bool    `mapstructure:"insecure"`
+	Debug               bool    `mapstructure:"debug"`         // http debug flag
+	Version             int     `mapstructure:"api_version"`   // api peer interface version
+	BearerToken         *string `mapstructure:"bearer:squash"` // current logged in user token
+	ExpiresAt           *string `mapstructure:"expires_at"`
+	DeviceID            string  `mapstructure:"device_id"`
+	PemFilePath         string  `mapstructure:"pem_filepath"`
+	Timeout             int     // HTTP timeout, not supported in the config file.
+	DisableVersionCheck bool    `mapstructure:"disable_version_check"`
+	LastVersionCheck    string  `mapstructure:"last_version_check"`
 }
 
 type Credentials struct {
@@ -292,18 +288,18 @@ func (c *Config) KeyringPrefix() (string, error) {
 	return h, nil
 }
 
-func (c *Config) CheckForUpdate(out io.Writer, client *http.Client, current string) (Meta, error) {
+func (c *Config) CheckForUpdate(out io.Writer, client *http.Client, current string) (*Config, error) {
 	// Check if version check is disabled in configuration
-	if c.Meta.DisableVersionCheck {
-		return c.Meta, errors.New("version check disabled")
+	if c.DisableVersionCheck {
+		return c, errors.New("version check disabled")
 	}
 
 	// Check if version check has already been done today
-	lastCheck, err := time.Parse(time.RFC3339Nano, c.Meta.LastChecked)
+	lastCheck, err := time.Parse(time.RFC3339Nano, c.LastVersionCheck)
 	if err == nil {
 		yesterday := time.Now().AddDate(0, 0, -1)
 		if !lastCheck.Before(yesterday) {
-			return c.Meta, errors.New("version check already done today")
+			return c, errors.New("version check already done today")
 		}
 	}
 
@@ -313,14 +309,15 @@ func (c *Config) CheckForUpdate(out io.Writer, client *http.Client, current stri
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cliReleasesURL, nil)
 	// Write new check time to config after request is made
-	c.Meta.LastChecked = time.Now().Format(time.RFC3339Nano)
+	c.LastVersionCheck = time.Now().Format(time.RFC3339Nano)
+	viper.Set("last_version_check", c.LastVersionCheck)
 	if err != nil {
-		return c.Meta, err
+		return c, err
 	}
 	req.Header.Add("Accept", "application/vnd.github+json")
 	res, err := client.Do(req)
 	if err != nil {
-		return c.Meta, err
+		return c, err
 	}
 	defer res.Body.Close()
 
@@ -333,36 +330,36 @@ func (c *Config) CheckForUpdate(out io.Writer, client *http.Client, current stri
 	type releaseList []githubRelease
 
 	if res.StatusCode != http.StatusOK {
-		return c.Meta, fmt.Errorf("unexpected request status: %d", res.StatusCode)
+		return c, fmt.Errorf("unexpected request status: %d", res.StatusCode)
 	}
 
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
-		return c.Meta, err
+		return c, err
 	}
 
 	var releases releaseList
 	if err := json.Unmarshal(b, &releases); err != nil {
-		return c.Meta, err
+		return c, err
 	}
 
 	v, err := version.NewVersion(current)
 	if err != nil {
-		return c.Meta, err
+		return c, err
 	}
 
 	var latest *version.Version
 	r := releases[0]
 	n, err := version.NewVersion(r.TagName)
 	if err != nil {
-		return c.Meta, err
+		return c, err
 	}
 	if !r.Draft && !r.PreRelease && n.GreaterThan(v) {
 		latest = n
 	}
 	if latest == nil {
-		return c.Meta, errors.New("already at latest version")
+		return c, errors.New("already at latest version")
 	}
 	fmt.Fprintf(out, "NOTICE: A new version of sdpctl is available for download: %s\nDownload it here: https://github.com/appgate/sdpctl/releases/tag/%s\n\n", latest.Original(), latest.Original())
-	return c.Meta, nil
+	return c, nil
 }


### PR DESCRIPTION
Check for a new version of sdpctl when running commands. If a new version is found, a notice will be printed at the top of the command output with a link where the new version can be downloaded.

Version is checked periodically, once every day, but can optionally be disabled in the config file.

Fixes: SA-20202