### PR TITLE
Avoid too many requests error when pulling LogServer images

### DIFF
--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -915,22 +915,16 @@ func downloadDockerImageBundle(args imageBundleArgs) {
 	}
 
 	requestRetry := func(client *http.Client, req *http.Request) (*http.Response, error) {
-		var err error
-		var res *http.Response
-		err = backoff.Retry(func() error {
-			res, err = client.Do(req)
+		return backoff.RetryWithData(func() (*http.Response, error) {
+			res, err := client.Do(req)
 			if err != nil {
-				return backoff.Permanent(err)
+				return nil, backoff.Permanent(err)
 			}
 			if res.StatusCode != http.StatusOK {
-				return fmt.Errorf("Recieved %s status", res.Status)
+				return nil, fmt.Errorf("Recieved %s status", res.Status)
 			}
-			return nil
+			return res, nil
 		}, backoff.NewExponentialBackOff())
-		if err != nil {
-			return nil, err
-		}
-		return res, nil
 	}
 
 	// Download the image manifest


### PR DESCRIPTION
Running the `appliance upgrade prepare` command would occassionally yield in a "Too many requests" error when sdpctl is trying to pull the LogServer images from the public ECR registry.

With this PR, all requests being made to the public ECR registry will be retried if the registry responds with an error.