### PR TITLE
Trigger ZTP update on upgrade complete

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -814,12 +814,12 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	// From v18 and up
 	// This step is not fatal, so we only log errors here
 	if opts.Config.Version >= 18 {
-		ZTPStatus, err := a.ZTPStatus(ctx)
+		ztpStatus, err := a.ZTPStatus(ctx)
 		if err != nil {
 			log.WithError(err).Warn("failed to get ZTP registered status")
 		}
-		if ZTPRegistered, ok := ZTPStatus.GetRegisteredOk(); err == nil && ok {
-			if isRegistered := *ZTPRegistered; isRegistered {
+		if ztpRegistered, ok := ztpStatus.GetRegisteredOk(); err == nil && ok {
+			if isRegistered := *ztpRegistered; isRegistered {
 				if _, err := a.ZTPUpdateNotify(ctx); err != nil {
 					log.WithError(err).Warn("failed to trigger ZTP update")
 				}

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -371,6 +371,9 @@ func (a *Appliance) ZTPStatus(ctx context.Context) (*openapi.ZtpStatus, error) {
 	if err != nil {
 		return nil, api.HTTPErrorResponse(response, err)
 	}
+	if result == nil {
+		return nil, api.HTTPErrorResponse(response, errors.New("ZtpStatus is nil"))
+	}
 	return result, nil
 }
 
@@ -378,6 +381,9 @@ func (a *Appliance) ZTPUpdateNotify(ctx context.Context) (*openapi.ZtpVersionSta
 	result, response, err := a.APIClient.ZTPApi.ZtpServicesVersionPost(ctx).Authorization(a.Token).Execute()
 	if err != nil {
 		return nil, api.HTTPErrorResponse(response, err)
+	}
+	if result == nil {
+		return nil, api.HTTPErrorResponse(response, errors.New("ZtpVersionStatus is nil"))
 	}
 	return result, nil
 }

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -365,3 +365,19 @@ func (a *Appliance) RepartitionIPAllocations(ctx context.Context) (string, error
 
 	return changeID, nil
 }
+
+func (a *Appliance) ZTPStatus(ctx context.Context) (*openapi.ZtpStatus, error) {
+	result, response, err := a.APIClient.ZTPApi.ZtpGet(ctx).Authorization(a.Token).Execute()
+	if err != nil {
+		return nil, api.HTTPErrorResponse(response, err)
+	}
+	return result, nil
+}
+
+func (a *Appliance) ZTPUpdateNotify(ctx context.Context) (*openapi.ZtpVersionStatus, error) {
+	result, response, err := a.APIClient.ZTPApi.ZtpServicesVersionPost(ctx).Authorization(a.Token).Execute()
+	if err != nil {
+		return nil, api.HTTPErrorResponse(response, err)
+	}
+	return result, nil
+}


### PR DESCRIPTION
Trigger a ZTP version update once an upgrade is completed. This will help ZTP get the correct state of appliances after an upgrade has completed.

Fixes SA-22348