### PR TITLE
Add actual-hostname flag to force-disable-controller command

### DIFF
--- a/pkg/appliance/status.go
+++ b/pkg/appliance/status.go
@@ -44,9 +44,9 @@ func (u *ApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance 
 				if !util.InSlice(current, want) {
 					return fmt.Errorf("Want status %s, got %s", want, current)
 				}
+				logEntry.Info("Reached the wanted appliance status")
 			}
 		}
-		logEntry.Info("Reached the wanted appliance status")
 		return nil
 
 	}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))


### PR DESCRIPTION
This implements the `actual-hostname` flag to the `force-disable-controller` command.

Also included in this PR is that the log will include the current status even when reaching the desired state when upgrading.