### PR TITLE
Better information on disk usage

### DIFF
--- a/cmd/appliance/stats.go
+++ b/cmd/appliance/stats.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"strings"
 
 	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
@@ -104,18 +103,8 @@ func statsDiskUsage(apiVersion int, stats openapi.StatsAppliancesListAllOfData) 
 	diskInfo := stats.GetDiskInfo()
 	used, total := diskInfo.GetUsed(), diskInfo.GetTotal()
 	percentUsed := (used / total) * 100
-	r := fmt.Sprintf("%.2f%% (%s / %s)", percentUsed, prettyBytes(float64(used)), prettyBytes(float64(total)))
+	r := fmt.Sprintf("%.2f%% (%s / %s)", percentUsed, appliancepkg.PrettyBytes(float64(used)), appliancepkg.PrettyBytes(float64(total)))
 	return r
-}
-
-func prettyBytes(v float64) string {
-	for _, unit := range []string{"", "K", "M", "G", "T", "P", "E", "Z"} {
-		if math.Abs(float64(v)) < 1024.0 {
-			return fmt.Sprintf("%.2f%sB", v, unit)
-		}
-		v /= 1024.0
-	}
-	return fmt.Sprintf("%.2fYB", v)
 }
 
 const na = "n/a"

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -245,7 +245,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	}
 
 	if hasLowDiskSpace := appliancepkg.HasLowDiskSpace(initialStats.GetData()); len(hasLowDiskSpace) > 0 {
-		appliancepkg.PrintDiskSpaceWarningMessage(opts.Out, hasLowDiskSpace)
+		appliancepkg.PrintDiskSpaceWarningMessage(opts.Out, hasLowDiskSpace, opts.Config.Version)
 		if !opts.NoInteractive {
 			if err := prompt.AskConfirmation(); err != nil {
 				return err

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -260,7 +260,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	}
 
 	if hasLowDiskSpace := appliancepkg.HasLowDiskSpace(initialStats.GetData()); len(hasLowDiskSpace) > 0 {
-		appliancepkg.PrintDiskSpaceWarningMessage(opts.Out, hasLowDiskSpace)
+		appliancepkg.PrintDiskSpaceWarningMessage(opts.Out, hasLowDiskSpace, opts.Config.Version)
 		if !opts.NoInteractive {
 			if err := prompt.AskConfirmation(); err != nil {
 				return err

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -24,8 +24,8 @@ func PrintDiskSpaceWarningMessage(out io.Writer, stats []openapi.StatsAppliances
 	p.AddHeader("Name", diskHeader)
 	for _, a := range stats {
 		diskUsage := fmt.Sprintf("%v%%", a.GetDisk())
-		if apiVersion >= 18 {
-			diskInfo := a.GetDiskInfo()
+		if v, ok := a.GetDiskInfoOk(); ok {
+			diskInfo := *v
 			used, total := diskInfo.GetUsed(), diskInfo.GetTotal()
 			percentUsed := (used / total) * 100
 			diskUsage = fmt.Sprintf("%.2f%% (%s / %s)", percentUsed, PrettyBytes(float64(used)), PrettyBytes(float64(total)))

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -764,4 +765,14 @@ func ShouldDisable(from, to *version.Version) bool {
 	}
 
 	return false
+}
+
+func PrettyBytes(v float64) string {
+	for _, unit := range []string{"", "K", "M", "G", "T", "P", "E", "Z"} {
+		if math.Abs(float64(v)) < 1024.0 {
+			return fmt.Sprintf("%.2f%sB", v, unit)
+		}
+		v /= 1024.0
+	}
+	return fmt.Sprintf("%.2fYB", v)
 }

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -611,9 +611,9 @@ func orderAppliances(appliances []openapi.Appliance, orderBy []string, descendin
 			sort.SliceStable(appliances, func(i, j int) bool { return appliances[i].GetName() < appliances[j].GetName() })
 		case "id":
 			sort.SliceStable(appliances, func(i, j int) bool { return appliances[i].GetId() < appliances[j].GetId() })
-		case "site":
+		case "site-id":
 			sort.SliceStable(appliances, func(i, j int) bool { return appliances[i].GetSite() < appliances[j].GetSite() })
-		case "site-name":
+		case "site-name", "site":
 			sort.SliceStable(appliances, func(i, j int) bool { return appliances[i].GetSiteName() < appliances[j].GetSiteName() })
 		case "hostname", "host":
 			sort.SliceStable(appliances, func(i, j int) bool { return appliances[i].GetHostname() < appliances[j].GetHostname() })


### PR DESCRIPTION
This implements a more detailed view of disk usage in `appliance stats` and in the disk space warning.

It uses the new `diskInfo` object provided by the appliance API since v18. If a lower version than v18 is used, the old disk info is shown instead.

Also contains a small change for the list ordering of appliances. Sorting by `site` now orders the list by site name (just as using `site-name` would) while ordering by site ID will require using the specific `site-id` keyword instead.

Fixes SA-19775