### PR TITLE
SA-21647-appliance-function-command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,8 +4,8 @@ env:
   - SNAPSHOT_VERSION={{ .Now.Format "2006.01.02" }}
 before:
   hooks:
-  - make clean
-  - make deps
+    - make clean
+    - make deps
 snapshot:
   name_template: "{{ if .IsSnapshot }}{{ .Env.SNAPSHOT_VERSION }}{{ else }}{{ .Tag }}{{ end }}"
 changelog:
@@ -14,7 +14,6 @@ github_urls:
   download: https://github.com/appgate/sdpctl/releases
 
 builds:
-
   - <<: &build_defaults
       binary: "{{ .ProjectName }}"
       main: ./main.go
@@ -22,7 +21,7 @@ builds:
         - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ if .IsSnapshot }}{{ .Env.SNAPSHOT_VERSION }}-dev{{ else }}{{ .Version }}{{ end }}"
         - -X "github.com/appgate/sdpctl/cmd.commit={{ .FullCommit }}"
         - -X "github.com/appgate/sdpctl/cmd.buildDate={{ .Date }}"
-        - -X "github.com/appgate/sdpctl/cmd/appliance/upgrade.dockerRegistry={{ .Env.DOCKER_REGISTRY_URL }}"
+        - -X "github.com/appgate/sdpctl/pkg/factory.dockerRegistry={{ .Env.DOCKER_REGISTRY_URL }}"
     id: linux
     goos: [linux]
     goarch: [amd64, arm64]
@@ -48,7 +47,6 @@ builds:
     hooks:
       post:
         - "{{ .Env.HOOK_PATH }}/sign-windows.sh '{{ .Path }}'"
-
 
 universal_binaries:
   - replace: false

--- a/cmd/appliance/appliance.go
+++ b/cmd/appliance/appliance.go
@@ -3,6 +3,7 @@ package appliance
 import (
 	"github.com/appgate/sdpctl/cmd/appliance/backup"
 	"github.com/appgate/sdpctl/cmd/appliance/files"
+	"github.com/appgate/sdpctl/cmd/appliance/functions"
 	"github.com/appgate/sdpctl/cmd/appliance/maintenance"
 	"github.com/appgate/sdpctl/cmd/appliance/upgrade"
 	"github.com/appgate/sdpctl/pkg/docs"
@@ -43,6 +44,7 @@ func NewApplianceCmd(f *factory.Factory) *cobra.Command {
 	cmd.AddCommand(maintenance.NewMaintenanceCmd(f))
 	cmd.AddCommand(NewSeedCmd(f))
 	cmd.AddCommand(NewForceDisableControllerCmd(f))
+	cmd.AddCommand(functions.NewApplianceFunctionsCmd(f))
 
 	return cmd
 }

--- a/cmd/appliance/backup/backup.go
+++ b/cmd/appliance/backup/backup.go
@@ -48,7 +48,7 @@ func NewCmdBackup(f *factory.Factory) *cobra.Command {
 
 	log.SetOutput(opts.Out)
 	flags := cmd.Flags()
-	flags.StringVarP(&opts.Destination, "destination", "d", "$HOME/Downloads/appgate/backup", "backup destination directory")
+	flags.StringVarP(&opts.Destination, "destination", "d", appliance.DefaultBackupDestination, "backup destination directory")
 	flags.BoolVar(&opts.AllFlag, "all", false, "backup all appliances in the Collective")
 	flags.BoolVar(&opts.PrimaryFlag, "primary", false, "backup the primary Controller")
 	flags.BoolVar(&opts.CurrentFlag, "current", false, "backup the current peer Controller")

--- a/cmd/appliance/functions/download.go
+++ b/cmd/appliance/functions/download.go
@@ -49,8 +49,8 @@ func NewApplianceFunctionsDownloadCmd(f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "download [function...]",
 		Aliases: []string{"dl", "bundle"},
-		Short: docs.ApplianceFunctionsDownloadDocs.Short,
-		Long: docs.ApplianceFunctionsDownloadDocs.Long,
+		Short:   docs.ApplianceFunctionsDownloadDocs.Short,
+		Long:    docs.ApplianceFunctionsDownloadDocs.Long,
 		Example: docs.ApplianceFunctionsDownloadDocs.ExampleString(),
 		Args: cobra.MatchAll(cobra.MinimumNArgs(1), func(cmd *cobra.Command, args []string) error {
 			registry, err := cmd.Flags().GetString("docker-registry")

--- a/cmd/appliance/functions/functions.go
+++ b/cmd/appliance/functions/functions.go
@@ -1,0 +1,30 @@
+package functions
+
+import (
+	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
+	"github.com/appgate/sdpctl/pkg/factory"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ValidFuncs []string = []string{
+		appliancepkg.FunctionLogServer,
+	}
+	UnavailableFuncs []string = []string{
+		appliancepkg.FunctionController,
+		appliancepkg.FunctionGateway,
+		appliancepkg.FunctionLogForwarder,
+		appliancepkg.FunctionConnector,
+		appliancepkg.FunctionPortal,
+	}
+)
+
+func NewApplianceFunctionsCmd(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "functions",
+	}
+
+	cmd.AddCommand(NewApplianceFunctionsDownloadCmd(f))
+
+	return cmd
+}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -385,11 +385,11 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	}).Debug("upgrade version information")
 
 	// Check if we need to bundle docker image and upload as well
-	constraint62, err := version.NewConstraint(">=6.2-alpha")
+	v62, err := version.NewVersion("6.2.0-alpha")
 	if err != nil {
 		return err
 	}
-	logserverbundleupload := constraint62.Check(opts.targetVersion) && len(groups[appliancepkg.FunctionLogServer]) > 0 && !opts.skipBundle
+	logserverbundleupload := opts.targetVersion.GreaterThanOrEqual(v62) && len(groups[appliancepkg.FunctionLogServer]) > 0 && !opts.skipBundle
 
 	upgradeNames := []string{}
 	skipNames := []string{}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -38,11 +38,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	// Set at build time or in environment variables
-	dockerRegistry string
-)
-
 type prepareUpgradeOptions struct {
 	Config           *configuration.Config
 	Out              io.Writer
@@ -116,24 +111,12 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			}
 
 			// Get the docker registry address
-			var reg string
-			if len(dockerRegistry) > 0 {
-				reg = dockerRegistry
-			}
-			if flagRegistry, err := cmd.Flags().GetString("docker-registry"); err == nil && len(flagRegistry) > 0 {
-				reg = flagRegistry
-			}
-			if envRegistry := os.Getenv("SDPCTL_DOCKER_REGISTRY"); len(envRegistry) > 0 {
-				reg = envRegistry
-			}
-			if len(reg) <= 0 {
-				return errors.New("no docker registry URL found. Please set the 'SDPCTL_DOCKER_REGISTRY' environment variable.")
-			}
-			if opts.dockerRegistry, err = util.NormalizeURL(reg); err != nil {
+			flagRegistry, err := cmd.Flags().GetString("docker-registry")
+			if err != nil {
 				return err
 			}
-			if !util.IsValidURL(opts.dockerRegistry.String()) {
-				return fmt.Errorf("%s is not a valid URL", opts.dockerRegistry)
+			if opts.dockerRegistry, err = f.DockerRegistry(flagRegistry); err != nil {
+				return err
 			}
 			log.WithField("URL", opts.dockerRegistry).Debug("found docker registry address")
 
@@ -462,7 +445,11 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			}
 
 			fmt.Fprintf(opts.Out, "[%s] Preparing image layers for LogServer:\n", time.Now().Format(time.RFC3339))
-			zipPath, err := appliancepkg.DownloadDockerBundles(ctx, spinnerOut, client, logServerZipName, opts.dockerRegistry, logServerImages, opts.ciMode)
+			var bundleProgress *tui.Progress
+			if !opts.ciMode {
+				bundleProgress = tui.New(ctx, opts.SpinnerOut())
+			}
+			zipPath, err := appliancepkg.DownloadDockerBundles(ctx, bundleProgress, client, logServerZipName, opts.dockerRegistry, logServerImages, opts.ciMode)
 			if err != nil {
 				return err
 			}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -511,6 +511,11 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				return err
 			}
 			os.Remove(zipPath)
+			defer func() {
+				if err := a.DeleteFile(ctx, logServerZipName); err != nil {
+					log.WithField("file", logServerZipName).WithError(err).Warning("failed to delete file from repository")
+				}
+			}()
 		} else {
 			fmt.Fprint(opts.Out, "LogServer image already exists on appliance. Skipping\n\n")
 		}

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -531,6 +531,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 
 				return a, nil
 			}
+			f.DockerRegistry = f.GetDockerRegistry
 			// add parent command to allow us to include test with parent flags
 			cmd := NewApplianceCmd(f)
 			upgradeCmd := NewUpgradeCmd(f)

--- a/docs/sdpctl_appliance.html
+++ b/docs/sdpctl_appliance.html
@@ -44,6 +44,7 @@ used together with one of the available sub-commands listed below.</p><hr class=
 <li><p><a href="sdpctl_appliance_export-seed.html">sdpctl appliance export-seed</a>	 - Export seed for an inactive Appliance</p></li>
 <li><p><a href="sdpctl_appliance_files.html">sdpctl appliance files</a>	 - The files command lets you manage the file repository on the connected Controller</p></li>
 <li><p><a href="sdpctl_appliance_force-disable-controller.html">sdpctl appliance force-disable-controller</a>	 - Force disable misbehaving Controllers using this command. USE WITH CAUTION!</p></li>
+<li><p><a href="sdpctl_appliance_functions.html">sdpctl appliance functions</a>	 -</p></li>
 <li><p><a href="sdpctl_appliance_list.html">sdpctl appliance list</a>	 - List all appliances</p></li>
 <li><p><a href="sdpctl_appliance_logs.html">sdpctl appliance logs</a>	 - Download zip bundle with logs</p></li>
 <li><p><a href="sdpctl_appliance_maintenance.html">sdpctl appliance maintenance</a>	 - Manually manage maintenance mode on Controllers</p></li>

--- a/docs/sdpctl_appliance_backup.html
+++ b/docs/sdpctl_appliance_backup.html
@@ -51,7 +51,7 @@ will be created there if it doesn&rsquo;t already exist and the backups will be 
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
 <pre class="code-editor margin-bottom"><code>      --all                  backup all appliances in the Collective
       --current              backup the current peer Controller
-  -d, --destination string   backup destination directory (default &quot;$HOME/Downloads/appgate/backup&quot;)
+  -d, --destination string   backup destination directory (default &quot;/home/larskajes/Downloads/appgate/backup&quot;)
   -h, --help                 help for backup
       --primary              backup the primary Controller
       --quiet                backup summary will not be printed if setting this flag

--- a/docs/sdpctl_appliance_functions.html
+++ b/docs/sdpctl_appliance_functions.html
@@ -1,0 +1,49 @@
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="Description" content="Appgate sdpctl Quick Start Guide">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="expires" content="0">
+  <title>sdpctl Reference Guide</title>
+  <link rel="stylesheet" href="./assets/guide.css">
+  <script type="text/javascript" src="./assets/guide.js"></script>
+  <script>document.addEventListener("DOMContentLoaded", () => initManPage());</script>
+</head>
+<body>
+  <main class="page text-center">
+    <div class="box">
+			<object class="appgate-logo" data="assets/appgate.svg" aria-label="appgate inc logo"></object>
+			<h1 class="margin-top-small">sdpctl Reference Guide</h1>
+      <hr />
+			<div id="breadcrumb" class="breadcrumb">
+				<a href="index.html">Quick Start Guide</a>
+				<span class="breadcrumb-seperator">/</span>
+			</div>
+			<hr />
+      <div class="content text-left">
+      <h2 class="text-left margin-bottom">sdpctl appliance functions</h2><hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3><pre class="code-editor margin-bottom"><code>  -h, --help   help for functions
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>
+<pre class="code-editor margin-bottom"><code>      --api-version int          Peer API version override
+      --ci-mode                  Log to stderr instead of file and disable progress-bars
+      --debug                    Enable debug logging
+      --descending               Change the direction of sort order when using the '--order-by' flag. Using this will reverse the sort order for all keywords specified in the ''--order-by' flag.
+      --events-path string       send logs to unix domain socket path
+  -e, --exclude stringToString   Filter appliances using a comma separated list of key-value pairs. Regex syntax is used for matching strings. Example: '--exclude name=controller,site=&lt;site-id&gt; etc.'.
+                                 Available keywords to filter on are: name, id, tags|tag, version, hostname|host, active|activated, site|site-id, function (default [])
+  -i, --include stringToString   Include appliances. Adheres to the same syntax and key-value pairs as '--exclude' (default [])
+      --no-interactive           Suppress interactive prompt with auto accept
+      --no-verify                Don't verify TLS on for the given command, overriding settings from config file
+      --order-by strings         Order appliance lists by keywords, i.e. 'name', 'id' etc. Accepts a comma seperated list of keywords, where first mentioned has priority. Applies to the 'appliance list' and 'appliance stats' commands. (default [name])
+  -p, --profile string           Profile configuration to use
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">SEE ALSO</h3>
+<ul>
+<li><p><a href="sdpctl_appliance.html">sdpctl appliance</a>	 - Manage the appliances and perform tasks such as backups, ugprades, metrics etc</p></li>
+<li><p><a href="sdpctl_appliance_functions_download.html">sdpctl appliance functions download</a>	 - Download functions as container bundles</p></li>
+</ul>
+
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/docs/sdpctl_appliance_functions_download.html
+++ b/docs/sdpctl_appliance_functions_download.html
@@ -1,0 +1,64 @@
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="Description" content="Appgate sdpctl Quick Start Guide">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="expires" content="0">
+  <title>sdpctl Reference Guide</title>
+  <link rel="stylesheet" href="./assets/guide.css">
+  <script type="text/javascript" src="./assets/guide.js"></script>
+  <script>document.addEventListener("DOMContentLoaded", () => initManPage());</script>
+</head>
+<body>
+  <main class="page text-center">
+    <div class="box">
+			<object class="appgate-logo" data="assets/appgate.svg" aria-label="appgate inc logo"></object>
+			<h1 class="margin-top-small">sdpctl Reference Guide</h1>
+      <hr />
+			<div id="breadcrumb" class="breadcrumb">
+				<a href="index.html">Quick Start Guide</a>
+				<span class="breadcrumb-seperator">/</span>
+			</div>
+			<hr />
+      <div class="content text-left">
+      <h2 class="text-left margin-bottom">sdpctl appliance functions download</h2><p>Download functions as container bundles</p><hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Synopsis</h3><p>Download appliance functions as container bundles. The container bundles can then be uploaded to the SDP Collective to enable the function contained in the bunde. Note that currently only the LogServer function is available for container bundle download.</p><pre class="code-editor margin-bottom"><code>sdpctl appliance functions download [function...] [flags]
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Examples</h3>
+<pre class="code-editor margin-bottom"><code>  # download the LogServer function as a bundle
+  &gt; sdpctl appliance functions download LogServer
+
+  # Save the container bundles in a custom path. This is expected to be a directory. If the directory does not exist, sdpctl will try to create it.
+  &gt; sdpctl appliance functions download LogServer --save-path=&lt;download-path&gt;
+
+  # Download the functions from a custom docker registry.
+  &gt; sdpctl appliance functions download LogServer --docker-registry=&lt;path-to-custom-docker-registry&gt;
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
+<pre class="code-editor margin-bottom"><code>      --docker-registry string   docker registry for downloading image bundles
+  -h, --help                     help for download
+      --save-path string          (default &quot;/home/larskajes/Downloads/appgate&quot;)
+      --version string           
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>
+<pre class="code-editor margin-bottom"><code>      --api-version int          Peer API version override
+      --ci-mode                  Log to stderr instead of file and disable progress-bars
+      --debug                    Enable debug logging
+      --descending               Change the direction of sort order when using the '--order-by' flag. Using this will reverse the sort order for all keywords specified in the ''--order-by' flag.
+      --events-path string       send logs to unix domain socket path
+  -e, --exclude stringToString   Filter appliances using a comma separated list of key-value pairs. Regex syntax is used for matching strings. Example: '--exclude name=controller,site=&lt;site-id&gt; etc.'.
+                                 Available keywords to filter on are: name, id, tags|tag, version, hostname|host, active|activated, site|site-id, function (default [])
+  -i, --include stringToString   Include appliances. Adheres to the same syntax and key-value pairs as '--exclude' (default [])
+      --no-interactive           Suppress interactive prompt with auto accept
+      --no-verify                Don't verify TLS on for the given command, overriding settings from config file
+      --order-by strings         Order appliance lists by keywords, i.e. 'name', 'id' etc. Accepts a comma seperated list of keywords, where first mentioned has priority. Applies to the 'appliance list' and 'appliance stats' commands. (default [name])
+  -p, --profile string           Profile configuration to use
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">SEE ALSO</h3>
+<ul>
+<li><p><a href="sdpctl_appliance_functions.html">sdpctl appliance functions</a>	 -</p></li>
+</ul>
+
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/pkg/docs/appliance.go
+++ b/pkg/docs/appliance.go
@@ -351,4 +351,22 @@ The command will accept one or more hostnames or ID:s of Controllers that will b
 			},
 		},
 	}
+	ApplianceFunctionsDownloadDocs = CommandDoc{
+		Short: "Download functions as container bundles",
+		Long:  "Download appliance functions as container bundles. The container bundles can then be uploaded to the SDP Collective to enable the function contained in the bunde. Note that currently only the LogServer function is available for container bundle download.",
+		Examples: []ExampleDoc{
+			{
+				Command:     "sdpctl appliance functions download LogServer",
+				Description: "download the LogServer function as a bundle",
+			},
+			{
+				Command: "sdpctl appliance functions download LogServer --save-path=<download-path>",
+				Description: "Save the container bundles in a custom path. This is expected to be a directory. If the directory does not exist, sdpctl will try to create it.",
+			},
+			{
+				Command: "sdpctl appliance functions download LogServer --docker-registry=<path-to-custom-docker-registry>",
+				Description: "Download the functions from a custom docker registry.",
+			},
+		},
+	}
 )

--- a/pkg/docs/appliance.go
+++ b/pkg/docs/appliance.go
@@ -360,11 +360,11 @@ The command will accept one or more hostnames or ID:s of Controllers that will b
 				Description: "download the LogServer function as a bundle",
 			},
 			{
-				Command: "sdpctl appliance functions download LogServer --save-path=<download-path>",
+				Command:     "sdpctl appliance functions download LogServer --save-path=<download-path>",
 				Description: "Save the container bundles in a custom path. This is expected to be a directory. If the directory does not exist, sdpctl will try to create it.",
 			},
 			{
-				Command: "sdpctl appliance functions download LogServer --docker-registry=<path-to-custom-docker-registry>",
+				Command:     "sdpctl appliance functions download LogServer --docker-registry=<path-to-custom-docker-registry>",
 				Description: "Download the functions from a custom docker registry.",
 			},
 		},

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -61,7 +61,11 @@ func DownloadDir() string {
 
 func parseUsersDirs() (map[string]string, error) {
 	res := map[string]string{}
-	file, err := os.Open(filepath.Join(xdg.ConfigHome, "user-dirs.dirs"))
+	configHome := xdg.ConfigHome
+	if len(configHome) <= 0 {
+		configHome = xdg.Home + "/.config"
+	}
+	file, err := os.Open(filepath.Join(configHome, "user-dirs.dirs"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -201,3 +201,13 @@ func AddSocketLogHook(path string) error {
 	log.AddHook(hook)
 	return nil
 }
+
+func Find[T any](s []T, f func(T) bool) (T, error) {
+	var r T
+	for _, v := range s {
+		if f(v) {
+			return v, nil
+		}
+	}
+	return r, errors.New("no match in slice")
+}


### PR DESCRIPTION
This implements a new command for downloading container bundles of an appliance function.

Since SDP Appliance version 6.2.0, the LogServer functionality has been detached from the base upgrade image and is now provided as a seperate package in the form of a docker container. Sdpctl has supported upgrading SDP Appliances to version 6.2.0 since version 2023.04.28, using the new downloadable LogServer upgrade path.

The new command, implemented in this PR, will provide the ability to download the LogServer container bundle seperately from preparing an upgrade.

This PR also contains a few bug fixes discovered along the way:
- the `backup` command will now properly account for the users language settings and download the backup to a localized download folder by default
- the LogServer container bundle that is prepared and uploaded will now be deleted from the Controller repository once the prepare has completed successfully, preventing dead failes taking up space on the Appliance when not needed.
- sdpctl will now print a warning when using sdpctl with an unsupported version of the SDP Appliance

Fixes SA-21647