### PR TITLE
LogServer image bundling

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,9 @@ builds:
         - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ if .Tag }}{{ .Tag }}{{ else }}dev{{ end }}"
         - -X "github.com/appgate/sdpctl/cmd.commit={{ .FullCommit }}"
         - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
+        - -X "github.com/appgate/sdpctl/cmd/appliance/upgrade.dockerRegistry={{ .Env.DOCKER_REGISTRY_URL }}"
+        - -X "github.com/appgate/sdpctl/cmd/appliance/upgrade.dockerRegistryUsername={{ .Env.DOCKER_REGISTRY_USERNAME }}"
+        - -X "github.com/appgate/sdpctl/cmd/appliance/upgrade.dockerRegistryPassword={{ .Env.DOCKER_REGISTRY_PASSWORD }}"
     id: linux
     goos: [linux]
     goarch: [amd64, arm64]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,8 +21,6 @@ builds:
         - -X "github.com/appgate/sdpctl/cmd.commit={{ .FullCommit }}"
         - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
         - -X "github.com/appgate/sdpctl/cmd/appliance/upgrade.dockerRegistry={{ .Env.DOCKER_REGISTRY_URL }}"
-        - -X "github.com/appgate/sdpctl/cmd/appliance/upgrade.dockerRegistryUsername={{ .Env.DOCKER_REGISTRY_USERNAME }}"
-        - -X "github.com/appgate/sdpctl/cmd/appliance/upgrade.dockerRegistryPassword={{ .Env.DOCKER_REGISTRY_PASSWORD }}"
     id: linux
     goos: [linux]
     goarch: [amd64, arm64]

--- a/cmd/appliance/force_disable_controller.go
+++ b/cmd/appliance/force_disable_controller.go
@@ -276,7 +276,7 @@ func forceDisableControllerRunE(opts cmdOpts, args []string) error {
 		if len(disableList) > 1 {
 			msg += "s"
 		}
-		t = p.AddTracker(msg, "done")
+		t = p.AddTracker(msg, "waiting", "done")
 		go func(t *tui.Tracker) {
 			t.Watch([]string{"done"}, []string{})
 		}(t)

--- a/cmd/appliance/upgrade/cancel.go
+++ b/cmd/appliance/upgrade/cancel.go
@@ -164,7 +164,7 @@ func upgradeCancelRun(cmd *cobra.Command, args []string, opts *upgradeCancelOpti
 		for _, appliance := range appliances {
 			var t *tui.Tracker
 			if !opts.ciMode {
-				t = bars.AddTracker(appliance.GetName(), "cancelled")
+				t = bars.AddTracker(appliance.GetName(), "waiting", "cancelled")
 				go t.Watch(appliancepkg.StatusNotBusy, undesiredStatus)
 			}
 			qs := queueStruct{

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -541,7 +541,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			if !opts.ciMode {
 				primaryControllerBars = tui.New(ctx, spinnerOut)
 				defer primaryControllerBars.Wait()
-				t = primaryControllerBars.AddTracker(controller.GetName(), "upgraded")
+				t = primaryControllerBars.AddTracker(controller.GetName(), "waiting", "upgraded")
 				go t.Watch(appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed})
 			}
 
@@ -601,7 +601,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 				logEntry.Info("checking if ready")
 				var t *tui.Tracker
 				if !opts.ciMode {
-					t = p.AddTracker(i.GetName(), "upgraded")
+					t = p.AddTracker(i.GetName(), "waiting", "upgraded")
 					go t.Watch(appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed})
 				}
 				if !util.InSlice(i.GetName(), toReboot) {
@@ -715,7 +715,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 
 			var t *tui.Tracker
 			if !opts.ciMode && p != nil {
-				t = p.AddTracker(controller.GetName(), "upgraded")
+				t = p.AddTracker(controller.GetName(), "waiting", "upgraded")
 				go t.Watch(appliancepkg.StatReady, []string{appliancepkg.UpgradeStatusFailed})
 			}
 			err := backoff.Retry(func() error {

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -116,7 +116,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			}
 
 			// Get the docker registry address
-			if flagRegistry, err := cmd.Flags().GetString("docker-registry"); err == nil && len(flagRegistry) <= 0 {
+			if flagRegistry, err := cmd.Flags().GetString("docker-registry"); err == nil && len(flagRegistry) > 0 {
 				opts.dockerRegistry = flagRegistry
 			}
 			if envRegistry := os.Getenv("SDPCTL_DOCKER_REGISTRY"); len(envRegistry) > 0 {

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -494,7 +494,6 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				return err
 			}
 			os.Remove(zipPath)
-			fmt.Fprintln(opts.Out)
 		} else {
 			fmt.Fprint(opts.Out, "LogServer image already exists on appliance. Skipping\n\n")
 		}
@@ -554,7 +553,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			"Content-Disposition": fmt.Sprintf("attachment; filename=%q", fileStat.Name()),
 		}
 
-		fmt.Fprintf(opts.Out, "[%s] Uploading upgrade image:\n", time.Now().Format(time.RFC3339))
+		fmt.Fprintf(opts.Out, "\n[%s] Uploading upgrade image:\n", time.Now().Format(time.RFC3339))
 		if !opts.ciMode {
 			err = uploadWithProgress(ctx, pr, fileStat.Name(), fileStat.Size(), headers)
 		} else {

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -124,7 +124,15 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 				opts.dockerRegistry = envRegistry
 			}
 			if len(opts.dockerRegistry) <= 0 {
-				return errors.New("no docker registry URL found")
+				return errors.New("no docker registry URL found. Please set the 'SDPCTL_DOCKER_REGISTRY' environment variable.")
+			}
+			normalized, err := util.NormalizeURL(opts.dockerRegistry)
+			if err != nil {
+				return err
+			}
+			opts.dockerRegistry = normalized.String()
+			if !util.IsValidURL(opts.dockerRegistry) {
+				return fmt.Errorf("%s is not a valid URL", opts.dockerRegistry)
 			}
 			log.WithField("URL", opts.dockerRegistry).Debug("found docker registry address")
 

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -116,21 +116,14 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			}
 
 			// Get the docker registry address
+			if flagRegistry, err := cmd.Flags().GetString("docker-registry"); err == nil && len(flagRegistry) <= 0 {
+				opts.dockerRegistry = flagRegistry
+			}
 			if envRegistry := os.Getenv("SDPCTL_DOCKER_REGISTRY"); len(envRegistry) > 0 {
 				opts.dockerRegistry = envRegistry
 			}
 			if len(opts.dockerRegistry) <= 0 {
-				opts.dockerRegistry, err = cmd.Flags().GetString("docker-registry")
-				if err != nil {
-					return err
-				}
-				if len(opts.dockerRegistry) <= 0 {
-					if len(dockerRegistry) > 0 {
-						opts.dockerRegistry = dockerRegistry
-					} else {
-						return errors.New("no docker registry address found")
-					}
-				}
+				return errors.New("no docker registry URL found")
 			}
 			log.WithField("URL", opts.dockerRegistry).Debug("found docker registry address")
 

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -451,7 +451,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}
 
 		fmt.Fprintln(opts.Out, "Downloading image layers for LogServer:")
-		logServerZipName := fmt.Sprintf("logserver-%s", opts.targetVersion.String())
+		logServerZipName := fmt.Sprintf("logserver-%s.zip", util.ApplianceVersionString(opts.targetVersion))
 		zipFile, zipInfo, err := appliancepkg.DownloadDockerBundles(ctx, spinnerOut, client, logServerZipName, opts.dockerRegistry, logServerImages, opts.ciMode)
 		if err != nil {
 			return err

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -451,7 +451,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}
 
 		fmt.Fprintln(opts.Out, "Downloading image layers for LogServer:")
-		logServerZipName := fmt.Sprintf("logserver-%s.zip", util.ApplianceVersionString(opts.targetVersion))
+		logServerZipName := fmt.Sprintf("logserver-%s", util.ApplianceVersionString(opts.targetVersion))
 		zipFile, zipInfo, err := appliancepkg.DownloadDockerBundles(ctx, spinnerOut, client, logServerZipName, opts.dockerRegistry, logServerImages, opts.ciMode)
 		if err != nil {
 			return err

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -473,22 +473,8 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			"Content-Type":        writer.FormDataContentType(),
 			"Content-Disposition": fmt.Sprintf("attachment; filename=%q", zipInfo.Name()),
 		}
-		var p *tui.Progress
-		var t *tui.Tracker
-		if !opts.ciMode {
-			p = tui.New(ctx, spinnerOut)
-			t = p.AddTracker("uploading images", "waiting", "uploaded")
-			go t.Watch([]string{"uploaded"}, []string{"failed"})
-		}
 		if err := a.UploadFile(ctx, pr, headers); err != nil {
-			if !opts.ciMode {
-				t.Fail(err.Error())
-			}
 			return err
-		}
-		if !opts.ciMode {
-			t.Update("uploaded")
-			p.Wait()
 		}
 		fmt.Fprint(opts.Out, "image bundles prepared\n\n")
 	}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -451,8 +451,8 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}
 
 		fmt.Fprintln(opts.Out, "Downloading image layers for LogServer:")
-		logServerZipName := fmt.Sprintf("logserver-%s", util.ApplianceVersionString(opts.targetVersion))
-		zipFile, zipInfo, err := appliancepkg.DownloadDockerBundles(ctx, spinnerOut, client, logServerZipName, opts.dockerRegistry, logServerImages, opts.ciMode)
+		logServerZipName := fmt.Sprintf("logserver-%s.zip", util.ApplianceVersionString(opts.targetVersion))
+		zipFile, _, err := appliancepkg.DownloadDockerBundles(ctx, spinnerOut, client, logServerZipName, opts.dockerRegistry, logServerImages, opts.ciMode)
 		if err != nil {
 			return err
 		}
@@ -464,7 +464,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			defer pw.Close()
 			defer writer.Close()
 
-			part, err := writer.CreateFormFile("file", zipFile.Name())
+			part, err := writer.CreateFormFile("file", logServerZipName)
 			if err != nil {
 				log.Warnf("multipart form err %s", err)
 				return
@@ -479,7 +479,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 
 		headers := map[string]string{
 			"Content-Type":        writer.FormDataContentType(),
-			"Content-Disposition": fmt.Sprintf("attachment; filename=%q", zipInfo.Name()),
+			"Content-Disposition": fmt.Sprintf("attachment; filename=%q", logServerZipName),
 		}
 		if err := a.UploadFile(ctx, pr, headers); err != nil {
 			return err

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -413,6 +413,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		defer p.Wait()
 		endMsg := "uploaded"
 		proxyReader, t := p.FileUploadProgress(name, endMsg, size, reader)
+		defer proxyReader.Close()
 		go t.Watch([]string{endMsg}, []string{"failed"})
 		log.WithField("file", name).Info("Uploading file")
 		if err = a.UploadFile(ctx, proxyReader, headers); err != nil {

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -489,7 +489,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				return
 			}
 		}()
-		
+
 		headers := map[string]string{
 			"Content-Type":        writer.FormDataContentType(),
 			"Content-Disposition": fmt.Sprintf("attachment; filename=%q", zipInfo.Name()),

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -116,6 +116,9 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			}
 
 			// Get the docker registry address
+			if len(dockerRegistry) > 0 {
+				opts.dockerRegistry = dockerRegistry
+			}
 			if flagRegistry, err := cmd.Flags().GetString("docker-registry"); err == nil && len(flagRegistry) > 0 {
 				opts.dockerRegistry = flagRegistry
 			}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -38,8 +38,9 @@ import (
 )
 
 var (
-	dockerRegistry  string
-	logServerImages map[string]string = map[string]string{
+	// Set at build time or in env varibales
+	dockerRegistry, dockerRegistryUsername, dockerRegistryPassword string
+	logServerImages                                                map[string]string = map[string]string{
 		"cz-opensearch":           "latest",
 		"cz-opensearchdashboards": "latest",
 	}
@@ -67,11 +68,6 @@ type prepareUpgradeOptions struct {
 	targetVersion    *version.Version
 	dockerRegistry   string
 }
-
-var (
-	// Set at build time or in env varibales
-	dockerRegistryUsername, dockerRegistryPassword string
-)
 
 // NewPrepareUpgradeCmd return a new prepare upgrade command
 func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
@@ -120,7 +116,9 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			}
 
 			// Get the docker registry address
-			opts.dockerRegistry = os.Getenv("SDPCTL_DOCKER_REGISTRY")
+			if envRegistry := os.Getenv("SDPCTL_DOCKER_REGISTRY"); len(envRegistry) > 0 {
+				opts.dockerRegistry = envRegistry
+			}
 			if len(opts.dockerRegistry) <= 0 {
 				opts.dockerRegistry, err = cmd.Flags().GetString("docker-registry")
 				if err != nil {

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -56,7 +57,7 @@ func NewApplianceCmd(f *factory.Factory) *cobra.Command {
 }
 
 func TestUpgradePrepareCommand(t *testing.T) {
-
+	os.Setenv("SDPCTL_DOCKER_REGISTRY", "https://localhost:5001")
 	tests := []struct {
 		name                string
 		cli                 string

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -722,8 +722,9 @@ func Test_showPrepareUpgradeMessage(t *testing.T) {
 			},
 			want: `PREPARE SUMMARY
 
-1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
-2. Prepare upgrade on the following appliances:
+1. Bundle and upload LogServer docker image if needed
+2. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
+3. Prepare upgrade on the following appliances:
 
   Appliance      Online    Current version    Prepare version
   ---------      ------    ---------------    ---------------
@@ -782,8 +783,9 @@ The following appliances will be skipped:
 			},
 			want: `PREPARE SUMMARY
 
-1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
-2. Prepare upgrade on the following appliances:
+1. Bundle and upload LogServer docker image if needed
+2. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
+3. Prepare upgrade on the following appliances:
 
   Appliance      Online    Current version    Prepare version
   ---------      ------    ---------------    ---------------
@@ -835,8 +837,9 @@ The following appliances will be skipped:
 			},
 			want: `PREPARE SUMMARY
 
-1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
-2. Prepare upgrade on the following appliances:
+1. Bundle and upload LogServer docker image if needed
+2. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
+3. Prepare upgrade on the following appliances:
 
   Appliance      Online    Current version    Prepare version
   ---------      ------    ---------------    ---------------

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -646,6 +646,7 @@ func Test_showPrepareUpgradeMessage(t *testing.T) {
 		skip                          []appliancepkg.SkipUpgrade
 		stats                         []openapi.StatsAppliancesListAllOfData
 		multiControllerUpgradeWarning bool
+		dockerBundleDownload          bool
 	}
 	tests := []struct {
 		name    string
@@ -722,9 +723,8 @@ func Test_showPrepareUpgradeMessage(t *testing.T) {
 			},
 			want: `PREPARE SUMMARY
 
-1. Bundle and upload LogServer docker image if needed
-2. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
-3. Prepare upgrade on the following appliances:
+1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
+2. Prepare upgrade on the following appliances:
 
   Appliance      Online    Current version    Prepare version
   ---------      ------    ---------------    ---------------
@@ -783,9 +783,8 @@ The following appliances will be skipped:
 			},
 			want: `PREPARE SUMMARY
 
-1. Bundle and upload LogServer docker image if needed
-2. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
-3. Prepare upgrade on the following appliances:
+1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
+2. Prepare upgrade on the following appliances:
 
   Appliance      Online    Current version    Prepare version
   ---------      ------    ---------------    ---------------
@@ -837,9 +836,8 @@ The following appliances will be skipped:
 			},
 			want: `PREPARE SUMMARY
 
-1. Bundle and upload LogServer docker image if needed
-2. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
-3. Prepare upgrade on the following appliances:
+1. Upload upgrade image appgate-6.0.0-29426-release.img.zip to Controller
+2. Prepare upgrade on the following appliances:
 
   Appliance      Online    Current version    Prepare version
   ---------      ------    ---------------    ---------------
@@ -854,14 +852,79 @@ A partial major or minor controller upgrade is not supported. The upgrade will f
 controllers are prepared for upgrade when running 'upgrade complete'.
 `,
 		},
+		{
+			name: "prepare >=6.2 appliance with log server",
+			args: args{
+				f:                    "appgate-6.2.0-89012-release.img.zip",
+				dockerBundleDownload: true,
+				appliance: []openapi.Appliance{
+					{
+						Id:   openapi.PtrString("d4dc0b97-ef59-4431-871b-6b214099797a"),
+						Name: "controller1",
+					},
+					{
+						Id:   openapi.PtrString("3f6f9e42-33c3-446c-9e0d-855c7d5b933b"),
+						Name: "controller2",
+					},
+					{
+						Id:   openapi.PtrString("8a064b81-c692-46ae-b0fa-c4661a018f24"),
+						Name: "gateway",
+					},
+					{
+						Id:   openapi.PtrString("3ab2caf1-2a6a-4e2c-a848-268d402492a1"),
+						Name: "logserver",
+					},
+				},
+				stats: []openapi.StatsAppliancesListAllOfData{
+					{
+						Id:      openapi.PtrString("d4dc0b97-ef59-4431-871b-6b214099797a"),
+						Name:    openapi.PtrString("controller1"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("6.1.0+56789"),
+					},
+					{
+						Id:      openapi.PtrString("3f6f9e42-33c3-446c-9e0d-855c7d5b933b"),
+						Name:    openapi.PtrString("controller2"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("6.1.0+56789"),
+					},
+					{
+						Id:      openapi.PtrString("8a064b81-c692-46ae-b0fa-c4661a018f24"),
+						Name:    openapi.PtrString("gateway"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("6.1.0+56789"),
+					},
+					{
+						Id:      openapi.PtrString("3ab2caf1-2a6a-4e2c-a848-268d402492a1"),
+						Name:    openapi.PtrString("logserver"),
+						Online:  openapi.PtrBool(true),
+						Version: openapi.PtrString("6.1.0+56789"),
+					},
+				},
+			},
+			want: `PREPARE SUMMARY
+
+1. Bundle and upload LogServer docker image
+2. Upload upgrade image appgate-6.2.0-89012-release.img.zip to Controller
+3. Prepare upgrade on the following appliances:
+
+  Appliance      Online    Current version    Prepare version
+  ---------      ------    ---------------    ---------------
+  controller1    ✓         6.1.0+56789        6.2.0+89012
+  controller2    ✓         6.1.0+56789        6.2.0+89012
+  gateway        ✓         6.1.0+56789        6.2.0+89012
+  logserver      ✓         6.1.0+56789        6.2.0+89012
+
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prepareVersion, err := appliancepkg.ParseVersionString("6.0.0-29426-release.img.zip")
+			prepareVersion, err := appliancepkg.ParseVersionString(tt.args.f)
 			if err != nil {
 				t.Fatalf("internal test error: %v", err)
 			}
-			got, err := showPrepareUpgradeMessage(tt.args.f, prepareVersion, tt.args.appliance, tt.args.skip, tt.args.stats, tt.args.multiControllerUpgradeWarning)
+			got, err := showPrepareUpgradeMessage(tt.args.f, prepareVersion, tt.args.appliance, tt.args.skip, tt.args.stats, tt.args.multiControllerUpgradeWarning, tt.args.dockerBundleDownload)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("showPrepareUpgradeMessage() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -92,7 +92,7 @@ func configRun(cmd *cobra.Command, args []string, opts *configureOptions) error 
 		}
 		viper.Set("pem_filepath", opts.PEM)
 	}
-	u, err := configuration.NormalizeURL(opts.URL)
+	u, err := configuration.NormalizeConfigurationURL(opts.URL)
 	if err != nil {
 		return fmt.Errorf("Could not determine URL for %s %s", opts.URL, err)
 	}

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -102,6 +102,8 @@ Available Variables:
   SDPCTL_DISABLE_VERSION_CHECK:
     Description: Disable version checking when running commands
     Options: true, false
+  SDPCTL_DOCKER_REGISTRY:
+    Description: Custom docker registry for downloading function docker images. Needs to be accessible by the sdpctl host machine.
   HTTP_PROXY:
     Description: HTTP Proxy for the client
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -21,7 +21,7 @@ func NewOpenCmd(f *factory.Factory) *cobra.Command {
 		},
 		Short: "Open the Admin UI in your browser",
 		RunE: func(c *cobra.Command, args []string) error {
-			addr, err := configuration.NormalizeURL(f.Config.URL)
+			addr, err := configuration.NormalizeConfigurationURL(f.Config.URL)
 			if err != nil {
 				return fmt.Errorf("Could not normalize addr %w", err)
 			}

--- a/docs/sdpctl_appliance_upgrade_prepare.html
+++ b/docs/sdpctl_appliance_upgrade_prepare.html
@@ -44,6 +44,7 @@ the upgrade image using the provided URL. It will fail if the Appliances cannot 
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
 <pre class="code-editor margin-bottom"><code>      --actual-hostname string   If the actual hostname is different from that which you are connecting to the appliance admin API, this flag can be used for setting the actual hostname
       --dev-keyring              Use the development keyring to verify the upgrade image
+      --docker-registry string   Custom docker registry for downloading function docker images. Needs to be accessible by the sdpctl host machine.
       --force                    Force prepare of upgrade on appliances even though the version uploaded is the same or lower than the version already running on the appliance
   -h, --help                     help for prepare
       --host-on-controller       Use the primary Controller as image host when uploading from remote source

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -194,6 +194,9 @@ func (a *Appliance) UploadFile(ctx context.Context, r io.Reader, headers map[str
 		return api.HTTPErrorResponse(response, err)
 	}
 	defer response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		return api.HTTPErrorResponse(response, err)
+	}
 	return nil
 }
 

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -293,7 +293,7 @@ func PerformBackup(cmd *cobra.Command, args []string, opts *BackupOpts) (map[str
 	}
 
 	for _, a := range toBackup {
-		t := progressBars.AddTracker(a.GetName(), "download complete")
+		t := progressBars.AddTracker(a.GetName(), "waiting", "download complete")
 		go t.Watch([]string{"download complete"}, []string{backup.Failure})
 		go func(appliance openapi.Appliance, tracker *tui.Tracker) {
 			defer wg.Done()

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -989,7 +989,7 @@ func downloadDockerImageBundle(args imageBundleArgs) {
 
 	// Create image.json
 	// It provides repository/image/tag information for arc
-	// Example: { "image": "lhr-nexus.agi.appgate.com:5001/aitorbot:latest" }
+	// Example: { "image": "docker-registry-url:5001/aitorbot:latest" }
 	imageJSON := ImageJSON{
 		Image: fmt.Sprintf("%s/%s:%s", args.registry.Host, args.image, args.tag),
 	}

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -828,7 +828,7 @@ type imageBundleArgs struct {
 
 func DownloadDockerBundles(ctx context.Context, out io.Writer, client *http.Client, zipName, registry string, images map[string]string, ciMode bool) (*os.File, fs.FileInfo, error) {
 	// Create zip-archive
-	archive, err := os.CreateTemp("", fmt.Sprintf("%s.zip", zipName))
+	archive, err := os.CreateTemp("", zipName)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
+	"github.com/vbauerster/mpb/v7"
 )
 
 const (
@@ -886,7 +887,7 @@ func DownloadDockerBundle(ctx context.Context, out io.Writer, client *http.Clien
 			bodyReader := layerRes.Body
 			if p != nil {
 				size := layerRes.ContentLength
-				bodyReader = p.FileDownloadProgress(f[0:7], "downloaded", size, 25, bodyReader)
+				bodyReader = p.FileDownloadProgress(f[0:7], "downloaded", size, 25, bodyReader, mpb.BarRemoveOnComplete())
 			}
 
 			buf := &bytes.Buffer{}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -128,19 +127,13 @@ func NeedUpdatedAPIVersionConfig(cmd *cobra.Command) bool {
 
 var ErrNoAddr = errors.New("No valid address set, run 'sdpctl configure' or set SDPCTL_URL")
 
-func NormalizeURL(u string) (string, error) {
+func NormalizeConfigurationURL(u string) (string, error) {
 	if len(u) <= 0 {
 		return "", ErrNoAddr
 	}
-	if r := regexp.MustCompile(`^https?://`); !r.MatchString(u) {
-		u = fmt.Sprintf("https://%s", u)
-	}
-	url, err := url.ParseRequestURI(u)
+	url, err := util.NormalizeURL(u)
 	if err != nil {
 		return "", err
-	}
-	if url.Scheme != "https" {
-		url.Scheme = "https"
 	}
 	if len(url.Port()) <= 0 {
 		url.Host = fmt.Sprintf("%s:%d", url.Hostname(), 8443)

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -225,7 +225,7 @@ func TestNormalizeURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			result, err := NormalizeURL(tt.URL)
+			result, err := NormalizeConfigurationURL(tt.URL)
 			if err != nil && !tt.err {
 				t.Fatalf("Test failed. Error: %v", err)
 			}

--- a/pkg/factory/http.go
+++ b/pkg/factory/http.go
@@ -183,7 +183,7 @@ func apiClientFunc(f *Factory) func(c *configuration.Config) (*openapi.APIClient
 			return nil, err
 		}
 
-		cfg.URL, err = configuration.NormalizeURL(cfg.URL)
+		cfg.URL, err = configuration.NormalizeConfigurationURL(cfg.URL)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/factory/http.go
+++ b/pkg/factory/http.go
@@ -27,6 +27,8 @@ type Factory struct {
 	// the custom HTTP client includes the default transport layer to import TLS certificate
 	// and applies Accept, Authorization, and User-Agent headers to all requests
 	CustomHTTPClient func() (*http.Client, error)
+	// BasicAuthClient is used when communicating with third party API:s that need basic authentication
+	BasicAuthClient func(username, password string) (*http.Client, error)
 	// HTTPTransport is used by all HTTP Clients to import custom TLS certificate and set timeout values
 	HTTPTransport func() (*http.Transport, error)
 	// APIClient is the generated api client based on the openapi-generator https://github.com/appgate/sdp-api-client-go
@@ -50,6 +52,7 @@ func New(appVersion string, config *configuration.Config) *Factory {
 	f.HTTPTransport = httpTransport(f)       // depends on config
 	f.HTTPClient = httpClientFunc(f)         // depends on config
 	f.CustomHTTPClient = customHTTPClient(f) // depends on config
+	f.BasicAuthClient = basicAuthClient(f)   // depends on config
 	f.APIClient = apiClientFunc(f)           // depends on config
 	f.Appliance = applianceFunc(f)           // depends on config
 	f.Token = tokenFunc(f)                   // depends on config
@@ -158,6 +161,51 @@ func customHTTPClient(f *Factory) func() (*http.Client, error) {
 			accept:              fmt.Sprintf("application/vnd.appgate.peer-v%d+json", cfg.Version),
 			useragent:           f.userAgent,
 			underlyingTransport: parentTransport,
+		}
+		return client, nil
+	}
+}
+
+type basicAuthTransport struct {
+	username, password, useragent, accept string
+	underlyingTransport                   http.RoundTripper
+}
+
+func (bat basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("User-Agent", bat.useragent)
+	req.Header.Add("Accept", bat.accept)
+	req.SetBasicAuth(bat.username, bat.password)
+
+	// overwrite Accept header if we have anything in the context
+	if accept, ok := req.Context().Value(ContextAcceptValue).(string); ok {
+		req.Header.Set("Accept", accept)
+	}
+
+	return bat.underlyingTransport.RoundTrip(req)
+}
+
+func basicAuthClient(f *Factory) func(username, password string) (*http.Client, error) {
+	return func(username, password string) (*http.Client, error) {
+		client, err := f.HTTPClient()
+		if err != nil {
+			return nil, err
+		}
+		parentTransport, err := f.HTTPTransport()
+		if err != nil {
+			return nil, err
+		}
+		if u := os.Getenv("SDPCTL_DOCKER_REGISTRY_USERNAME"); len(u) > 0 {
+			username = u
+		}
+		if p := os.Getenv("SDPCTL_DOCKER_REGISTRY_PASSWORD"); len(p) > 0 {
+			password = p
+		}
+		client.Transport = basicAuthTransport{
+			underlyingTransport: parentTransport,
+			username:            username,
+			password:            password,
+			useragent:           f.userAgent,
+			accept:              fmt.Sprintf("application/vnd.appgate.peer-v%d+json", f.Config.Version),
 		}
 		return client, nil
 	}

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/vbauerster/mpb/v7"
+	"github.com/vbauerster/mpb/v7/decor"
 )
 
 type Progress struct {
@@ -30,8 +31,50 @@ func New(ctx context.Context, out io.Writer, options ...mpb.ContainerOption) *Pr
 
 // AddTracker will add a status tracker to the appliance
 // the returned channel is to be used by other functions to update the tracker progress
-func (p *Progress) AddTracker(name, endMsg string) *Tracker {
+func (p *Progress) AddTracker(name, state, endMsg string, opts ...mpb.BarOption) *Tracker {
 	t := Tracker{
+		container:    p,
+		name:         name,
+		current:      state,
+		endMsg:       endMsg,
+		statusReport: make(chan string, 1),
+		failReason:   make(chan string, 1),
+	}
+
+	t.mu.Lock()
+	barOptions := []mpb.BarOption{
+		mpb.AppendDecorators(t.decoratorFunc(t.name)),
+		mpb.BarFillerMiddleware(t.barFillerFunc()),
+	}
+	barOptions = append(barOptions, opts...)
+	t.bar = p.pc.New(1,
+		mpb.SpinnerStyle(SpinnerStyle...),
+		barOptions...,
+	)
+	t.mu.Unlock()
+
+	p.trackers = append(p.trackers, &t)
+	return &t
+}
+
+func (p *Progress) FileUploadProgress(name, endMsg string, size int64, reader io.Reader) (io.Reader, *Tracker) {
+	bar := p.pc.AddBar(
+		size,
+		mpb.BarWidth(50),
+		mpb.BarFillerOnComplete(endMsg),
+		mpb.PrependDecorators(
+			decor.Spinner(SpinnerStyle, decor.WC{W: 2}),
+			decor.Name(name, decor.WC{W: len(name) + 1}),
+		),
+		mpb.AppendDecorators(
+			decor.OnComplete(decor.CountersKibiByte("% .2f / % .2f"), ""),
+			decor.OnComplete(decor.Name(" | "), ""),
+			decor.OnComplete(decor.AverageSpeed(decor.UnitKiB, "% .2f"), ""),
+		),
+	)
+
+	t := Tracker{
+		bar:          bar,
 		container:    p,
 		name:         name,
 		current:      "waiting",
@@ -39,17 +82,29 @@ func (p *Progress) AddTracker(name, endMsg string) *Tracker {
 		statusReport: make(chan string, 1),
 		failReason:   make(chan string, 1),
 	}
-
-	t.mu.Lock()
-	t.bar = p.pc.New(1,
-		mpb.SpinnerStyle(SpinnerStyle...),
-		mpb.AppendDecorators(t.decoratorFunc(t.name)),
-		mpb.BarFillerMiddleware(t.barFillerFunc()),
-	)
-	t.mu.Unlock()
-
 	p.trackers = append(p.trackers, &t)
-	return &t
+
+	qt := p.AddTracker(name, "waiting for server ok", endMsg, mpb.BarQueueAfter(bar, true))
+
+	return bar.ProxyReader(reader), qt
+}
+
+func (p *Progress) FileDownloadProgress(name, endMsg string, size int64, width int, reader io.Reader) io.ReadCloser {
+	bar := p.pc.AddBar(
+		size,
+		mpb.BarWidth(width),
+		mpb.BarFillerOnComplete(endMsg),
+		mpb.PrependDecorators(
+			decor.OnComplete(decor.Spinner(SpinnerStyle, decor.WC{W: 2}), Check),
+			decor.Name(name, decor.WC{W: len(name) + 1}),
+		),
+		mpb.AppendDecorators(
+			decor.OnComplete(decor.CountersKibiByte("% .2f / % .2f"), ""),
+			decor.OnComplete(decor.Name(" | "), ""),
+			decor.OnComplete(decor.AverageSpeed(decor.UnitKiB, "% .2f"), ""),
+		),
+	)
+	return bar.ProxyReader(reader)
 }
 
 // Complete will complete all currently active trackers and wait for them to finish before returning

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -57,7 +57,7 @@ func (p *Progress) AddTracker(name, state, endMsg string, opts ...mpb.BarOption)
 	return &t
 }
 
-func (p *Progress) FileUploadProgress(name, endMsg string, size int64, reader io.Reader) (io.Reader, *Tracker) {
+func (p *Progress) FileUploadProgress(name, endMsg string, size int64, reader io.Reader) (io.ReadCloser, *Tracker) {
 	bar := p.pc.AddBar(
 		size,
 		mpb.BarWidth(50),

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -89,9 +89,8 @@ func (p *Progress) FileUploadProgress(name, endMsg string, size int64, reader io
 	return bar.ProxyReader(reader), qt
 }
 
-func (p *Progress) FileDownloadProgress(name, endMsg string, size int64, width int, reader io.Reader) io.ReadCloser {
-	bar := p.pc.AddBar(
-		size,
+func (p *Progress) FileDownloadProgress(name, endMsg string, size int64, width int, reader io.Reader, opts ...mpb.BarOption) io.ReadCloser {
+	barOpts := []mpb.BarOption{
 		mpb.BarWidth(width),
 		mpb.BarFillerOnComplete(endMsg),
 		mpb.PrependDecorators(
@@ -103,6 +102,13 @@ func (p *Progress) FileDownloadProgress(name, endMsg string, size int64, width i
 			decor.OnComplete(decor.Name(" | "), ""),
 			decor.OnComplete(decor.AverageSpeed(decor.UnitKiB, "% .2f"), ""),
 		),
+	}
+	if len(opts) > 0 {
+		barOpts = append(barOpts, opts...)
+	}
+	bar := p.pc.AddBar(
+		size,
+		barOpts...,
 	)
 	return bar.ProxyReader(reader)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"regexp"
@@ -93,6 +94,23 @@ func IsValidURL(addr string) bool {
 		return false
 	}
 	return true
+}
+
+func NormalizeURL(u string) (*url.URL, error) {
+	if len(u) <= 0 {
+		return nil, errors.New("no address set")
+	}
+	if r := regexp.MustCompile(`^https?://`); !r.MatchString(u) {
+		u = fmt.Sprintf("https://%s", u)
+	}
+	url, err := url.ParseRequestURI(u)
+	if err != nil {
+		return nil, err
+	}
+	if url.Scheme != "https" {
+		url.Scheme = "https"
+	}
+	return url, nil
 }
 
 func ParseFilteringFlags(flags *pflag.FlagSet, defaultFilter map[string]map[string]string) (map[string]map[string]string, []string, bool) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-version"
 	"github.com/spf13/pflag"
 )
 
@@ -156,4 +157,13 @@ func Reverse[S ~[]T, T any](items S) S {
 		result = append(result, items[i])
 	}
 	return result
+}
+
+func ApplianceVersionString(v *version.Version) string {
+	segments := v.Segments()
+	preString := v.Prerelease()
+	if len(preString) <= 0 {
+		preString = "release"
+	}
+	return fmt.Sprintf("%d.%d.%d-%s-%s", segments[0], segments[1], segments[2], v.Metadata(), preString)
 }


### PR DESCRIPTION
From appliance version 6.2, the LogServer function is decoupled from the base appliance image. Upgrading LogServer appliances will be done by downloading the required docker images for LogServer and uploading it to the Primary Controller, just like the base image is being uploaded already.

This PR will automatically pull the required LogServer images needed, pack them into a zip-file and upload it when running `upgrade prepare`.

Fixes: SA-21477 