### PR TITLE
Bump go version requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN_NAME=sdpctl
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
-GORELEASER_CROSS_VERSION=v1.18.3
+GORELEASER_CROSS_VERSION=v1.20.0
 DESTDIR :=
 prefix  := /usr/local
 bindir  := ${prefix}/bin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/appgate/sdpctl
 
-go 1.18
+go 1.20
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6


### PR DESCRIPTION
`errors.Join()` used [here](https://github.com/appgate/sdpctl/blob/aa05dcd55fc3faa83c6e59030ec2648b9173c3e4/pkg/api/apiutil.go#L33) was implemented in go version 1.20, so we need to follow with build requirements.