### PR TITLE
Improve UX for commands annotated with updateAPIConfig

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -73,7 +73,7 @@ func NewUpgradeCompleteCmd(f *factory.Factory) *cobra.Command {
 		Long:    docs.ApplianceUpgradeCompleteDoc.Long,
 		Example: docs.ApplianceUpgradeCompleteDoc.ExampleString(),
 		Annotations: map[string]string{
-			"updateAPIConfig": "true",
+			configuration.NeedUpdateAPIConfig: "true",
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			minTimeout := 5 * time.Minute

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -85,7 +85,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 		Long:    docs.ApplianceUpgradePrepareDoc.Long,
 		Example: docs.ApplianceUpgradePrepareDoc.ExampleString(),
 		Annotations: map[string]string{
-			"updateAPIConfig": "true",
+			configuration.NeedUpdateAPIConfig: "true",
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(opts.image) < 1 {

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -13,7 +13,7 @@ func NewCmdCompletion() *cobra.Command {
 	var completionCmd = &cobra.Command{
 		Use: "completion [bash|zsh|fish|powershell]",
 		Annotations: map[string]string{
-			"skipAuthCheck": "true",
+			configuration.SkipAuthCheck: "true",
 		},
 		Short:     docs.CompletionDocs.Short,
 		Long:      docs.CompletionDocs.Long,

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/appgate/sdpctl/pkg/configuration"
 	"os"
 
 	"github.com/appgate/sdpctl/pkg/docs"

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -38,7 +38,7 @@ func NewCmdConfigure(f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "configure",
 		Annotations: map[string]string{
-			"skipAuthCheck": "true",
+			configuration.SkipAuthCheck: "true",
 		},
 		Short:   docs.ConfigureDocs.Short,
 		Long:    docs.ConfigureDocs.Long,

--- a/cmd/configure/signin.go
+++ b/cmd/configure/signin.go
@@ -2,6 +2,7 @@ package configure
 
 import (
 	"fmt"
+	"github.com/appgate/sdpctl/pkg/configuration"
 	"io"
 	"os"
 
@@ -27,7 +28,7 @@ func NewSigninCmd(f *factory.Factory) *cobra.Command {
 	var signinCmd = &cobra.Command{
 		Use: "signin",
 		Annotations: map[string]string{
-			"skipAuthCheck": "true",
+			configuration.SkipAuthCheck: "true",
 		},
 		Aliases: []string{"login"},
 		Short:   docs.ConfigureSigninDocs.Short,

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"github.com/appgate/sdpctl/pkg/configuration"
 	"io"
 	"io/fs"
 	"os"
@@ -32,7 +33,7 @@ var generateCmd = &cobra.Command{
 	Aliases: []string{"gen"},
 	Hidden:  true,
 	Annotations: map[string]string{
-		"skipAuthCheck": "true",
+		configuration.SkipAuthCheck: "true",
 	},
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"man", "html", "all"},

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -17,7 +17,7 @@ func NewOpenCmd(f *factory.Factory) *cobra.Command {
 	return &cobra.Command{
 		Use: "open",
 		Annotations: map[string]string{
-			"skipAuthCheck": "true",
+			configuration.SkipAuthCheck: "true",
 		},
 		Short: "Open the Admin UI in your browser",
 		RunE: func(c *cobra.Command, args []string) error {

--- a/cmd/profile/profile.go
+++ b/cmd/profile/profile.go
@@ -36,7 +36,7 @@ func NewProfileCmd(f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "profile",
 		Annotations: map[string]string{
-			"skipAuthCheck": "true",
+			configuration.SkipAuthCheck: "true",
 		},
 		TraverseChildren: true,
 		Short:            docs.ProfileRootDoc.Short,

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -116,9 +116,11 @@ func CheckMinAPIVersionRestriction(cmd *cobra.Command, currentVersion int) error
 	return nil
 }
 
+const NeedUpdateAPIConfig = "updateAPIConfig"
+
 func NeedUpdatedAPIVersionConfig(cmd *cobra.Command) bool {
 	for c := cmd; c.Parent() != nil; c = c.Parent() {
-		if c.Annotations != nil && c.Annotations["updateAPIConfig"] == "true" {
+		if c.Annotations != nil && c.Annotations[NeedUpdateAPIConfig] == "true" {
 			return true
 		}
 	}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -85,13 +85,15 @@ func DefaultDeviceID() string {
 	return v
 }
 
+const SkipAuthCheck = "skipAuthCheck"
+
 func IsAuthCheckEnabled(cmd *cobra.Command) bool {
 	switch cmd.Name() {
 	case "help", cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd:
 		return false
 	}
 	for c := cmd; c.Parent() != nil; c = c.Parent() {
-		if c.Annotations != nil && c.Annotations["skipAuthCheck"] == "true" {
+		if c.Annotations != nil && c.Annotations[SkipAuthCheck] == "true" {
 			return false
 		}
 	}


### PR DESCRIPTION
When a command `upgrade prepare` and `upgrade complete` (commands with updateAPIConfig annotation) is run before the sdpctl configuration is initialized, it prints the following warning: 

```
It is strongly adviced that you upgrade your appliance to a supported version before executing any sdpctl command. Executing sdpctl commands on an unsupported API version can have serious unforseen consequenses.
Minimum supported API version: 17
Currently using API version: 0
``` 

sdpctl reads the key `api_version` in the config to extract the current API version. This configuration key is only initialized when the user authenticates sdpctl. I changed the orders of the warning printer after there is an attempt to signin. 