### PR TITLE
add authorization token for public ecr

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -132,7 +132,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			}
 			if !strings.HasPrefix(opts.dockerRegistry.Path, "/v2") {
 				// add 'v2' to path if it doesn't exist
-				opts.dockerRegistry.Path = "/v2"
+				opts.dockerRegistry.Path = "/v2" + opts.dockerRegistry.Path
 			}
 			log.WithField("URL", opts.dockerRegistry).Debug("found docker registry address")
 

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"text/template"
 	"time"
@@ -128,6 +129,10 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			}
 			if !util.IsValidURL(opts.dockerRegistry.String()) {
 				return fmt.Errorf("%s is not a valid URL", opts.dockerRegistry)
+			}
+			if !strings.HasPrefix(opts.dockerRegistry.Path, "/v2") {
+				// add 'v2' to path if it doesn't exist
+				opts.dockerRegistry.Path = "/v2"
 			}
 			log.WithField("URL", opts.dockerRegistry).Debug("found docker registry address")
 

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -908,7 +908,7 @@ func downloadDockerImageBundle(args imageBundleArgs) {
 		type ecrToken struct {
 			Token string
 		}
-		res, err := args.client.Get("https://public.ecr.aws/token/")
+		res, err := args.client.Get(fmt.Sprintf("https://public.ecr.aws/token/?scope=repository:appgate-sdp/%s:pull&service=public.ecr.aws", args.image))
 		if err != nil {
 			args.fileEntryChan <- fileEntry{err: err}
 			return


### PR DESCRIPTION
This will download and add the token needed for bundling docker images when using a public ecr registry.