### PR TITLE
remove timeouts and tls handshake on http clients

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -60,7 +60,6 @@ type prepareUpgradeOptions struct {
 
 // NewPrepareUpgradeCmd return a new prepare upgrade command
 func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
-	f.Config.Timeout = 300
 	opts := &prepareUpgradeOptions{
 		Config:     f.Config,
 		Appliance:  f.Appliance,

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -32,7 +32,6 @@ type Config struct {
 	ExpiresAt           *string `mapstructure:"expires_at"`
 	DeviceID            string  `mapstructure:"device_id"`
 	PemFilePath         string  `mapstructure:"pem_filepath"`
-	Timeout             int     // HTTP timeout, not supported in the config file.
 	DisableVersionCheck bool    `mapstructure:"disable_version_check"`
 	LastVersionCheck    string  `mapstructure:"last_version_check"`
 }


### PR DESCRIPTION
This fix will prevent file upload from timing out on slow connections by removing any timeouts set on the http clients used in sdpctl.

Timeouts on commands are mainly handled by setting a timeout on the context anyway, but uploading a file will never timeout since it does not use a timeout on the context.

Fixes SA21447