### PR TITLE
Token list sorting

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,10 +77,11 @@ nfpms:
           group: root
       - src: ./build/man/*.gz
         dst: /usr/share/man/man3/
-        type: config
+        file_info:
+          group: root
+          mode: 0644
       - src: LICENSE
         dst: /usr/share/doc/sdpctl/copyright
-        type: config
         file_info:
           group: root
           mode: 0644
@@ -89,5 +90,6 @@ nfpms:
         - statically-linked-binary
         - changelog-file-missing-in-native-package
         - groff-message
+        - no-manual-page
     rpm:
       compression: gzip

--- a/cmd/appliance/maintenance/status.go
+++ b/cmd/appliance/maintenance/status.go
@@ -10,6 +10,7 @@ import (
 	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
+	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/spf13/cobra"
@@ -30,7 +31,9 @@ func NewStatusCmd(f *factory.Factory) *cobra.Command {
 		Out:       f.IOOutWriter,
 	}
 	var cmd = &cobra.Command{
-		Use: "status",
+		Use:   "status",
+		Short: docs.MaintenanceStatusDoc.Short,
+		Long:  docs.MaintenanceStatusDoc.Long,
 		Annotations: map[string]string{
 			"MinAPIVersion": "18",
 			"ErrorMessage":  "sdpctl appliance maintenance status requires appliance version higher or equal to 6.1 with API Version 18",

--- a/cmd/token/list.go
+++ b/cmd/token/list.go
@@ -15,10 +15,25 @@ func NewTokenListCmd(opts *TokenOptions) *cobra.Command {
 		Long:    docs.TokenListDoc.Long,
 		Example: docs.TokenListDoc.ExampleString(),
 		Aliases: []string{"ls"},
+		Args: func(cmd *cobra.Command, args []string) error {
+			var err error
+			opts.orderBy, err = cmd.Flags().GetStringSlice("order-by")
+			if err != nil {
+				return err
+			}
+			opts.descending, err = cmd.Flags().GetBool("descending")
+			if err != nil {
+				return err
+			}
+			return nil
+		},
 		RunE: func(c *cobra.Command, args []string) error {
 			return tokenListRun(opts)
 		},
 	}
+
+	listCmd.Flags().StringSlice("order-by", []string{"distinguished-name"}, "Order tokens list by keyword. Available keywords are 'distinguished-name', 'hostname', 'username', 'provider-name', 'device-id' and 'username'")
+	listCmd.Flags().Bool("descending", false, "Reverses the order of the token list")
 
 	return listCmd
 }
@@ -30,7 +45,7 @@ func tokenListRun(opts *TokenOptions) error {
 		return err
 	}
 
-	distinguishedNames, err := t.ListDistinguishedNames(ctx)
+	distinguishedNames, err := t.ListDistinguishedNames(ctx, opts.orderBy, opts.descending)
 	if err != nil {
 		return err
 	}

--- a/cmd/token/list_test.go
+++ b/cmd/token/list_test.go
@@ -76,20 +76,20 @@ func TestTokenList(t *testing.T) {
 
 	expected := `Distinguished Name                                       Device ID                               Last Token Issued At           Provider Name    Username
 ------------------                                       ---------                               --------------------           -------------    --------
-CN=f0f4305444d24991b070160de7b69fe9,CN=bob,OU=local      f0f43054-44d2-4991-b070-160de7b69fe9    2021-12-20T19:29:29.107201Z    local            bob
-CN=55e3408fe69c49358d6f345e3d2ee4bd,CN=admin,OU=local    55e3408f-e69c-4935-8d6f-345e3d2ee4bd    2021-12-20T19:29:27.451869Z    local            admin
-CN=877b2d887c2048e4b2e8daae6bb4c077,CN=bob,OU=local      877b2d88-7c20-48e4-b2e8-daae6bb4c077    2021-12-20T19:29:25.778469Z    local            bob
+CN=3332396333654131b235633864363134,CN=admin,OU=local    33323963-3365-4131-b235-633864363134    2021-12-20T18:37:46.634198Z    local            admin
 CN=37b8c15f300d40b6898c9131019327d4,CN=bob,OU=local      37b8c15f-300d-40b6-898c-9131019327d4    2021-12-20T19:29:22.380330Z    local            bob
-CN=522db03c06494122a508befb91ba95af,CN=bob,OU=local      522db03c-0649-4122-a508-befb91ba95af    2021-12-20T19:29:17.801181Z    local            bob
 CN=43f87ebf811249f8a3a965edc7db0601,CN=bob,OU=local      43f87ebf-8112-49f8-a3a9-65edc7db0601    2021-12-20T19:29:14.519041Z    local            bob
-CN=d7d47adbb1bc4a0baaaf9c970d9682c8,CN=bob,OU=local      d7d47adb-b1bc-4a0b-aaaf-9c970d9682c8    2021-12-20T19:29:11.319131Z    local            bob
-CN=9c607025108d4a03b25a22f0d4b2ffba,CN=bob,OU=local      9c607025-108d-4a03-b25a-22f0d4b2ffba    2021-12-20T19:29:07.997339Z    local            bob
-CN=b37de2ed4b4c4d21952f718e2dd6e34b,CN=bob,OU=local      b37de2ed-4b4c-4d21-952f-718e2dd6e34b    2021-12-20T19:29:04.809781Z    local            bob
-CN=a3c70825dc0945c48dbc6a6d991d7d0b,CN=bob,OU=local      a3c70825-dc09-45c4-8dbc-6a6d991d7d0b    2021-12-20T19:29:01.415945Z    local            bob
-CN=f7e1d6fec2344b49b1d65a107025e795,CN=bob,OU=local      f7e1d6fe-c234-4b49-b1d6-5a107025e795    2021-12-20T19:28:56.367895Z    local            bob
+CN=522db03c06494122a508befb91ba95af,CN=bob,OU=local      522db03c-0649-4122-a508-befb91ba95af    2021-12-20T19:29:17.801181Z    local            bob
+CN=55e3408fe69c49358d6f345e3d2ee4bd,CN=admin,OU=local    55e3408f-e69c-4935-8d6f-345e3d2ee4bd    2021-12-20T19:29:27.451869Z    local            admin
 CN=6633333637304266a631306131646637,CN=admin,OU=local    66333336-3730-4266-a631-306131646637    2021-12-20T19:25:29.414827Z    local            admin
 CN=70e076801c4b5bdc87b4afc71540e720,CN=admin,OU=local    70e07680-1c4b-5bdc-87b4-afc71540e720    2021-12-20T19:24:34.652187Z    local            admin
-CN=3332396333654131b235633864363134,CN=admin,OU=local    33323963-3365-4131-b235-633864363134    2021-12-20T18:37:46.634198Z    local            admin
+CN=877b2d887c2048e4b2e8daae6bb4c077,CN=bob,OU=local      877b2d88-7c20-48e4-b2e8-daae6bb4c077    2021-12-20T19:29:25.778469Z    local            bob
+CN=9c607025108d4a03b25a22f0d4b2ffba,CN=bob,OU=local      9c607025-108d-4a03-b25a-22f0d4b2ffba    2021-12-20T19:29:07.997339Z    local            bob
+CN=a3c70825dc0945c48dbc6a6d991d7d0b,CN=bob,OU=local      a3c70825-dc09-45c4-8dbc-6a6d991d7d0b    2021-12-20T19:29:01.415945Z    local            bob
+CN=b37de2ed4b4c4d21952f718e2dd6e34b,CN=bob,OU=local      b37de2ed-4b4c-4d21-952f-718e2dd6e34b    2021-12-20T19:29:04.809781Z    local            bob
+CN=d7d47adbb1bc4a0baaaf9c970d9682c8,CN=bob,OU=local      d7d47adb-b1bc-4a0b-aaaf-9c970d9682c8    2021-12-20T19:29:11.319131Z    local            bob
+CN=f0f4305444d24991b070160de7b69fe9,CN=bob,OU=local      f0f43054-44d2-4991-b070-160de7b69fe9    2021-12-20T19:29:29.107201Z    local            bob
+CN=f7e1d6fec2344b49b1d65a107025e795,CN=bob,OU=local      f7e1d6fe-c234-4b49-b1d6-5a107025e795    2021-12-20T19:28:56.367895Z    local            bob
 `
 	assert.Equal(t, string(actual), expected)
 }

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -28,10 +28,9 @@ func NewTokenCmd(f *factory.Factory) *cobra.Command {
 	}
 
 	var tokenCmd = &cobra.Command{
-		Use:     "token",
-		Aliases: []string{"tokens"},
-		Short:   "Perform actions on Admin, Claims and Entitlement tokens",
-		Long:    `The token command allows you to renew or revoke tokens used in the Collective.`,
+		Use:   "token",
+		Short: "Perform actions on Admin, Claims and Entitlement tokens",
+		Long:  `The token command allows you to renew or revoke tokens used in the Collective.`,
 	}
 
 	tokenCmd.PersistentFlags().BoolVar(&opts.useJSON, "json", false, "Display in JSON format")

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -10,11 +10,13 @@ import (
 )
 
 type TokenOptions struct {
-	Config  *configuration.Config
-	Out     io.Writer
-	Token   func(c *configuration.Config) (*token.Token, error)
-	Debug   bool
-	useJSON bool
+	Config     *configuration.Config
+	Out        io.Writer
+	Token      func(c *configuration.Config) (*token.Token, error)
+	Debug      bool
+	useJSON    bool
+	orderBy    []string
+	descending bool
 }
 
 func NewTokenCmd(f *factory.Factory) *cobra.Command {
@@ -26,9 +28,10 @@ func NewTokenCmd(f *factory.Factory) *cobra.Command {
 	}
 
 	var tokenCmd = &cobra.Command{
-		Use:   "token",
-		Short: "Perform actions on Admin, Claims and Entitlement tokens",
-		Long:  `The token command allows you to renew or revoke tokens used in the Collective.`,
+		Use:     "token",
+		Aliases: []string{"tokens"},
+		Short:   "Perform actions on Admin, Claims and Entitlement tokens",
+		Long:    `The token command allows you to renew or revoke tokens used in the Collective.`,
 	}
 
 	tokenCmd.PersistentFlags().BoolVar(&opts.useJSON, "json", false, "Display in JSON format")

--- a/docs/sdpctl_appliance_maintenance.html
+++ b/docs/sdpctl_appliance_maintenance.html
@@ -40,7 +40,7 @@
 <li><p><a href="sdpctl_appliance.html">sdpctl appliance</a>	 - Manage the appliances and perform tasks such as backups, ugprades, metrics etc</p></li>
 <li><p><a href="sdpctl_appliance_maintenance_disable.html">sdpctl appliance maintenance disable</a>	 - Disable maintenance mode on a single Controller</p></li>
 <li><p><a href="sdpctl_appliance_maintenance_enable.html">sdpctl appliance maintenance enable</a>	 - Enable maintenance mode on a single Controller</p></li>
-<li><p><a href="sdpctl_appliance_maintenance_status.html">sdpctl appliance maintenance status</a>	 -</p></li>
+<li><p><a href="sdpctl_appliance_maintenance_status.html">sdpctl appliance maintenance status</a>	 - View maintenance status of appliances</p></li>
 </ul>
 
       </div>

--- a/docs/sdpctl_appliance_maintenance_status.html
+++ b/docs/sdpctl_appliance_maintenance_status.html
@@ -20,7 +20,7 @@
 			</div>
 			<hr />
       <div class="content text-left">
-      <h2 class="text-left margin-bottom">sdpctl appliance maintenance status</h2><pre class="code-editor margin-bottom"><code>sdpctl appliance maintenance status [flags]
+      <h2 class="text-left margin-bottom">sdpctl appliance maintenance status</h2><p>View maintenance status of appliances</p><pre class="code-editor margin-bottom"><code>sdpctl appliance maintenance status [flags]
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
 <pre class="code-editor margin-bottom"><code>  -h, --help   help for status

--- a/docs/sdpctl_token_list.html
+++ b/docs/sdpctl_token_list.html
@@ -30,7 +30,9 @@
   &gt; sdpctl token list --json
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
-<pre class="code-editor margin-bottom"><code>  -h, --help   help for list
+<pre class="code-editor margin-bottom"><code>      --descending         Reverses the order of the token list
+  -h, --help               help for list
+      --order-by strings   Order tokens list by keyword. Available keywords are 'distinguished-name', 'hostname', 'username', 'provider-name', 'device-id' and 'username' (default [distinguished-name])
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>
 <pre class="code-editor margin-bottom"><code>      --api-version int   Peer API version override

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -584,17 +584,6 @@ func applyApplianceFilter(appliances []openapi.Appliance, filter map[string]stri
 	return filteredAppliances, nil
 }
 
-func reverse[S ~[]T, T any](items S) S {
-	if len(items) <= 1 {
-		return items
-	}
-	result := make([]T, 0, len(items))
-	for i := len(items) - 1; i >= 0; i-- {
-		result = append(result, items[i])
-	}
-	return result
-}
-
 func orderAppliances(appliances []openapi.Appliance, orderBy []string, descending bool) ([]openapi.Appliance, error) {
 	var errs *multierror.Error
 	// reverse loop the slice to prioritize the ordering. First entered has priority
@@ -619,7 +608,7 @@ func orderAppliances(appliances []openapi.Appliance, orderBy []string, descendin
 		}
 	}
 	if descending {
-		return reverse(appliances), errs.ErrorOrNil()
+		return util.Reverse(appliances), errs.ErrorOrNil()
 	}
 	return appliances, errs.ErrorOrNil()
 }
@@ -665,7 +654,7 @@ func orderApplianceStats(stats []openapi.StatsAppliancesListAllOfData, orderBy [
 		}
 	}
 	if descending {
-		return reverse(stats), errs.ErrorOrNil()
+		return util.Reverse(stats), errs.ErrorOrNil()
 	}
 	return stats, errs.ErrorOrNil()
 }
@@ -699,7 +688,7 @@ func orderApplianceFiles(files []openapi.File, orderBy []string, descending bool
 		}
 	}
 	if descending {
-		return reverse(files), errs.ErrorOrNil()
+		return util.Reverse(files), errs.ErrorOrNil()
 	}
 	return files, errs.ErrorOrNil()
 }

--- a/pkg/docs/maintenance.go
+++ b/pkg/docs/maintenance.go
@@ -15,6 +15,11 @@ var (
 		Long:  ``,
 	}
 
+	MaintenanceStatusDoc = CommandDoc{
+		Short: "View maintenance status of appliances",
+		Long:  "",
+	}
+
 	MaintenanceDisable = CommandDoc{
 		Short: "Disable maintenance mode on a single Controller",
 		Long:  MaintenanceModeLongDescription,

--- a/pkg/docs/maintenance.go
+++ b/pkg/docs/maintenance.go
@@ -17,7 +17,6 @@ var (
 
 	MaintenanceStatusDoc = CommandDoc{
 		Short: "View maintenance status of appliances",
-		Long:  "",
 	}
 
 	MaintenanceDisable = CommandDoc{

--- a/pkg/token/api.go
+++ b/pkg/token/api.go
@@ -2,10 +2,15 @@ package token
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 
 	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
+	"github.com/appgate/sdpctl/pkg/util"
+	"github.com/hashicorp/go-multierror"
 )
 
 type Token struct {
@@ -14,12 +19,12 @@ type Token struct {
 	Token      string
 }
 
-func (t *Token) ListDistinguishedNames(ctx context.Context) ([]openapi.DistinguishedName, error) {
+func (t *Token) ListDistinguishedNames(ctx context.Context, orderBy []string, descending bool) ([]openapi.DistinguishedName, error) {
 	dn, response, err := t.APIClient.ActiveDevicesApi.TokenRecordsDnGet(ctx).Authorization(t.Token).Execute()
 	if err != nil {
 		return nil, api.HTTPErrorResponse(response, err)
 	}
-	return dn.GetData(), nil
+	return orderTokenList(dn.GetData(), orderBy, descending)
 }
 
 func (t *Token) RevokeByDistinguishedName(request openapi.ApiTokenRecordsRevokedByDnDistinguishedNamePutRequest, body openapi.TokenRevocationRequest) (*http.Response, error) {
@@ -44,4 +49,32 @@ func (t *Token) ReevaluateByDistinguishedName(ctx context.Context, dn string) ([
 		return nil, api.HTTPErrorResponse(response, err)
 	}
 	return reevaluatedDn.GetReevaluatedDistinguishedNames(), nil
+}
+
+func orderTokenList(tokens []openapi.DistinguishedName, orderBy []string, descending bool) ([]openapi.DistinguishedName, error) {
+	var errs *multierror.Error
+	for i := len(orderBy) - 1; i >= 0; i-- {
+		switch strings.ToLower(orderBy[i]) {
+		case "distinguished-name", "dn":
+			sort.SliceStable(tokens, func(i, j int) bool { return tokens[i].GetDistinguishedName() < tokens[j].GetDistinguishedName() })
+		case "hostname":
+			sort.SliceStable(tokens, func(i, j int) bool { return tokens[i].GetHostname() < tokens[j].GetHostname() })
+		case "username", "user":
+			sort.SliceStable(tokens, func(i, j int) bool { return tokens[i].GetUsername() < tokens[j].GetUsername() })
+		case "provider-name", "provider":
+			sort.SliceStable(tokens, func(i, j int) bool { return tokens[i].GetProviderName() < tokens[j].GetProviderName() })
+		case "device-id", "device":
+			sort.SliceStable(tokens, func(i, j int) bool { return tokens[i].GetDeviceId() < tokens[j].GetDeviceId() })
+		case "last-issued":
+			sort.SliceStable(tokens, func(i, j int) bool { return tokens[i].GetLastTokenIssuedAt() < tokens[j].GetLastTokenIssuedAt() })
+		default:
+			errs = multierror.Append(errs, fmt.Errorf("keyword not sortable: %s", orderBy[i]))
+		}
+	}
+
+	if descending {
+		tokens = util.Reverse(tokens)
+	}
+
+	return tokens, errs.ErrorOrNil()
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -128,3 +128,14 @@ func PrefixStringLines(s, prefixChar string, prefixLength int) string {
 	}
 	return strings.Join(split, "\n")
 }
+
+func Reverse[S ~[]T, T any](items S) S {
+	if len(items) <= 1 {
+		return items
+	}
+	result := make([]T, 0, len(items))
+	for i := len(items) - 1; i >= 0; i-- {
+		result = append(result, items[i])
+	}
+	return result
+}


### PR DESCRIPTION
Implements list sorting for the `tokens list` command. Similar to the appliance list sorting, it uses the `--order-by` and `--descending` flags, where the former accepts a comma separated list of sortable keywords, while the latter reverses the sort order if set.

Also included are some minor build issues found:
* add missing docs for the `maintenance status`
* set correct permissions for included files in deb/rpm package