### PR TITLE
Prevent same site gateways from batching together when upgrading

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = space
+indent_style = tab
 indent_size = 4
 end_of_line = lf
 charset = utf-8

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -208,6 +208,10 @@ func ChunkApplianceGroup(chunkSize int, applianceGroups map[int][]openapi.Applia
 	for index, slice := range chunks {
 		if len(slice) == 1 {
 			item, org := slice[len(slice)-1], slice[:len(slice)-1]
+			if v, ok := item.GetGatewayOk(); ok && v.GetEnabled() {
+				// needed so that we don't accidentally add same site gateways to the same batch
+				continue
+			}
 			chunks[index] = org
 			candidates = append(candidates, item)
 		}
@@ -249,14 +253,19 @@ func applianceGroupHash(appliance openapi.Appliance) int {
 	if len(appliance.GetSite()) > 0 {
 		buf.WriteString(appliance.GetSite())
 	}
+	if v, ok := appliance.GetGatewayOk(); ok {
+		enabled := v.GetEnabled()
+		buf.WriteString(fmt.Sprintf("%s=%t", "&gateway", enabled))
+		if enabled {
+			// all enabled gateways with same site need to be grouped together regardless of other functions enabled
+			return hashcode.String(buf.String())
+		}
+	}
 	if v, ok := appliance.GetLogForwarderOk(); ok {
 		buf.WriteString(fmt.Sprintf("%s=%t", "&log_forwarder", v.GetEnabled()))
 	}
 	if v, ok := appliance.GetLogServerOk(); ok {
 		buf.WriteString(fmt.Sprintf("%s=%t", "&log_server", v.GetEnabled()))
-	}
-	if v, ok := appliance.GetGatewayOk(); ok {
-		buf.WriteString(fmt.Sprintf("%s=%t", "&gateway", v.GetEnabled()))
 	}
 	if v, ok := appliance.GetConnectorOk(); ok {
 		buf.WriteString(fmt.Sprintf("%s=%t", "&connector", v.GetEnabled()))

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -212,6 +212,9 @@ func ChunkApplianceGroup(chunkSize int, applianceGroups map[int][]openapi.Applia
 				// needed so that we don't accidentally add same site gateways to the same batch
 				continue
 			}
+			if v, ok := item.GetConnectorOk(); ok && v.GetEnabled() {
+				continue
+			}
 			chunks[index] = org
 			candidates = append(candidates, item)
 		}
@@ -261,14 +264,19 @@ func applianceGroupHash(appliance openapi.Appliance) int {
 			return hashcode.String(buf.String())
 		}
 	}
+	if v, ok := appliance.GetConnectorOk(); ok {
+		enabled := v.GetEnabled()
+		buf.WriteString(fmt.Sprintf("%s=%t", "&connector", enabled))
+		if enabled {
+			// same rules apply to connectors as gateways
+			return hashcode.String(buf.String())
+		}
+	}
 	if v, ok := appliance.GetLogForwarderOk(); ok {
 		buf.WriteString(fmt.Sprintf("%s=%t", "&log_forwarder", v.GetEnabled()))
 	}
 	if v, ok := appliance.GetLogServerOk(); ok {
 		buf.WriteString(fmt.Sprintf("%s=%t", "&log_server", v.GetEnabled()))
-	}
-	if v, ok := appliance.GetConnectorOk(); ok {
-		buf.WriteString(fmt.Sprintf("%s=%t", "&connector", v.GetEnabled()))
 	}
 	if v, ok := appliance.GetPortalOk(); ok {
 		buf.WriteString(fmt.Sprintf("%s=%t", "&portal", v.GetEnabled()))

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -2657,6 +2657,62 @@ func TestChunkApplianceGroup(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "two connectors same site",
+			args: args{
+				divisor: 2,
+				appliances: map[int][]openapi.Appliance{
+					hashcode.String(fmt.Sprintf("%s%s", *sites["A"], "&gateway=false&connector=true")): {
+						{
+							Name: "conn1",
+							Connector: &openapi.ApplianceAllOfConnector{
+								Enabled: openapi.PtrBool(true),
+							},
+							AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+								Hostname: "conn1.devops",
+							},
+							Site: sites["A"],
+						},
+						{
+							Name: "conn2",
+							Connector: &openapi.ApplianceAllOfConnector{
+								Enabled: openapi.PtrBool(true),
+							},
+							AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+								Hostname: "conn2.devops",
+							},
+							Site: sites["A"],
+						},
+					},
+				},
+			},
+			want: [][]openapi.Appliance{
+				{
+					{
+						Name: "conn2",
+						Connector: &openapi.ApplianceAllOfConnector{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "conn2.devops",
+						},
+						Site: sites["A"],
+					},
+				},
+				{
+					{
+						Name: "conn1",
+						Connector: &openapi.ApplianceAllOfConnector{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "conn1.devops",
+						},
+						Site: sites["A"],
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -1256,6 +1256,85 @@ func TestSplitAppliancesByGroup(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "gateways with multiple functions enabled",
+			args: args{
+				appliances: []openapi.Appliance{
+					{
+						Name: "g1",
+						Gateway: &openapi.ApplianceAllOfGateway{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "g1.devops",
+						},
+						Site: sites["A"],
+					},
+					{
+						Name: "g2",
+						Gateway: &openapi.ApplianceAllOfGateway{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "g2.devops",
+						},
+						Site: sites["B"],
+					},
+					{
+						Name: "g3",
+						Gateway: &openapi.ApplianceAllOfGateway{
+							Enabled: openapi.PtrBool(true),
+						},
+						LogForwarder: &openapi.ApplianceAllOfLogForwarder{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "g3.devops",
+						},
+						Site: sites["A"],
+					},
+				},
+			},
+			want: map[int][]openapi.Appliance{
+				hashcode.String(fmt.Sprintf("%s%s", *sites["B"], "&gateway=true")): {
+					{
+						Name: "g2",
+						Gateway: &openapi.ApplianceAllOfGateway{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "g2.devops",
+						},
+						Site: sites["B"],
+					},
+				},
+				hashcode.String(fmt.Sprintf("%s%s", *sites["A"], "&gateway=true")): {
+					{
+						Name: "g1",
+						Gateway: &openapi.ApplianceAllOfGateway{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "g1.devops",
+						},
+						Site: sites["A"],
+					},
+					{
+						Name: "g3",
+						Gateway: &openapi.ApplianceAllOfGateway{
+							Enabled: openapi.PtrBool(true),
+						},
+						LogForwarder: &openapi.ApplianceAllOfLogForwarder{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "g3.devops",
+						},
+						Site: sites["A"],
+					},
+				},
+			},
+		},
 	}
 	opts := []cmp.Option{cmp.AllowUnexported(openapi.NullableElasticsearch{})}
 	for _, tt := range tests {
@@ -1304,7 +1383,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&log_forwarder=true&log_server=false&gateway=false&connector=false&portal=false")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&log_forwarder=true&log_server=false&connector=false&portal=false")),
 		},
 		{
 			name: "log server enabled",
@@ -1329,7 +1408,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&log_forwarder=false&log_server=true&gateway=false&connector=false&portal=false")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&log_forwarder=false&log_server=true&connector=false&portal=false")),
 		},
 		{
 			name: "gateway enabled",
@@ -1354,7 +1433,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&log_forwarder=false&log_server=false&gateway=true&connector=false&portal=false")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=true")),
 		},
 		{
 			name: "connector enabled",
@@ -1379,7 +1458,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&log_forwarder=false&log_server=false&gateway=false&connector=true&portal=false")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&log_forwarder=false&log_server=false&connector=true&portal=false")),
 		},
 		{
 			name: "portal enabled",
@@ -1404,7 +1483,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&log_forwarder=false&log_server=false&gateway=false&connector=false&portal=true")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&log_forwarder=false&log_server=false&connector=false&portal=true")),
 		},
 		{
 			name: "gateway and log_forwarder enabled",
@@ -1429,7 +1508,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&log_forwarder=true&log_server=false&gateway=true&connector=false&portal=false")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=true")),
 		},
 		{
 			name: "controller enabled",
@@ -2518,6 +2597,62 @@ func TestChunkApplianceGroup(t *testing.T) {
 							Hostname: "connectorb.devops",
 						},
 						Site: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "two gateways same site",
+			args: args{
+				divisor: 2,
+				appliances: map[int][]openapi.Appliance{
+					hashcode.String(fmt.Sprintf("%s%s", *sites["A"], "&gateway=true")): {
+						{
+							Name: "g1",
+							Gateway: &openapi.ApplianceAllOfGateway{
+								Enabled: openapi.PtrBool(true),
+							},
+							AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+								Hostname: "g1.devops",
+							},
+							Site: sites["A"],
+						},
+						{
+							Name: "g2",
+							Gateway: &openapi.ApplianceAllOfGateway{
+								Enabled: openapi.PtrBool(true),
+							},
+							AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+								Hostname: "g2.devops",
+							},
+							Site: sites["A"],
+						},
+					},
+				},
+			},
+			want: [][]openapi.Appliance{
+				{
+					{
+						Name: "g2",
+						Gateway: &openapi.ApplianceAllOfGateway{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "g2.devops",
+						},
+						Site: sites["A"],
+					},
+				},
+				{
+					{
+						Name: "g1",
+						Gateway: &openapi.ApplianceAllOfGateway{
+							Enabled: openapi.PtrBool(true),
+						},
+						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
+							Hostname: "g1.devops",
+						},
+						Site: sites["A"],
 					},
 				},
 			},

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -1383,7 +1383,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&log_forwarder=true&log_server=false&connector=false&portal=false")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&connector=false&log_forwarder=true&log_server=false&portal=false")),
 		},
 		{
 			name: "log server enabled",
@@ -1408,7 +1408,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&log_forwarder=false&log_server=true&connector=false&portal=false")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&connector=false&log_forwarder=false&log_server=true&portal=false")),
 		},
 		{
 			name: "gateway enabled",
@@ -1458,7 +1458,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&log_forwarder=false&log_server=false&connector=true&portal=false")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&connector=true")),
 		},
 		{
 			name: "portal enabled",
@@ -1483,7 +1483,7 @@ func TestApplianceGroupHash(t *testing.T) {
 				},
 				Site: site,
 			},
-			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&log_forwarder=false&log_server=false&connector=false&portal=true")),
+			expect: hashcode.String(fmt.Sprintf("%s%s", *site, "&gateway=false&connector=false&log_forwarder=false&log_server=false&portal=true")),
 		},
 		{
 			name: "gateway and log_forwarder enabled",


### PR DESCRIPTION
This fixes a bug where same site gateways were sometimes batched together when upgrading, causing downtime for the site when completing an upgrade.

Gateways are now treated specially if they are enabled, giving them the same hash code if they belong to the same site and are enabled. An additional check is also made to prevent enabled gateways to be batched together with same site gateways when re-balancing of batches occurs. It is better to have a batch with only one appliance rather than causing downtime.

Fixes SA-21318