### PR TITLE
Fix some pathing issues with downloads

### DIFF
--- a/cmd/appliance/functions/download.go
+++ b/cmd/appliance/functions/download.go
@@ -210,7 +210,7 @@ func NewApplianceFunctionsDownloadCmd(f *factory.Factory) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.String("docker-registry", "", "docker registry for downloading image bundles")
-	flags.StringVar(&opts.savePath, "save-path", filepath.Join(filesystem.DownloadDir(), "appgate"), "path to where the container bundle should be saved")
+	flags.StringVar(&opts.savePath, "save-path", filesystem.DownloadDir(), "path to where the container bundle should be saved")
 	flags.StringVar(&opts.version, "version", "", "Override the LogServer version that will be downloaded. Defaults to the same version as the primary controller.")
 
 	return cmd

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -486,7 +486,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				if !opts.ciMode {
 					bundleProgress = tui.New(ctx, opts.SpinnerOut())
 				}
-				path := filepath.Join(filesystem.DownloadDir(), "appgate", logServerZipName)
+				path := filepath.Join(filesystem.DownloadDir(), logServerZipName)
 				zip, err = appliancepkg.DownloadDockerBundles(ctx, bundleProgress, client, path, opts.dockerRegistry, logServerImages, opts.ciMode)
 				if err != nil {
 					return err

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -99,6 +99,12 @@ Available Variables:
   SDPCTL_CONFIG_DIR:
     Description: the directory where sdpctl will store configuration files.
     Default: "$XDG_CONFIG_HOME/sdpctl" or "$HOME/.config/sdpctl on UNIX and %APPDATA%\Local\sdpctl on Windows".
+  SDPCTL_DATA_DIR:
+    Description: the directory where sdpctl will log to.
+    Default: "$XDG_DATA_DIR/sdpctl" or "$HOME/.local/share/sdpctl on UNIX and %APPDATA%\Local\sdpctl on Windows".
+  SDPCTL_DOWNLOAD_DIR:
+    Description: the directory where sdpctl will download to by default.
+    Default: "$XDG_DOWNLOAD_DIR/appgate" or "$HOME/Downloads/appgate on UNIX and %APPDATA%\Local\sdpctl on Windows".
   SDPCTL_LOG_LEVEL:
     Description: application log level
     Default: INFO

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	DefaultBackupDestination = filepath.Join(filesystem.DownloadDir(), "appgate", "backup")
+	DefaultBackupDestination = filepath.Join(filesystem.DownloadDir(), "backup")
 )
 
 type BackupOpts struct {

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -13,6 +13,7 @@ import (
 const (
 	AgConfigDir   = "SDPCTL_CONFIG_DIR"
 	AgDataDir     = "SDPCTL_DATA_DIR"
+	AgDownloadDir = "SDPCTL_DOWNLOAD_DIR"
 	XdgConfigHome = "XDG_CONFIG_HOME"
 	AppData       = "AppData"
 )
@@ -58,20 +59,26 @@ func DataDir() string {
 }
 
 func DownloadDir() string {
+	if path := os.Getenv(AgDownloadDir); len(path) > 0 {
+		return path
+	}
 	// xdg library does not currently parse the user-dirs.dirs file (see https://github.com/adrg/xdg/issues/29)
 	// we'll do it manually for now
 	ud, _ := parseUsersDirs()
 	if dlDir, ok := ud["DOWNLOAD"]; ok {
 		return dlDir
 	}
-	return xdg.UserDirs.Download
+	if len(xdg.UserDirs.Download) > 0 {
+		return xdg.UserDirs.Download
+	}
+	return filepath.Join(xdg.Home, "Downloads", "appgate")
 }
 
 func parseUsersDirs() (map[string]string, error) {
 	res := map[string]string{}
-	configHome := xdg.ConfigHome
-	if len(configHome) <= 0 {
-		configHome = xdg.Home + "/.config"
+	configHome := filepath.Join(xdg.Home, ".config")
+	if len(xdg.ConfigHome) > 0 {
+		configHome = xdg.ConfigHome
 	}
 	file, err := os.Open(filepath.Join(configHome, "user-dirs.dirs"))
 	if err != nil {


### PR DESCRIPTION
This PR will use $HOME/Downloads if no xdg settings are set for download directory.

It also introduces the `SDPCTL_DOWNLOAD_DIR` environment variable to set the default download directory that sdpctl will use.