### PR TITLE
Place log file in correct directory

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -8,7 +8,9 @@ import (
 
 func HelpTemplate() string {
 	cobra.AddTemplateFunc("caller", cmdutil.GetCaller)
-	cobra.AddTemplateFunc("storage", cmdutil.GetPath)
+	cobra.AddTemplateFunc("profile", cmdutil.CurrentProfile)
+	cobra.AddTemplateFunc("storage", cmdutil.GetConfigPath)
+	cobra.AddTemplateFunc("logs", cmdutil.GetLogPath)
 	return `© 2022-2023 Appgate Cybersecurity, Inc.
 All rights reserved. Appgate is a trademark of Appgate Cybersecurity, Inc.
 https://www.appgate.com
@@ -18,11 +20,14 @@ https://www.appgate.com
 Environment Variables:
   See '{{caller}} help environment' for the list of supported environment variables.
 
+Current Profile:
+  {{profile}}
+
 Configuration Path:
-  {{storage}}/config.json
+  {{storage}}
 
 Log Path:
-  {{storage}}/sdpctl.log
+  {{logs}}
 
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 }

--- a/cmd/profile/add.go
+++ b/cmd/profile/add.go
@@ -46,7 +46,7 @@ func NewAddCmd(opts *commandOpts) *cobra.Command {
 
 // defaultProfileName is the profile name if already have a config populated
 // before we run the command
-const defaultProfileName string = "default"
+var defaultProfileName string = "default"
 
 func addRun(cmd *cobra.Command, args []string, opts *commandOpts) error {
 	if !profiles.FileExists() {
@@ -59,9 +59,14 @@ func addRun(cmd *cobra.Command, args []string, opts *commandOpts) error {
 			return err
 		}
 	}
-	if !profiles.DirectoryExists() {
-		if err := profiles.CreateDirectories(); err != nil {
-			return fmt.Errorf("could not create profile directory %w", err)
+	if !profiles.ConfigDirectoryExists() {
+		if err := profiles.CreateConfigDirectory(); err != nil {
+			return fmt.Errorf("failed to create profile directory %w", err)
+		}
+	}
+	if !profiles.LogDirectoryExists() {
+		if err := profiles.CreateLogDirectory(); err != nil {
+			return fmt.Errorf("failed to create profile log directory %w", err)
 		}
 	}
 
@@ -81,7 +86,8 @@ func addRun(cmd *cobra.Command, args []string, opts *commandOpts) error {
 				return err
 			}
 			if h, err := config.GetHost(); len(h) > 0 && err == nil {
-				directory := filepath.Join(profiles.Directories(), defaultProfileName)
+				cfg, _ := profiles.Directories()
+				directory := filepath.Join(cfg, defaultProfileName)
 				if err := os.Mkdir(directory, os.ModePerm); err != nil {
 					return fmt.Errorf("could not create new default config profile directory %w", err)
 				}
@@ -96,19 +102,26 @@ func addRun(cmd *cobra.Command, args []string, opts *commandOpts) error {
 					Name:      defaultProfileName,
 					Directory: directory,
 				})
-				p.Current = &directory
+				p.Current = &defaultProfileName
 			}
 		}
 	}
 	name := args[0]
-	directory := filepath.Join(profiles.Directories(), name)
+	cfg, logs := profiles.Directories()
+	directory := filepath.Join(cfg, name)
 	if err := os.Mkdir(directory, os.ModePerm); err != nil {
 		return fmt.Errorf("profile already exists with the name %s", name)
+	}
+	if ok, err := util.FileExists(logs); err == nil && !ok {
+		if err := os.Mkdir(logs, os.ModePerm); err != nil {
+			return fmt.Errorf("failed creating log directory for %s", name)
+		}
 	}
 
 	p.List = append(p.List, profiles.Profile{
 		Name:      name,
 		Directory: directory,
+		LogPath:   filepath.Join(logs, name+".log"),
 	})
 
 	if err := profiles.Write(p); err != nil {

--- a/cmd/profile/add_test.go
+++ b/cmd/profile/add_test.go
@@ -100,6 +100,8 @@ func TestNewAddCmdMigrateExistingRootConfig(t *testing.T) {
 	if _, err := profileFile.WriteString(data); err != nil {
 		t.Fatal(err)
 	}
+	logs := t.TempDir()
+	t.Setenv("SDPCTL_DATA_DIR", logs)
 	stdout := &bytes.Buffer{}
 	opts := &commandOpts{
 		Out: stdout,

--- a/cmd/profile/delete.go
+++ b/cmd/profile/delete.go
@@ -57,10 +57,17 @@ func deleteRun(cmd *cobra.Command, args []string, opts *commandOpts) error {
 
 	p.List = list
 
-	profileDir := filepath.Join(profiles.Directories(), key)
+	cfgDir, logDir := profiles.Directories()
+	profileDir := filepath.Join(cfgDir, key)
 	if ok, err := util.FileExists(profileDir); err == nil && ok {
 		if err := os.RemoveAll(profileDir); err != nil {
-			fmt.Fprintf(opts.Out, "could not remove profile directory %s %s", profileDir, err)
+			fmt.Fprintf(opts.Out, "failed to remove profile directory %s %s", profileDir, err)
+		}
+	}
+	logsDir := filepath.Join(logDir, key)
+	if ok, err := util.FileExists(logsDir); err == nil && ok {
+		if err := os.RemoveAll(profileDir); err != nil {
+			fmt.Fprintf(opts.Out, "failed to remove profile log directory %s %s", logsDir, err)
 		}
 	}
 

--- a/cmd/profile/list.go
+++ b/cmd/profile/list.go
@@ -60,9 +60,9 @@ func listRun(cmd *cobra.Command, args []string, opts *commandOpts, json bool) er
 	}
 	fmt.Fprintf(opts.Out, "\nAvailable profiles\n")
 	printer := util.NewPrinter(opts.Out, 4)
-	printer.AddHeader("Name", "Config directory")
+	printer.AddHeader("Name", "Config directory", "Log file path")
 	for _, profile := range p.List {
-		printer.AddLine(profile.Name, profile.Directory)
+		printer.AddLine(profile.Name, profile.Directory, profile.GetLogPath())
 	}
 	printer.Print()
 	return nil

--- a/cmd/profile/list.go
+++ b/cmd/profile/list.go
@@ -46,13 +46,13 @@ func listRun(cmd *cobra.Command, args []string, opts *commandOpts, json bool) er
 	if currentProfile != nil {
 		currentConfig, err := readConfig(filepath.Join(currentProfile.Directory, "config.json"))
 		if err != nil {
-			fmt.Fprintf(opts.Out, "Current profile %s is not configure, run 'sdpctl configure'\n", currentProfile.Name)
+			fmt.Fprintf(opts.Out, "Current profile %s is not configured, run 'sdpctl configure'\n", currentProfile.Name)
 		}
 
 		if currentConfig != nil {
 			h, err := currentConfig.GetHost()
 			if err != nil {
-				fmt.Fprintf(opts.Out, "Current profile %s is not configure, run 'sdpctl configure'\n", currentProfile.Name)
+				fmt.Fprintf(opts.Out, "Current profile %s is not configured, run 'sdpctl configure'\n", currentProfile.Name)
 			} else {
 				fmt.Fprintf(opts.Out, "Current profile is %s (%s) the primary Controller %s\n", currentProfile.Name, currentProfile.Directory, h)
 			}

--- a/cmd/profile/list_test.go
+++ b/cmd/profile/list_test.go
@@ -43,33 +43,37 @@ var resetRead = func() {
 	profiles.ReadProfiles = nil
 }
 
-func setupExistingProfiles(t *testing.T) string {
+func setupExistingProfiles(t *testing.T) (string, string) {
 	t.Helper()
 	t.Cleanup(resetRead)
 	dir := t.TempDir()
 	t.Setenv("SDPCTL_CONFIG_DIR", dir)
+	logs := t.TempDir()
+	t.Setenv("SDPCTL_DATA_DIR", logs)
 	profileFile, err := os.Create(profiles.FilePath())
 	if err != nil {
-		t.Fatalf("could not create testing profile %s", err)
+		t.Fatalf("failed to create testing profile %s", err)
 	}
 	defer profileFile.Close()
-	if err := profiles.CreateDirectories(); err != nil {
+	if err := profiles.CreateConfigDirectory(); err != nil {
 		t.Fatal(err)
 	}
 
 	p := profiles.Profiles{}
 	names := []string{"staging", "production"}
 	for _, name := range names {
-		directory := filepath.Join(profiles.Directories(), name)
+		cfgDir, _ := profiles.Directories()
+		directory := filepath.Join(cfgDir, name)
 		if err := os.Mkdir(directory, os.ModePerm); err != nil {
 			t.Fatalf("profile already exists with the name %s", name)
 		}
 
 		p.List = append(p.List, profiles.Profile{
 			Name:      name,
+			LogPath:   filepath.Join(logs, name+".log"),
 			Directory: directory,
 		})
-		p.Current = &directory
+		p.Current = &name
 	}
 
 	bytes, err := json.Marshal(p)
@@ -79,8 +83,7 @@ func setupExistingProfiles(t *testing.T) string {
 	if _, err := profileFile.Write(bytes); err != nil {
 		t.Fatalf("could not write testing profile %s", err)
 	}
-	return dir
-
+	return dir, logs
 }
 
 func Nprintf(format string, params map[string]interface{}) string {
@@ -91,7 +94,7 @@ func Nprintf(format string, params map[string]interface{}) string {
 }
 
 func TestNewListCmdTwoProfilesOneCurrent(t *testing.T) {
-	dir := setupExistingProfiles(t)
+	dir, logs := setupExistingProfiles(t)
 
 	stdout := &bytes.Buffer{}
 	opts := &commandOpts{
@@ -111,16 +114,17 @@ func TestNewListCmdTwoProfilesOneCurrent(t *testing.T) {
 	}
 	gotStr := string(got)
 	params := map[string]interface{}{
-		"dir": dir,
+		"dir":  dir,
+		"logs": logs,
 	}
 
 	want := Nprintf(`Current profile production is not configure, run 'sdpctl configure'
 
 Available profiles
-Name          Config directory
-----          ----------------
-staging       %{dir}/profiles/staging
-production    %{dir}/profiles/production
+Name          Config directory                                                              Log file path
+----          ----------------                                                              -------------
+staging       %{dir}/profiles/staging       %{logs}/staging.log
+production    %{dir}/profiles/production    %{logs}/production.log
 `, params)
 
 	if diff := cmp.Diff(want, gotStr); diff != "" {

--- a/cmd/profile/list_test.go
+++ b/cmd/profile/list_test.go
@@ -118,7 +118,7 @@ func TestNewListCmdTwoProfilesOneCurrent(t *testing.T) {
 		"logs": logs,
 	}
 
-	want := Nprintf(`Current profile production is not configure, run 'sdpctl configure'
+	want := Nprintf(`Current profile production is not configured, run 'sdpctl configure'
 
 Available profiles
 Name          Config directory                                                              Log file path

--- a/cmd/profile/set.go
+++ b/cmd/profile/set.go
@@ -68,8 +68,8 @@ func setRun(cmd *cobra.Command, args []string, opts *commandOpts) error {
 			return err
 		}
 	}
-	p.Current = &p.List[index].Directory
-	fmt.Fprintf(opts.Out, "%s (%s) is selected as current sdp profile\n", p.List[index].Name, p.List[index].Directory)
+	p.Current = &p.List[index].Name
+	fmt.Fprintf(opts.Out, "%s is selected as current sdp profile\n", p.List[index].Name)
 
 	if err := profiles.Write(p); err != nil {
 		return err

--- a/cmd/profile/set_test.go
+++ b/cmd/profile/set_test.go
@@ -38,7 +38,7 @@ run 'sdpctl profile add' first
 }
 
 func TestNewSetCmdSetValid(t *testing.T) {
-	dir := setupExistingProfiles(t)
+	dir, _ := setupExistingProfiles(t)
 
 	stdout := &bytes.Buffer{}
 	opts := &commandOpts{
@@ -57,7 +57,7 @@ func TestNewSetCmdSetValid(t *testing.T) {
 		t.Fatalf("unable to read stdout %s", err)
 	}
 	gotStr := string(got)
-	want := Nprintf(`staging (%{dir}/profiles/staging) is selected as current sdp profile
+	want := Nprintf(`staging is selected as current sdp profile
 staging is not configured yet, run 'sdpctl configure'
 `, map[string]interface{}{"dir": dir})
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,8 +85,8 @@ func initConfig(currentProfile *string) {
 				fmt.Printf("Invalid profile name, got %s, available %s\n", selectedProfile, p.Available())
 				os.Exit(1)
 			}
-		} else if p.CurrentExists() {
-			viper.AddConfigPath(*p.Current)
+		} else if profile, err := p.GetProfile(*p.Current); err == nil && profile != nil {
+			viper.AddConfigPath(profile.Directory)
 		}
 	} else {
 		// if we don't have any profiles
@@ -211,7 +211,7 @@ func logOutput(cmd *cobra.Command, f *factory.Factory, cfg *configuration.Config
 		return f.StdErr
 	}
 
-	name := filepath.Join(profiles.GetStorageDirectory(), "sdpctl.log")
+	name := filepath.Join(profiles.GetDataDirectory(), "sdpctl.log")
 	file, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return f.IOOutWriter

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -260,7 +260,11 @@ func logOutput(cmd *cobra.Command, f *factory.Factory, cfg *configuration.Config
 		return f.StdErr
 	}
 
-	name := filepath.Join(profiles.GetLogDirectory(), "sdpctl.log")
+	logDir := profiles.GetLogDirectory()
+	if err := os.MkdirAll(logDir, os.ModePerm); err != nil {
+		return f.IOOutWriter
+	}
+	name := filepath.Join(logDir, "sdpctl.log")
 	file, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return f.IOOutWriter

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -260,7 +260,7 @@ func logOutput(cmd *cobra.Command, f *factory.Factory, cfg *configuration.Config
 		return f.StdErr
 	}
 
-	logDir := profiles.GetLogDirectory()
+	logDir := profiles.GetLogPath()
 	if err := os.MkdirAll(logDir, os.ModePerm); err != nil {
 		return f.IOOutWriter
 	}

--- a/pkg/cmdutil/template-funcs.go
+++ b/pkg/cmdutil/template-funcs.go
@@ -18,6 +18,14 @@ func GetCaller() string {
 	return binary
 }
 
-func GetPath() string {
-	return profiles.GetConfigDirectory()
+func GetConfigPath() string {
+	return profiles.GetConfigPath()
+}
+
+func GetLogPath() string {
+	return profiles.GetLogPath()
+}
+
+func CurrentProfile() string {
+	return profiles.GetCurrentProfile()
 }

--- a/pkg/cmdutil/template-funcs.go
+++ b/pkg/cmdutil/template-funcs.go
@@ -19,5 +19,5 @@ func GetCaller() string {
 }
 
 func GetPath() string {
-	return profiles.GetStorageDirectory()
+	return profiles.GetConfigDirectory()
 }

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	AgConfigDir   = "SDPCTL_CONFIG_DIR"
+	AgDataDir     = "SDPCTL_DATA_DIR"
 	XdgConfigHome = "XDG_CONFIG_HOME"
 	AppData       = "AppData"
 )
@@ -45,6 +46,9 @@ func ConfigDir() string {
 }
 
 func DataDir() string {
+	if path := os.Getenv(AgDataDir); len(path) > 0 {
+		return path
+	}
 	path := filepath.Join(xdg.DataHome, "sdpctl")
 	// Create the directory if not exist
 	if _, err := os.Stat(path); os.IsNotExist(err) {

--- a/pkg/profiles/profile.go
+++ b/pkg/profiles/profile.go
@@ -29,20 +29,21 @@ func GetConfigDirectory() string {
 		return filesystem.ConfigDir()
 	}
 	if p.CurrentExists() {
-		return filepath.Join(filesystem.ConfigDir(), *p.Current)
+		return filepath.Join(filesystem.ConfigDir(), "profiles", *p.Current)
 	}
 	return filesystem.ConfigDir()
 }
 
 func GetConfigPath() string {
+	defaultConfigPath := filepath.Join(filesystem.ConfigDir(), "config.json")
 	p, err := Read()
 	if err != nil {
-		return filepath.Join(filesystem.ConfigDir(), "sdpctl.log")
+		return defaultConfigPath
 	}
 	if p.CurrentExists() {
-		return filepath.Join(filesystem.ConfigDir(), *p.Current, *p.Current+".log")
+		return filepath.Join(filesystem.ConfigDir(), "profiles", *p.Current, "config.json")
 	}
-	return filepath.Join(filesystem.ConfigDir(), "sdpctl.log")
+	return defaultConfigPath
 }
 
 func GetDataDirectory() string {
@@ -57,14 +58,15 @@ func GetDataDirectory() string {
 }
 
 func GetLogPath() string {
+	defaultLogPath := filepath.Join(filesystem.DataDir(), "logs", "sdpctl.log")
 	p, err := Read()
 	if err != nil {
-		return filepath.Join(filesystem.DataDir(), "logs", "sdpctl.log")
+		return defaultLogPath
 	}
 	if p.CurrentExists() {
-		return filepath.Join(filesystem.DataDir(), "logs", *p.Current, *p.Current+".log")
+		return filepath.Join(filesystem.DataDir(), "logs", *p.Current+".log")
 	}
-	return filepath.Join(filesystem.DataDir(), "logs", "sdpctl.log")
+	return defaultLogPath
 }
 
 func FilePath() string {

--- a/pkg/profiles/profile.go
+++ b/pkg/profiles/profile.go
@@ -12,15 +12,37 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+func GetCurrentProfile() string {
+	p, err := Read()
+	if err != nil {
+		return "<no profile configured>"
+	}
+	if p.CurrentExists() {
+		return *p.Current
+	}
+	return "default"
+}
+
 func GetConfigDirectory() string {
 	p, err := Read()
 	if err != nil {
 		return filesystem.ConfigDir()
 	}
 	if p.CurrentExists() {
-		return *p.Current
+		return filepath.Join(filesystem.ConfigDir(), *p.Current)
 	}
 	return filesystem.ConfigDir()
+}
+
+func GetConfigPath() string {
+	p, err := Read()
+	if err != nil {
+		return filepath.Join(filesystem.ConfigDir(), "sdpctl.log")
+	}
+	if p.CurrentExists() {
+		return filepath.Join(filesystem.ConfigDir(), *p.Current, *p.Current+".log")
+	}
+	return filepath.Join(filesystem.ConfigDir(), "sdpctl.log")
 }
 
 func GetDataDirectory() string {
@@ -29,13 +51,20 @@ func GetDataDirectory() string {
 		return filesystem.DataDir()
 	}
 	if p.CurrentExists() {
-		return *p.Current
+		return filepath.Join(filesystem.DataDir(), *p.Current)
 	}
 	return filesystem.DataDir()
 }
 
-func GetLogDirectory() string {
-	return filepath.Join(filesystem.DataDir(), "logs")
+func GetLogPath() string {
+	p, err := Read()
+	if err != nil {
+		return filepath.Join(filesystem.DataDir(), "logs", "sdpctl.log")
+	}
+	if p.CurrentExists() {
+		return filepath.Join(filesystem.DataDir(), "logs", *p.Current, *p.Current+".log")
+	}
+	return filepath.Join(filesystem.DataDir(), "logs", "sdpctl.log")
 }
 
 func FilePath() string {


### PR DESCRIPTION
Since "profiles" were implemented, the sdpctl log files have been placed in the wrong directory, alongside the configuration. This PR fixes this and also migrates log files from old versions and places the logs at the correct destination.

Fixes SA-22429