### PR TITLE
API upgrade to v19

### DIFF
--- a/cmd/appliance/backup/api.go
+++ b/cmd/appliance/backup/api.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"

--- a/cmd/appliance/backup/api_test.go
+++ b/cmd/appliance/backup/api_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/Netflix/go-expect"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/backup/backup_test.go
+++ b/cmd/appliance/backup/backup_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/files/delete_test.go
+++ b/cmd/appliance/files/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/files/list_test.go
+++ b/cmd/appliance/files/list_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/force_disable_controller.go
+++ b/cmd/appliance/force_disable_controller.go
@@ -12,7 +12,7 @@ import (
 	"text/template"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/appliance/change"
 	"github.com/appgate/sdpctl/pkg/cmdutil"

--- a/cmd/appliance/force_disable_controller_test.go
+++ b/cmd/appliance/force_disable_controller_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/list_test.go
+++ b/cmd/appliance/list_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/logs_test.go
+++ b/cmd/appliance/logs_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/maintenance/enable_test.go
+++ b/cmd/appliance/maintenance/enable_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/maintenance/status.go
+++ b/cmd/appliance/maintenance/status.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"regexp"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"

--- a/cmd/appliance/maintenance/status_test.go
+++ b/cmd/appliance/maintenance/status_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/metric.go
+++ b/cmd/appliance/metric.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/cmdutil"

--- a/cmd/appliance/metric_test.go
+++ b/cmd/appliance/metric_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/resolve_name.go
+++ b/cmd/appliance/resolve_name.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/cmdutil"

--- a/cmd/appliance/resolve_name_status.go
+++ b/cmd/appliance/resolve_name_status.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/cmdutil"

--- a/cmd/appliance/resolve_name_status_test.go
+++ b/cmd/appliance/resolve_name_status_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/resolve_name_test.go
+++ b/cmd/appliance/resolve_name_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/cmdutil"
 	"github.com/appgate/sdpctl/pkg/configuration"

--- a/cmd/appliance/seed.go
+++ b/cmd/appliance/seed.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"

--- a/cmd/appliance/seed_test.go
+++ b/cmd/appliance/seed_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/Netflix/go-expect"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"
@@ -53,9 +53,9 @@ var inactiveApplianceListResponse = `{
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "beta.devops",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",

--- a/cmd/appliance/stats.go
+++ b/cmd/appliance/stats.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"

--- a/cmd/appliance/stats_test.go
+++ b/cmd/appliance/stats_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/upgrade/cancel.go
+++ b/cmd/appliance/upgrade/cancel.go
@@ -8,7 +8,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"

--- a/cmd/appliance/upgrade/cancel_test.go
+++ b/cmd/appliance/upgrade/cancel_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/appliance/change"

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/appliance/upgrade/status_test.go
+++ b/cmd/appliance/upgrade/status_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/cmd/serviceusers/create.go
+++ b/cmd/serviceusers/create.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/filesystem"

--- a/cmd/serviceusers/serviceusers_test.go
+++ b/cmd/serviceusers/serviceusers_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/httpmock"

--- a/cmd/token/list_test.go
+++ b/cmd/token/list_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/httpmock"

--- a/cmd/token/revoke.go
+++ b/cmd/token/revoke.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/spf13/cobra"

--- a/cmd/token/revoke_test.go
+++ b/cmd/token/revoke_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/httpmock"

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/sirupsen/logrus"

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/appgate/sdpctl/pkg/appliance/backup"
 	"github.com/appgate/sdpctl/pkg/cmdutil"

--- a/pkg/appliance/backup/backup.go
+++ b/pkg/appliance/backup/backup.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 )
 

--- a/pkg/appliance/change/change.go
+++ b/pkg/appliance/change/change.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"

--- a/pkg/appliance/change/change_test.go
+++ b/pkg/appliance/change/change_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/httpmock"
 	"github.com/google/go-cmp/cmp"
 )

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-version"
@@ -200,55 +200,6 @@ func TestApplianceGroupDescription(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := applianceGroupDescription(tt.args.appliances); got != tt.want {
 				t.Errorf("applianceGroupDescription() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestShowPeerInterfaceWarningMessage(t *testing.T) {
-	type args struct {
-		peerAppliances []openapi.Appliance
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{
-			name: "prepare example",
-			args: args{
-				peerAppliances: []openapi.Appliance{
-					{
-						Name: "controller",
-						Controller: &openapi.ApplianceAllOfController{
-							Enabled: openapi.PtrBool(true),
-						},
-						PeerInterface: &openapi.ApplianceAllOfPeerInterface{
-							HttpsPort: openapi.PtrInt32(443),
-						},
-					},
-				},
-			},
-			want: `
-Version 5.4 and later are designed to operate with the admin port (default 8443)
-separate from the deprecated peer port (set to 443).
-It is recommended to switch to port 8443 before continuing
-The following Controller is still configured without the Admin/API TLS Connection:
-
-  - controller
-`,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ShowPeerInterfaceWarningMessage(tt.args.peerAppliances)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ShowPeerInterfaceWarningMessage() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !cmp.Equal(got, tt.want) {
-				t.Fatalf("\nGot: \n %q \n\n Want: \n %q \n", got, tt.want)
 			}
 		})
 	}

--- a/pkg/appliance/fixtures/appliance_list.json
+++ b/pkg/appliance/fixtures/appliance_list.json
@@ -30,9 +30,9 @@
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "appgate.com",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",
@@ -234,9 +234,9 @@
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "gateway.devops",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",

--- a/pkg/appliance/fixtures/ha_appliance_list.json
+++ b/pkg/appliance/fixtures/ha_appliance_list.json
@@ -30,9 +30,9 @@
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "appgate.com",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",
@@ -234,9 +234,9 @@
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "cryptzone.com",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",
@@ -438,9 +438,9 @@
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "ctrl3.cryptzone.com",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",
@@ -642,9 +642,9 @@
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "ctrl4.cryptzone.com",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",
@@ -846,9 +846,9 @@
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "gateway.devops",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",

--- a/pkg/appliance/fixtures/two_controller_one_offline.json
+++ b/pkg/appliance/fixtures/two_controller_one_offline.json
@@ -30,9 +30,9 @@
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "appgate.com",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",
@@ -234,9 +234,9 @@
                     }
                 ]
             },
-            "peerInterface": {
+            "adminInterface": {
                 "hostname": "secondcontroller.devops",
-                "httpsPort": 444,
+                "httpsPort": 8443,
                 "allowSources": [
                     {
                         "address": "0.0.0.0",

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/hashcode"
 	"github.com/appgate/sdpctl/pkg/network"
 	"github.com/appgate/sdpctl/pkg/tui"
@@ -117,17 +117,6 @@ func GetActiveFunctions(appliance openapi.Appliance) []string {
 	}
 
 	return functions
-}
-
-// WithAdminOnPeerInterface List all appliances still using the peer interface for the admin API, this is now deprecated.
-func WithAdminOnPeerInterface(appliances []openapi.Appliance) []openapi.Appliance {
-	peer := make([]openapi.Appliance, 0)
-	for _, a := range appliances {
-		if _, ok := a.GetAdminInterfaceOk(); !ok {
-			peer = append(peer, a)
-		}
-	}
-	return peer
 }
 
 // FilterAvailable return lists of online, offline, errors that will be used during upgrade
@@ -319,11 +308,7 @@ func FindPrimaryController(appliances []openapi.Appliance, hostname string, vali
 	}
 	for _, controller := range controllers {
 		var hostnames []string
-		hostnames = append(hostnames, strings.ToLower(controller.GetPeerInterface().Hostname))
 		if v, ok := controller.GetAdminInterfaceOk(); ok {
-			hostnames = append(hostnames, strings.ToLower(v.GetHostname()))
-		}
-		if v, ok := controller.GetPeerInterfaceOk(); ok {
 			hostnames = append(hostnames, strings.ToLower(v.GetHostname()))
 		}
 		data[controller.GetId()] = details{
@@ -368,9 +353,6 @@ func ValidateHostname(controller openapi.Appliance, hostname string) error {
 	if ai, ok := controller.GetAdminInterfaceOk(); ok {
 		h = ai.GetHostname()
 	}
-	if pi, ok := controller.GetPeerInterfaceOk(); ok && len(h) <= 0 {
-		h = pi.GetHostname()
-	}
 	if len(h) <= 0 {
 		return fmt.Errorf("Failed to determine hostname for the Controller admin interface")
 	}
@@ -398,9 +380,6 @@ func FindCurrentController(appliances []openapi.Appliance, hostname string) (*op
 		hostnames := []string{}
 		hostnames = append(hostnames, strings.ToLower(a.GetHostname()))
 		if v, ok := a.GetAdminInterfaceOk(); ok {
-			hostnames = append(hostnames, strings.ToLower(v.GetHostname()))
-		}
-		if v, ok := a.GetPeerInterfaceOk(); ok {
 			hostnames = append(hostnames, strings.ToLower(v.GetHostname()))
 		}
 		if util.InSlice(l, hostnames) {

--- a/pkg/appliance/functions_test.go
+++ b/pkg/appliance/functions_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/hashcode"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -260,9 +260,6 @@ func TestFindPrimaryController(t *testing.T) {
 						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
 							Hostname: "localhost",
 						},
-						PeerInterface: &openapi.ApplianceAllOfPeerInterface{
-							Hostname: "localhost",
-						},
 						Controller: &openapi.ApplianceAllOfController{
 							Enabled: openapi.PtrBool(true),
 						},
@@ -321,9 +318,6 @@ func TestGroupByFunctions(t *testing.T) {
 						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
 							Hostname: "foo.devops",
 						},
-						PeerInterface: &openapi.ApplianceAllOfPeerInterface{
-							Hostname: "foo.devops",
-						},
 						Controller: &openapi.ApplianceAllOfController{
 							Enabled: openapi.PtrBool(true),
 						},
@@ -358,9 +352,6 @@ func TestGroupByFunctions(t *testing.T) {
 						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
 							Hostname: "foo.devops",
 						},
-						PeerInterface: &openapi.ApplianceAllOfPeerInterface{
-							Hostname: "foo.devops",
-						},
 						Controller: &openapi.ApplianceAllOfController{
 							Enabled: openapi.PtrBool(true),
 						},
@@ -383,9 +374,6 @@ func TestGroupByFunctions(t *testing.T) {
 						Name: "secondary controller with log server",
 						Id:   openapi.PtrString("two"),
 						AdminInterface: &openapi.ApplianceAllOfAdminInterface{
-							Hostname: "foo.devops",
-						},
-						PeerInterface: &openapi.ApplianceAllOfPeerInterface{
 							Hostname: "foo.devops",
 						},
 						Controller: &openapi.ApplianceAllOfController{
@@ -2783,10 +2771,6 @@ func TestValidateHostname(t *testing.T) {
 			Name:      "controller",
 			Activated: openapi.PtrBool(true),
 			Hostname:  tt.hostname,
-			PeerInterface: &openapi.ApplianceAllOfPeerInterface{
-				Hostname:  tt.adminHostName,
-				HttpsPort: openapi.PtrInt32(444),
-			},
 			AdminInterface: &openapi.ApplianceAllOfAdminInterface{
 				Hostname:  tt.adminHostName,
 				HttpsPort: openapi.PtrInt32(8443),
@@ -3114,22 +3098,20 @@ func GenerateApplianceWithStats(activeFunctions []string, name, hostname, versio
 	}
 
 	app := openapi.Appliance{
-		Id:                                   openapi.PtrString(id),
-		Name:                                 name,
-		Notes:                                nil,
-		Created:                              openapi.PtrTime(now),
-		Updated:                              openapi.PtrTime(now),
-		Tags:                                 []string{},
-		ConnectToPeersUsingClientPortWithSpa: nil,
-		PeerInterface:                        &openapi.ApplianceAllOfPeerInterface{},
-		Activated:                            openapi.PtrBool(true),
-		PendingCertificateRenewal:            openapi.PtrBool(false),
-		Version:                              openapi.PtrInt32(18),
-		Hostname:                             hostname,
-		Site:                                 openapi.PtrString("Default Site"),
-		SiteName:                             new(string),
-		Customization:                        new(string),
-		ClientInterface:                      openapi.ApplianceAllOfClientInterface{},
+		Id:                        openapi.PtrString(id),
+		Name:                      name,
+		Notes:                     nil,
+		Created:                   openapi.PtrTime(now),
+		Updated:                   openapi.PtrTime(now),
+		Tags:                      []string{},
+		Activated:                 openapi.PtrBool(true),
+		PendingCertificateRenewal: openapi.PtrBool(false),
+		Version:                   openapi.PtrInt32(18),
+		Hostname:                  hostname,
+		Site:                      openapi.PtrString("Default Site"),
+		SiteName:                  new(string),
+		Customization:             new(string),
+		ClientInterface:           openapi.ApplianceAllOfClientInterface{},
 		AdminInterface: &openapi.ApplianceAllOfAdminInterface{
 			Hostname:  hostname,
 			HttpsPort: openapi.PtrInt32(8443),
@@ -3139,7 +3121,7 @@ func GenerateApplianceWithStats(activeFunctions []string, name, hostname, versio
 		SshServer:           &openapi.ApplianceAllOfSshServer{},
 		SnmpServer:          &openapi.ApplianceAllOfSnmpServer{},
 		HealthcheckServer:   &openapi.ApplianceAllOfHealthcheckServer{},
-		PrometheusExporter:  &openapi.ApplianceAllOfPrometheusExporter{},
+		PrometheusExporter:  &openapi.PrometheusExporter{},
 		Ping:                &openapi.ApplianceAllOfPing{},
 		LogServer:           ls,
 		Controller:          ctrl,

--- a/pkg/appliance/prompt.go
+++ b/pkg/appliance/prompt.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/prompt"
 )
 

--- a/pkg/appliance/status.go
+++ b/pkg/appliance/status.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/tui"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/cenkalti/backoff/v4"

--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/tui"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/cenkalti/backoff/v4"

--- a/pkg/auth/local.go
+++ b/pkg/auth/local.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/prompt"
 )

--- a/pkg/auth/mfa.go
+++ b/pkg/auth/mfa.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 )
 

--- a/pkg/auth/mfa_test.go
+++ b/pkg/auth/mfa_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/appgate/sdpctl/pkg/httpmock"
 	"github.com/google/go-cmp/cmp"

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/keyring"
 	"github.com/google/uuid"

--- a/pkg/auth/signin.go
+++ b/pkg/auth/signin.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/cmdutil"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/pkg/auth/signin_test.go
+++ b/pkg/auth/signin_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	expect "github.com/Netflix/go-expect"
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"

--- a/pkg/factory/http.go
+++ b/pkg/factory/http.go
@@ -14,7 +14,7 @@ import (
 	"github.com/appgate/sdpctl/pkg/token"
 	"golang.org/x/net/http/httpproxy"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/util"

--- a/pkg/httpmock/http.go
+++ b/pkg/httpmock/http.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/google/go-cmp/cmp"
 )

--- a/pkg/serviceusers/api.go
+++ b/pkg/serviceusers/api.go
@@ -3,7 +3,7 @@ package serviceusers
 import (
 	"context"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 )
 

--- a/pkg/token/api.go
+++ b/pkg/token/api.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
 	"github.com/appgate/sdpctl/pkg/api"
 	"github.com/appgate/sdpctl/pkg/util"
 	"github.com/hashicorp/go-multierror"


### PR DESCRIPTION
Upgrade the API peer version to v19. This will deprecate support for the obsolete peer interface on appliances.