### PR TITLE
Use image tag derived from upgrade version

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -440,7 +440,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			}
 		}
 		if !exists {
-			tagVersion := util.DockerTagVersion(opts.targetVersion)
+			tagVersion, err := util.DockerTagVersion(opts.targetVersion)
+			if err != nil {
+				return err
+			}
 			logServerImages := map[string]string{
 				"cz-opensearch":           tagVersion,
 				"cz-opensearchdashboards": tagVersion,

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -62,7 +62,6 @@ type prepareUpgradeOptions struct {
 	actualHostname   string
 	targetVersion    *version.Version
 	dockerRegistry   *url.URL
-	dockerTag        string
 }
 
 // NewPrepareUpgradeCmd return a new prepare upgrade command
@@ -131,10 +130,6 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 				return fmt.Errorf("%s is not a valid URL", opts.dockerRegistry)
 			}
 			log.WithField("URL", opts.dockerRegistry).Debug("found docker registry address")
-
-			if envTag := os.Getenv("SDPCTL_DOCKER_TAG"); len(envTag) > 0 {
-				opts.dockerTag = envTag
-			}
 
 			// allow remote addr for image, such as aws s3 bucket
 			if util.IsValidURL(opts.image) {
@@ -445,14 +440,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			}
 		}
 		if !exists {
-			segments := opts.targetVersion.Segments()
-			tagVersion := fmt.Sprintf("%d.%d", segments[0], segments[1])
-			if segments[2] > 0 {
-				tagVersion += fmt.Sprintf(".%d", segments[2])
-			}
-			if len(opts.dockerTag) > 0 {
-				tagVersion = opts.dockerTag
-			}
+			tagVersion := util.DockerTagVersion(opts.targetVersion)
 			logServerImages := map[string]string{
 				"cz-opensearch":           tagVersion,
 				"cz-opensearchdashboards": tagVersion,

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -104,6 +104,8 @@ Available Variables:
     Options: true, false
   SDPCTL_DOCKER_REGISTRY:
     Description: Custom docker registry for downloading function docker images. Needs to be accessible by the sdpctl host machine.
+  SDPCTL_DOCKER_TAG:
+    Description: Manually set a tag which will be used to try to pull downloadable docker images.
   HTTP_PROXY:
     Description: It will be used as the proxy URL for HTTP requests unless overridden by NoProxy.
   HTTPS_PROXY:

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -168,11 +168,14 @@ func ApplianceVersionString(v *version.Version) string {
 	return fmt.Sprintf("%d.%d.%d-%s-%s", segments[0], segments[1], segments[2], v.Metadata(), preString)
 }
 
-func DockerTagVersion(v *version.Version) string {
+func DockerTagVersion(v *version.Version) (string, error) {
 	if envTag := os.Getenv("SDPCTL_DOCKER_TAG"); len(envTag) > 0 {
-		return envTag
+		return envTag, nil
+	}
+	if v == nil {
+		return "", errors.New("DockerTagVersion() - version is nil")
 	}
 	segments := v.Segments()
 	tagVersion := fmt.Sprintf("%d.%d", segments[0], segments[1])
-	return tagVersion
+	return tagVersion, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -167,3 +167,12 @@ func ApplianceVersionString(v *version.Version) string {
 	}
 	return fmt.Sprintf("%d.%d.%d-%s-%s", segments[0], segments[1], segments[2], v.Metadata(), preString)
 }
+
+func DockerTagVersion(v *version.Version) string {
+	if envTag := os.Getenv("SDPCTL_DOCKER_TAG"); len(envTag) > 0 {
+		return envTag
+	}
+	segments := v.Segments()
+	tagVersion := fmt.Sprintf("%d.%d", segments[0], segments[1])
+	return tagVersion
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"os"
 	"reflect"
 	"testing"
 
@@ -157,10 +156,11 @@ func TestSearchSlice(t *testing.T) {
 
 func TestDockerTagVersion(t *testing.T) {
 	tests := []struct {
-		name string
-		env  string
-		v    string
-		want string
+		name    string
+		env     string
+		v       string
+		want    string
+		wantErr bool
 	}{
 		{
 			name: "version 6.2.0",
@@ -183,15 +183,27 @@ func TestDockerTagVersion(t *testing.T) {
 			env:  "latest",
 			want: "latest",
 		},
+		{
+			name:    "version is nil",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v, err := version.NewVersion(tt.v)
-			if err != nil {
-				t.Fatal(err)
+			var v *version.Version
+			var err error
+			if len(tt.v) > 0 {
+				v, err = version.NewVersion(tt.v)
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 			t.Setenv("SDPCTL_DOCKER_TAG", tt.env)
-			if got := DockerTagVersion(v); got != tt.want {
+			got, err := DockerTagVersion(v)
+			if err != nil && !tt.wantErr {
+				t.Errorf("DockerTagVersion() = %v, want no err", err)
+			}
+			if got != tt.want {
 				t.Errorf("DockerTagVersion() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,8 +1,11 @@
 package util
 
 import (
+	"os"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/go-version"
 )
 
 func TestIsValidURL(t *testing.T) {
@@ -147,6 +150,51 @@ func TestSearchSlice(t *testing.T) {
 			}
 			if got := SearchSlice(tt.args.needle, tt.args.haystack, tt.args.caseInsensitive); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("SearchSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDockerTagVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		v    string
+		want string
+	}{
+		{
+			name: "version 6.2.0",
+			v:    "6.2.0",
+			want: "6.2",
+		},
+		{
+			name: "version 6.2.1",
+			v:    "6.2.1",
+			want: "6.2",
+		},
+		{
+			name: "version 6.0.0",
+			v:    "6.0.0",
+			want: "6.0",
+		},
+		{
+			name: "override with env variable",
+			v:    "6.2.1",
+			env:  "latest",
+			want: "latest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := version.NewVersion(tt.v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(tt.env) > 0 {
+				os.Setenv("SDPCTL_DOCKER_TAG", tt.env)
+			}
+			if got := DockerTagVersion(v); got != tt.want {
+				t.Errorf("DockerTagVersion() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -190,9 +190,7 @@ func TestDockerTagVersion(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(tt.env) > 0 {
-				os.Setenv("SDPCTL_DOCKER_TAG", tt.env)
-			}
+			t.Setenv("SDPCTL_DOCKER_TAG", tt.env)
 			if got := DockerTagVersion(v); got != tt.want {
 				t.Errorf("DockerTagVersion() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Pulling docker image will try to pull an image tag derived from the upgrade version.

Tag is overridable by setting the `SDPCTL_DOCKER_TAG` environment variable when running the command.

Fixes: SA-21648