### PR TITLE
Add skip-bundle flag for skipping bundling of docker images

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -111,7 +111,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 				return err
 			}
 
-			if opts.skipBundle, err = cmd.Flags().GetBool("skip-bundle"); err != nil {
+			if opts.skipBundle, err = cmd.Flags().GetBool("skip-container-bundle"); err != nil {
 				return err
 			}
 

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -63,6 +63,7 @@ type prepareUpgradeOptions struct {
 	actualHostname   string
 	targetVersion    *version.Version
 	dockerRegistry   *url.URL
+	skipBundle       bool
 }
 
 // NewPrepareUpgradeCmd return a new prepare upgrade command
@@ -107,6 +108,10 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			var errs *multierr.Error
 			opts.filename = filepath.Base(opts.image)
 			if err := checkImageFilename(opts.filename); err != nil {
+				return err
+			}
+
+			if opts.skipBundle, err = cmd.Flags().GetBool("skip-bundle"); err != nil {
 				return err
 			}
 
@@ -199,6 +204,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 	flags.BoolVar(&opts.hostOnController, "host-on-controller", false, "Use the primary Controller as image host when uploading from remote source")
 	flags.StringVar(&opts.actualHostname, "actual-hostname", "", "If the actual hostname is different from that which you are connecting to the appliance admin API, this flag can be used for setting the actual hostname")
 	flags.BoolVar(&opts.forcePrepare, "force", false, "Force prepare of upgrade on appliances even though the version uploaded is the same or lower than the version already running on the appliance")
+	flags.BoolVar(&opts.skipBundle, "skip-bundle", false, "skip the bundling of the docker images for functions that need them, e.g. the LogServer")
 	flags.String("docker-registry", "", "Custom docker registry for downloading function docker images. Needs to be accessible by the sdpctl host machine.")
 
 	return prepareCmd
@@ -383,7 +389,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	if err != nil {
 		return err
 	}
-	logserverbundleupload := constraint62.Check(opts.targetVersion) && len(groups[appliancepkg.FunctionLogServer]) > 0
+	logserverbundleupload := constraint62.Check(opts.targetVersion) && len(groups[appliancepkg.FunctionLogServer]) > 0 && !opts.skipBundle
 
 	upgradeNames := []string{}
 	skipNames := []string{}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -204,7 +204,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 	flags.BoolVar(&opts.hostOnController, "host-on-controller", false, "Use the primary Controller as image host when uploading from remote source")
 	flags.StringVar(&opts.actualHostname, "actual-hostname", "", "If the actual hostname is different from that which you are connecting to the appliance admin API, this flag can be used for setting the actual hostname")
 	flags.BoolVar(&opts.forcePrepare, "force", false, "Force prepare of upgrade on appliances even though the version uploaded is the same or lower than the version already running on the appliance")
-	flags.BoolVar(&opts.skipBundle, "skip-bundle", false, "skip the bundling of the docker images for functions that need them, e.g. the LogServer")
+	flags.BoolVar(&opts.skipBundle, "skip-container-bundle", false, "skip the bundling of the docker images for functions that need them, e.g. the LogServer")
 	flags.String("docker-registry", "", "Custom docker registry for downloading function docker images. Needs to be accessible by the sdpctl host machine.")
 
 	return prepareCmd

--- a/docs/sdpctl_appliance_upgrade_prepare.html
+++ b/docs/sdpctl_appliance_upgrade_prepare.html
@@ -50,6 +50,7 @@ the upgrade image using the provided URL. It will fail if the Appliances cannot 
       --host-on-controller       Use the primary Controller as image host when uploading from remote source
       --image string             Upgrade image file or URL
       --no-interactive           Suppress interactive prompt with auto accept
+      --skip-bundle              skip the bundling of the docker images for functions that need them, e.g. the LogServer
       --throttle int             Upgrade is done in batches using a throttle value. You can control the throttle using this flag (default 5)
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>

--- a/docs/sdpctl_appliance_upgrade_prepare.html
+++ b/docs/sdpctl_appliance_upgrade_prepare.html
@@ -50,7 +50,7 @@ the upgrade image using the provided URL. It will fail if the Appliances cannot 
       --host-on-controller       Use the primary Controller as image host when uploading from remote source
       --image string             Upgrade image file or URL
       --no-interactive           Suppress interactive prompt with auto accept
-      --skip-bundle              skip the bundling of the docker images for functions that need them, e.g. the LogServer
+      --skip-container-bundle    skip the bundling of the docker images for functions that need them, e.g. the LogServer
       --throttle int             Upgrade is done in batches using a throttle value. You can control the throttle using this flag (default 5)
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>


### PR DESCRIPTION
Using the flag will prevent sdpctl from downloading and bundling the LogServer images when preparing. This will put the load of downloading and upgrading the LogServer image on the appliance itself.

This would be preferrable if, for example, the client that is running sdpctl, has a slow connection.

The registry which the LogServer images are pulled from needs to be accessible by the appliance in this case for upgrading of LogServer to work.