### PR TITLE
Match all files when looking for existing logserver bundle

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -440,7 +440,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}
 		for _, f := range files {
 			lfFileName := fmt.Sprintf("logserver-%s", tagVersion)
-			if strings.HasPrefix(lfFileName, *f.Name) {
+			if strings.HasPrefix(*f.Name, lfFileName) {
 				exists = true
 			}
 		}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -425,11 +425,11 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			return err
 		}
 
-		logServerZipName := fmt.Sprintf("logserver-%s.zip", util.ApplianceVersionString(opts.targetVersion))
 		tagVersion, err := util.DockerTagVersion(opts.targetVersion)
 		if err != nil {
 			return err
 		}
+		logServerZipName := fmt.Sprintf("logserver-%s.zip", tagVersion)
 		// check if already exists
 		// we don't know the exact name, so we match with all existing files in the repository
 		// will match if major and minor versions are the same in the filename
@@ -440,7 +440,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}
 		for _, f := range files {
 			lfFileName := fmt.Sprintf("logserver-%s", tagVersion)
-			if strings.HasPrefix(*f.Name, lfFileName) {
+			if strings.HasPrefix(*f.Name, lfFileName) && strings.HasSuffix(*f.Name, ".zip") {
 				exists = true
 			}
 		}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -440,8 +440,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}
 		for _, f := range files {
 			lfFileName := fmt.Sprintf("logserver-%s", tagVersion)
-			regex := regexp.MustCompile(strings.Replace(lfFileName, `.`, `\.`, -1))
-			if regex.MatchString(*f.Name) {
+			if strings.HasPrefix(lfFileName, *f.Name) {
 				exists = true
 			}
 		}


### PR DESCRIPTION
This changes how the `upgrade prepare` command will match the existing LogServer bundle when checking if it exists. Instead of requesting an exakt filename, it will match with the filenames of all files currently in repository.

This puts less restrictions on the the filename when manually uploading a bundle to the controller repository.