### PR TITLE
properly close archive in download function

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -493,11 +493,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				}
 				defer os.Remove(zip.Name())
 				opts.logServerBundlePath = zip.Name()
-			} else {
-				zip, err = os.Open(opts.logServerBundlePath)
-				if err != nil {
-					return err
-				}
+			}
+			zip, err = os.Open(opts.logServerBundlePath)
+			if err != nil {
+				return err
 			}
 			defer zip.Close()
 
@@ -534,11 +533,11 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				err = uploadWithProgress(ctx, pr, "uploading "+logServerZipName, zipInfo.Size(), headers)
 			} else {
 				err = a.UploadFile(ctx, pr, headers)
-				fmt.Fprint(opts.Out, "Image bundles prepared\n\n")
 			}
 			if err != nil {
 				return err
 			}
+			fmt.Fprint(opts.Out, "Image bundles prepared\n\n")
 		} else {
 			fmt.Fprint(opts.Out, "LogServer image already exists on appliance. Skipping\n\n")
 		}

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -810,6 +810,7 @@ func DownloadDockerBundles(ctx context.Context, p *tui.Progress, client *http.Cl
 	if err != nil {
 		return nil, err
 	}
+	defer archive.Close()
 	zipWriter := zip.NewWriter(archive)
 	defer zipWriter.Close()
 
@@ -864,12 +865,6 @@ func DownloadDockerBundles(ctx context.Context, p *tui.Progress, client *http.Cl
 			continue
 		}
 		log.WithField("path", v.path).WithField("size", size).Debug("wrote layer")
-	}
-
-	archive.Close()
-	archive, err = os.Open(archive.Name())
-	if err != nil {
-		errs = multierror.Append(errs, err)
 	}
 
 	return archive, errs.ErrorOrNil()


### PR DESCRIPTION
Downloading the LogServer image bundle could cause a corrupted zip file.