### PR TITLE
Make global-settings read optional on backup

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v19/openapi"
+	"github.com/appgate/sdpctl/pkg/api"
 	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/appliance/change"
 	"github.com/appgate/sdpctl/pkg/cmdutil"
@@ -429,7 +430,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		exists := true
 		if _, err := a.FileStatus(ctx, logServerZipName); err != nil {
 			// if we dont get 404, return err
-			if errors.Is(err, appliancepkg.ErrFileNotFound) {
+			if errors.Is(err, api.ErrFileNotFound) {
 				exists = false
 			} else {
 				return err
@@ -514,7 +515,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 	existingFile, err := a.FileStatus(ctx, opts.filename)
 	if err != nil {
 		// if we dont get 404, return err
-		if errors.Is(err, appliancepkg.ErrFileNotFound) {
+		if errors.Is(err, api.ErrFileNotFound) {
 			shouldUpload = true
 		} else {
 			return err

--- a/pkg/api/apiutil.go
+++ b/pkg/api/apiutil.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	stderrors "errors"
 	"fmt"
 	"io"
@@ -24,6 +25,18 @@ type Error struct {
 	Err        error
 	Errors     []error
 }
+
+var (
+	ErrFileNotFound       = errors.New("File not found")
+	ForbiddenErr    error = &Error{
+		StatusCode: 403,
+		Err:        errors.New("403 Forbidden"),
+	}
+	UnavailableErr error = &Error{
+		StatusCode: 503,
+		Err:        errors.New("503 Service Unavailable"),
+	}
+)
 
 func (e *Error) Error() string {
 	if e.Err != nil {

--- a/pkg/api/apiutil.go
+++ b/pkg/api/apiutil.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	stderrors "errors"
 	"fmt"
 	"io"
@@ -27,14 +26,14 @@ type Error struct {
 }
 
 var (
-	ErrFileNotFound       = errors.New("File not found")
+	ErrFileNotFound       = stderrors.New("File not found")
 	ForbiddenErr    error = &Error{
 		StatusCode: 403,
-		Err:        errors.New("403 Forbidden"),
+		Err:        stderrors.New("403 Forbidden"),
 	}
 	UnavailableErr error = &Error{
 		StatusCode: 503,
-		Err:        errors.New("503 Service Unavailable"),
+		Err:        stderrors.New("503 Service Unavailable"),
 	}
 )
 

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -154,8 +154,6 @@ func (a *Appliance) Stats(ctx context.Context, orderBy []string, descending bool
 	return status, response, nil
 }
 
-var ErrFileNotFound = errors.New("File not found")
-
 // FileStatus Get the status of a File uploaded to the current Controller.
 func (a *Appliance) FileStatus(ctx context.Context, filename string) (*openapi.File, error) {
 	log := logrus.WithField("file", filename)
@@ -164,7 +162,7 @@ func (a *Appliance) FileStatus(ctx context.Context, filename string) (*openapi.F
 	defer log.WithField("status", f.GetStatus()).Info("got file status")
 	if err != nil {
 		if r.StatusCode == http.StatusNotFound {
-			return f, fmt.Errorf("%q: %w", filename, ErrFileNotFound)
+			return f, fmt.Errorf("%q: %w", filename, api.ErrFileNotFound)
 		}
 		return f, api.HTTPErrorResponse(r, err)
 	}

--- a/pkg/appliance/backup/backup.go
+++ b/pkg/appliance/backup/backup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -33,6 +34,9 @@ func (b *Backup) Initiate(ctx context.Context, applianceID string, logs, audit b
 	}
 	status, response, err := b.APIClient.ApplianceBackupApi.AppliancesIdBackupPost(ctx, applianceID).Authorization(b.Token).AppliancesIdBackupPostRequest(o).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusServiceUnavailable {
+			return "", api.UnavailableErr
+		}
 		return "", api.HTTPErrorResponse(response, err)
 	}
 


### PR DESCRIPTION
This will prevent errors in the backup command if the user does not have priviliges to read the global settings of the collective.

If the user has priviliges to read global settings and the backup API is disabled, the user will be prompted to enable the backup API. If the user does not have the the priviliges to read global settings and the backup API is disabled, the command will error when trying to initiate the backup.

Fixes SA-22098