### PR TITLE
Better errors in license prune

### DIFF
--- a/cmd/license/prune_test.go
+++ b/cmd/license/prune_test.go
@@ -49,7 +49,7 @@ func TestPruneCommand(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrOut: regexp.MustCompile(`Could not prune the user licenses got HTTP 200`),
+			wantErrOut: regexp.MustCompile(`failed to prune license: unexpected response status - want 204, got 200`),
 		},
 		{
 			name: "not found",
@@ -62,7 +62,7 @@ func TestPruneCommand(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrOut: regexp.MustCompile(`Could not prune the user licenses, not supported on your appliance version`),
+			wantErrOut: regexp.MustCompile(`failed to prune license: Operation not supported on your appliance version`),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -1,8 +1,20 @@
 package cmdutil
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
+	// GenericErrorWrap wraps an error along with a message
+	// The message is intended to be specific to a certain operation the user is trying to perform while the error is more generic
+	GenericErrorWrap = func(msg string, err error) error {
+		return fmt.Errorf("%s: %w", msg, err)
+	}
+	// ErrUnexpectedResponseStatus is used for generic response statuses that are unexpected, but not considered errors
+	ErrUnexpectedResponseStatus = func(want, got int) error {
+		return fmt.Errorf("unexpected response status - want %d, got %d", want, got)
+	}
 	// ErrExecutedOnAppliance signals when the program is executed within a appliance
 	ErrExecutedOnAppliance = errors.New("This should not be executed on an appliance")
 	// ErrExecutionCanceledByUser signals user-initiated cancellation
@@ -21,4 +33,6 @@ var (
 	ErrDailyVersionCheck = errors.New("version check already done today")
 	// ErrVersionCheckDisabled is used when version check has been disabled
 	ErrVersionCheckDisabled = errors.New("version check disabled")
+	// ErrUnsupportedOperation is used when the user tries to do an operation that is unsupported by the Appliance, likely due to version
+	ErrUnsupportedOperation = errors.New("Operation not supported on your appliance version")
 )


### PR DESCRIPTION
The `license prune` was not giving a useful error message when an unexpected response status was recieved.