### PR TITLE
Better version detection when uploading local upgrade image

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -169,11 +169,12 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 					errs = multierr.Append(errs, fmt.Errorf("Image file not found %q", opts.image))
 				}
 				if ok {
-					// guess version from filename first, then from the extracted zip if filename fails
+					// get version from metadata first. guess from filename if that fails
 					// fatal if both fail
-					if opts.targetVersion, err = appliancepkg.ParseVersionString(opts.filename); err != nil {
-						if opts.targetVersion, err = appliancepkg.ParseVersionFromZip(opts.image); err != nil {
-							errs = multierr.Append(errs, err)
+					if opts.targetVersion, err = appliancepkg.ParseVersionFromZip(opts.image); err != nil {
+						var e error
+						if opts.targetVersion, e = appliancepkg.ParseVersionString(opts.filename); e != nil {
+							errs = multierr.Append(errs, err, e)
 						}
 					}
 				}


### PR DESCRIPTION
This PR improves the version detection when uploading a local upgrade image using sdpctl. Instead of guessing from filename, it will now read the upgrade file and get the versin information from the metadata entry.

In case of a remote image, sdpctl will still attempt to determine which version it is using the name of the file from the url.