### PR TITLE
Zero exit when there is nothing to prepare

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -343,7 +343,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 
 		if len(appliances) <= 0 {
 			var errs *multierr.Error
-			errs = multierr.Append(errs, errors.New("No appliances to prepare for upgrade. All appliances may have been filtered or are already prepared. See the log for more details"))
+			errs = multierr.Append(errs, cmdutil.ErrNothingToPrepare)
 			if len(skipAppliances) > 0 {
 				for _, skip := range skipAppliances {
 					errs = multierr.Append(errs, skip)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gomarkdown/markdown v0.0.0-20230322041520-c84983bdbf2a
 	github.com/google/go-cmp v0.5.9
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/google/uuid v1.3.0
+	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -13,4 +13,6 @@ var (
 	ErrMissingTTY = errors.New("No TTY present")
 	// ErrNetworkError is used when a command encounters multiple timeouts on a request, which we will presume is a network error
 	ErrNetworkError = errors.New("Failed to communicate with SDP Collective. Bad connection")
+	// ErrNothingToPrepare is used when there are no appliances to prepare for upgrade
+	ErrNothingToPrepare = errors.New("No appliances to prepare for upgrade. All appliances may have been filtered or are already prepared. See the log for more details")
 )

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -13,6 +13,8 @@ var (
 	ErrMissingTTY = errors.New("No TTY present")
 	// ErrNetworkError is used when a command encounters multiple timeouts on a request, which we will presume is a network error
 	ErrNetworkError = errors.New("Failed to communicate with SDP Collective. Bad connection")
+	// ErrSSL is used when a certificate is not provided or is invalid
+	ErrSSL = errors.New("Trust the certificate or import a PEM file using 'sdpctl configure --pem=<path/to/pem>'")
 	// ErrNothingToPrepare is used when there are no appliances to prepare for upgrade
 	ErrNothingToPrepare = errors.New("No appliances to prepare for upgrade. All appliances may have been filtered or are already prepared. See the log for more details")
 )

--- a/pkg/cmdutil/execute.go
+++ b/pkg/cmdutil/execute.go
@@ -78,7 +78,7 @@ func ExecuteCommand(cmd *cobra.Command) ExitCode {
 
 		// if error is ErrNothingToUpgrade, exit with zero code
 		if errors.Is(err, ErrNothingToPrepare) {
-			fmt.Println(err.Error())
+			fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
 			return ExitOK
 		}
 

--- a/pkg/cmdutil/execute.go
+++ b/pkg/cmdutil/execute.go
@@ -76,6 +76,12 @@ func ExecuteCommand(cmd *cobra.Command) ExitCode {
 			result = multierror.Append(result, ErrCommandTimeout)
 		}
 
+		// if error is ErrNothingToUpgrade, exit with zero code
+		if errors.Is(err, ErrNothingToPrepare) {
+			fmt.Println(err.Error())
+			return ExitOK
+		}
+
 		// if we during any request get a SSL error, (un-trusted certificate) error, prompt the user to import the pem file.
 		var sslErr x509.UnknownAuthorityError
 		if errors.As(err, &sslErr) {

--- a/pkg/cmdutil/execute.go
+++ b/pkg/cmdutil/execute.go
@@ -85,7 +85,7 @@ func ExecuteCommand(cmd *cobra.Command) ExitCode {
 		// if we during any request get a SSL error, (un-trusted certificate) error, prompt the user to import the pem file.
 		var sslErr x509.UnknownAuthorityError
 		if errors.As(err, &sslErr) {
-			result = multierror.Append(result, errors.New("Trust the certificate or import a PEM file using 'sdpctl configure --pem=<path/to/pem>'"))
+			result = multierror.Append(result, ErrSSL)
 		}
 
 		// print all multierrors to stderr, then return correct exitcode based on error type

--- a/pkg/cmdutil/execute_test.go
+++ b/pkg/cmdutil/execute_test.go
@@ -225,7 +225,7 @@ func TestCommandErrorHandling(t *testing.T) {
 			args: args{
 				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return ErrNothingToPrepare }},
 			},
-			want: ExitOK,
+			want:         ExitOK,
 			wantedOutput: fmt.Sprintf("%s\n", ErrNothingToPrepare.Error()),
 		},
 	}

--- a/pkg/cmdutil/execute_test.go
+++ b/pkg/cmdutil/execute_test.go
@@ -220,6 +220,14 @@ func TestCommandErrorHandling(t *testing.T) {
 
 `,
 		},
+		{
+			name: "zero exit on no prepare",
+			args: args{
+				cmd: &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return ErrNothingToPrepare }},
+			},
+			want: ExitOK,
+			wantedOutput: fmt.Sprintf("%s\n", ErrNothingToPrepare.Error()),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This makes the prepare command exit with code 0 if there's nothing to prepare due to appliances already prepared or already at the same version.

Error messages will still be printed to the output, but the zero exit code will not make it fail in an automated environment.