### PR TITLE
Fix missing folder on LogServer bundle download

### DIFF
--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -800,6 +800,12 @@ type imageBundleArgs struct {
 
 func DownloadDockerBundles(ctx context.Context, p *tui.Progress, client *http.Client, path string, registry *url.URL, images map[string]string, ciMode bool) (*os.File, error) {
 	// Create zip-archive
+	dir := filepath.Dir(path)
+	if ok, err := util.FileExists(dir); err == nil && !ok {
+		os.MkdirAll(dir, os.ModePerm)
+	} else if err != nil {
+		return nil, err
+	}
 	archive, err := os.Create(path)
 	if err != nil {
 		return nil, err

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -933,6 +933,9 @@ func downloadDockerImageBundle(args imageBundleArgs) {
 				return nil, backoff.Permanent(err)
 			}
 			if res.StatusCode != http.StatusOK {
+				if res.StatusCode == http.StatusNotFound {
+					return nil, backoff.Permanent(errors.New("image bundle not found"))
+				}
 				return nil, fmt.Errorf("Recieved %s status", res.Status)
 			}
 			return res, nil


### PR DESCRIPTION
If the prepare command is trying to download the LogServer bundle, the command would fail if the default appgate download directory does not exist.

This PR will fix that issue by creating the directory, if it does not exist, prior to creating the bundle zip file.

Meanwhile, there are two workarounds available to avoid this bug:
1. create the directory manually before running the prepare command
2. Download the LogServer bundle before the prepare command, using `sdpctl appliance functions download Logserver`. The downloaded bundle can then be specified using the `--logserver-bundle` flag when running the prepare command.