### PR TITLE
Minor bugfixes and improvements

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -75,7 +75,8 @@ func NewUpgradeCompleteCmd(f *factory.Factory) *cobra.Command {
 		Annotations: map[string]string{
 			configuration.NeedUpdateAPIConfig: "true",
 		},
-		Args: func(cmd *cobra.Command, args []string) error {
+		Args: cobra.ExactArgs(0),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			minTimeout := 5 * time.Minute
 			flagTimeout, err := cmd.Flags().GetDuration("timeout")
 			if err != nil {

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -73,6 +73,12 @@ func TestUpgradeCompleteCommand(t *testing.T) {
 		wantErrOut                  *regexp.Regexp
 	}{
 		{
+			name:       "with invalid arg",
+			cli:        "upgrade complete some.invalid.arg",
+			wantErr:    true,
+			wantErrOut: regexp.MustCompile(`accepts 0 arg\(s\), received 1`),
+		},
+		{
 			name: "test complete multiple appliances backup false",
 			cli:  "upgrade complete --backup=false",
 			askStubs: func(as *prompt.AskStubber) {

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -786,7 +786,6 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 						"details":   c.GetDetails(),
 						"appliance": qs.appliance.GetName(),
 					}).Info("prepare image change")
-					unwantedStatus = append(unwantedStatus, appliancepkg.UpgradeStatusIdle)
 				}
 				if err := a.UpgradeStatusWorker.WaitForUpgradeStatus(ctx, qs.appliance, wantedStatus, unwantedStatus, qs.tracker); err != nil {
 					queueContinue <- queueStruct{err: err}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -88,7 +88,8 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 		Annotations: map[string]string{
 			configuration.NeedUpdateAPIConfig: "true",
 		},
-		Args: func(cmd *cobra.Command, args []string) error {
+		Args: cobra.ExactArgs(0),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(opts.image) < 1 {
 				return errors.New("--image is mandatory")
 			}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -174,6 +174,13 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 				if !ok {
 					errs = multierr.Append(errs, fmt.Errorf("LogServer image bundle not found: %q", opts.logServerBundlePath))
 				}
+				info, err := os.Stat(opts.logServerBundlePath)
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					errs = multierr.Append(errs, fmt.Errorf("invalid LogServer bundle: bundle is a directory"))
+				}
 			}
 
 			if opts.ciMode, err = cmd.Flags().GetBool("ci-mode"); err != nil {
@@ -463,7 +470,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		}
 		if !exists {
 			fmt.Fprintf(opts.Out, "[%s] Preparing image bundle for LogServer:\n", time.Now().Format(time.RFC3339))
-			var zipPath string
+			var zip *os.File
 			if len(opts.logServerBundlePath) <= 0 {
 				tagVersion, err := util.DockerTagVersion(opts.targetVersion)
 				if err != nil {
@@ -478,37 +485,20 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				if !opts.ciMode {
 					bundleProgress = tui.New(ctx, opts.SpinnerOut())
 				}
-				zipPath, err = appliancepkg.DownloadDockerBundles(ctx, bundleProgress, client, logServerZipName, opts.dockerRegistry, logServerImages, opts.ciMode)
+				path := filepath.Join(filesystem.DownloadDir(), "appgate", logServerZipName)
+				zip, err = appliancepkg.DownloadDockerBundles(ctx, bundleProgress, client, path, opts.dockerRegistry, logServerImages, opts.ciMode)
 				if err != nil {
 					return err
 				}
+				defer os.Remove(zip.Name())
+				opts.logServerBundlePath = zip.Name()
 			} else {
-				tempZip, err := os.CreateTemp("", logServerZipName)
+				zip, err = os.Open(opts.logServerBundlePath)
 				if err != nil {
 					return err
 				}
-				defer tempZip.Close()
-				pathZip, err := os.Open(opts.logServerBundlePath)
-				if err != nil {
-					return err
-				}
-				defer pathZip.Close()
-
-				if _, err := io.Copy(tempZip, pathZip); err != nil {
-					return err
-				}
-				zipPath = tempZip.Name()
 			}
-
-			if len(zipPath) <= 0 {
-				return errors.New("Something went wrong")
-			}
-
-			zipFile, err := os.Open(zipPath)
-			if err != nil {
-				return err
-			}
-			defer zipFile.Close()
+			defer zip.Close()
 
 			pr, pw := io.Pipe()
 			writer := multipart.NewWriter(pw)
@@ -522,7 +512,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 					return
 				}
 
-				size, err := io.Copy(part, zipFile)
+				size, err := io.Copy(part, zip)
 				if err != nil {
 					log.Warnf("copy err %s", err)
 					return
@@ -530,7 +520,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				log.WithField("size", size).WithField("zip", logServerZipName).Debug("wrote zip part")
 			}()
 
-			zipInfo, err := zipFile.Stat()
+			zipInfo, err := zip.Stat()
 			if err != nil {
 				return err
 			}
@@ -548,7 +538,6 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			if err != nil {
 				return err
 			}
-			os.Remove(zipPath)
 			defer func() {
 				if err := a.DeleteFile(ctx, logServerZipName); err != nil {
 					log.WithField("file", logServerZipName).WithError(err).Warning("failed to delete file from repository")

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -71,6 +71,12 @@ func TestUpgradePrepareCommand(t *testing.T) {
 		wantErrOut          *regexp.Regexp
 	}{
 		{
+			name:       "with args",
+			cli:        "upgrade prepare some.invalid.arg.com",
+			wantErr:    true,
+			wantErrOut: regexp.MustCompile(`accepts 0 arg\(s\), received 1`),
+		},
+		{
 			name: "with existing file",
 			cli:  "upgrade prepare --image './testdata/appgate-5.5.1-9876.img.zip'",
 			askStubs: func(s *prompt.AskStubber) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -324,7 +324,7 @@ func rootPersistentPreRunEFunc(f *factory.Factory, cfg *configuration.Config) fu
 		}
 		cfg, err = cfg.CheckForUpdate(f.StdErr, client, version)
 		if err != nil {
-			if errors.Is(err, cmdutil.ErrDailyVersionCheck) {
+			if errors.Is(err, cmdutil.ErrDailyVersionCheck) || errors.Is(err, cmdutil.ErrVersionCheckDisabled) {
 				log.Info(err.Error())
 			} else {
 				log.WithError(err).Error("version check error")

--- a/pkg/appliance/upgrade_status.go
+++ b/pkg/appliance/upgrade_status.go
@@ -57,8 +57,11 @@ func (u *UpgradeStatus) upgradeStatus(ctx context.Context, appliance openapi.App
 		status, err := u.Appliance.UpgradeStatus(ctx, appliance.GetId())
 		if err != nil {
 			if tracker != nil {
-				msg := "switching partition"
-				if _, ok := ctx.Value(PrimaryUpgrade).(bool); ok {
+				msg := tracker.Current()
+
+				// Check if upgrading primary controller and apply logic for offline check
+				if primaryUpgrade, ok := ctx.Value(PrimaryUpgrade).(bool); ok && primaryUpgrade {
+					msg = "switching partition"
 					if offlineRegex.MatchString(err.Error()) {
 						hasRebooted = true
 					} else if onlineRegex.MatchString(err.Error()) {

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -17,6 +17,8 @@ var (
 	ErrSSL = errors.New("Trust the certificate or import a PEM file using 'sdpctl configure --pem=<path/to/pem>'")
 	// ErrNothingToPrepare is used when there are no appliances to prepare for upgrade
 	ErrNothingToPrepare = errors.New("No appliances to prepare for upgrade. All appliances may have been filtered or are already prepared. See the log for more details")
-
+	// ErrDailyVersionCheck is used when version check has already been done recently
 	ErrDailyVersionCheck = errors.New("version check already done today")
+	// ErrVersionCheckDisabled is used when version check has been disabled
+	ErrVersionCheckDisabled = errors.New("version check disabled")
 )

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -295,7 +295,7 @@ func (c *Config) KeyringPrefix() (string, error) {
 func (c *Config) CheckForUpdate(out io.Writer, client *http.Client, current string) (*Config, error) {
 	// Check if version check is disabled in configuration
 	if c.DisableVersionCheck {
-		return c, errors.New("version check disabled")
+		return c, cmdutil.ErrVersionCheckDisabled
 	}
 
 	// Check if version check has already been done today

--- a/pkg/tui/style_windows.go
+++ b/pkg/tui/style_windows.go
@@ -7,7 +7,6 @@ var (
 	// SpinnerStyle for Windows has no special unicode characters, to support cmd.exe out-of-the-box.
 	SpinnerStyle []string = []string{"-", "\\", "|", "/"}
 
-	// SpinnerDone intentionally left empty due to causing false positives in cmd.exe
 	Check string = "[COMPLETE]"
 	Cross string = "[ERROR]"
 	Yes   string = "Y"

--- a/pkg/tui/tracker.go
+++ b/pkg/tui/tracker.go
@@ -128,3 +128,7 @@ func (t *Tracker) Fail(s string) {
 	default:
 	}
 }
+
+func (t *Tracker) Current() string {
+	return t.current
+}


### PR DESCRIPTION
This is collection of fixes and improvements:
- tracker would, in some cases, give wrong status message during prepare
- LogServer bundle is streamed directly to file when downloading, preventing the need to use a temporary file
- Version check disabled now logs as info instead of an error
- return error when arguments are used in prepare and complete command instead of just ignoring them