### PR TITLE
filtering for stats command

### DIFF
--- a/cmd/appliance/appliance.go
+++ b/cmd/appliance/appliance.go
@@ -30,7 +30,7 @@ func NewApplianceCmd(f *factory.Factory) *cobra.Command {
 	pFlags.StringToStringP("include", "i", map[string]string{}, "Include appliances. Adheres to the same syntax and key-value pairs as '--exclude'")
 	pFlags.StringToStringP("exclude", "e", map[string]string{}, filterHelp)
 	pFlags.StringSlice("order-by", []string{"name"}, orderByHelp)
-	pFlags.Bool("descending", false, "Change the direction of sort order when using the '--order-by' flag. Using this will reverse the sort order for all keywords specified in the ''--order-by' flag.")
+	pFlags.Bool("descending", false, "Change the direction of sort order when using the '--order-by' flag. Using this will reverse the sort order for all keywords specified in the '--order-by' flag.")
 
 	cmd.AddCommand(upgrade.NewUpgradeCmd(f))
 	cmd.AddCommand(backup.NewCmdBackup(f))

--- a/cmd/appliance/force_disable_controller.go
+++ b/cmd/appliance/force_disable_controller.go
@@ -141,7 +141,7 @@ func forceDisableControllerRunE(opts cmdOpts, args []string) error {
 		return fmt.Errorf("No controllers to disable")
 	}
 
-	stats, _, err := a.Stats(ctx, nil, false)
+	stats, _, err := a.Stats(ctx, nil, nil, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/appliance/functions/download.go
+++ b/cmd/appliance/functions/download.go
@@ -119,7 +119,7 @@ func NewApplianceFunctionsDownloadCmd(f *factory.Factory) *cobra.Command {
 					return err
 				}
 				logrus.WithField("primary-controller", primary.GetName()).Debug("found primary controller")
-				stats, response, err := api.Stats(ctx, []string{"name"}, false)
+				stats, response, err := api.Stats(ctx, nil, []string{"name"}, false)
 				if err != nil {
 					return apipkg.HTTPErrorResponse(response, err)
 				}

--- a/cmd/appliance/list_test.go
+++ b/cmd/appliance/list_test.go
@@ -50,6 +50,10 @@ func TestApplianceListCommandJSON(t *testing.T) {
 		return a, nil
 	}
 	cmd := NewListCmd(f)
+	cmd.PersistentFlags().StringToStringP("include", "i", map[string]string{}, "")
+	cmd.PersistentFlags().StringToStringP("exclude", "e", map[string]string{}, "")
+	cmd.PersistentFlags().StringSlice("order-by", []string{"name"}, "")
+	cmd.PersistentFlags().Bool("descending", false, "")
 	cmd.SetArgs([]string{"--json"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
@@ -101,7 +105,11 @@ func TestApplianceListCommandTable(t *testing.T) {
 		return a, nil
 	}
 	cmd := NewListCmd(f)
-
+	cmd.PersistentFlags().StringToStringP("include", "i", map[string]string{}, "")
+	cmd.PersistentFlags().StringToStringP("exclude", "e", map[string]string{}, "")
+	cmd.PersistentFlags().StringSlice("order-by", []string{"name"}, "")
+	cmd.PersistentFlags().Bool("descending", false, "")
+	cmd.SetArgs([]string{})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 

--- a/cmd/appliance/maintenance/status.go
+++ b/cmd/appliance/maintenance/status.go
@@ -53,7 +53,7 @@ func listRun(cmd *cobra.Command, args []string, opts *statusOptions) error {
 		return err
 	}
 	ctx := context.Background()
-	stats, _, err := a.Stats(ctx, nil, false)
+	stats, _, err := a.Stats(ctx, nil, nil, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/appliance/upgrade/cancel.go
+++ b/cmd/appliance/upgrade/cancel.go
@@ -96,7 +96,7 @@ func upgradeCancelRun(cmd *cobra.Command, args []string, opts *upgradeCancelOpti
 
 	ctx := context.WithValue(context.Background(), appliancepkg.Caller, cmd.CalledAs())
 	filter, orderBy, descending := util.ParseFilteringFlags(cmd.Flags(), opts.defaultfilter)
-	stats, _, err := a.Stats(ctx, orderBy, descending)
+	stats, _, err := a.Stats(ctx, nil, orderBy, descending)
 	if err != nil {
 		return err
 	}

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -215,7 +215,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	}
 
 	skipping := []appliancepkg.SkipUpgrade{}
-	initialStats, _, err := a.Stats(ctx, orderBy, descending)
+	initialStats, _, err := a.Stats(ctx, nil, orderBy, descending)
 	if err != nil {
 		return err
 	}
@@ -560,7 +560,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			if err := a.ApplianceStats.WaitForApplianceState(ctx, controller, appliancepkg.StatReady, t); err != nil {
 				return err
 			}
-			s, _, err := a.Stats(ctx, orderBy, descending)
+			s, _, err := a.Stats(ctx, nil, orderBy, descending)
 			if err != nil {
 				return err
 			}
@@ -642,7 +642,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 					return fmt.Errorf("%s %w", i.GetName(), err)
 				}
 
-				s, _, err := a.Stats(ctx, orderBy, descending)
+				s, _, err := a.Stats(ctx, nil, orderBy, descending)
 				if err != nil {
 					return err
 				}
@@ -766,7 +766,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 					return err
 				}
 			}
-			s, _, err := a.Stats(ctx, orderBy, descending)
+			s, _, err := a.Stats(ctx, nil, orderBy, descending)
 			if err != nil {
 				return err
 			}
@@ -845,7 +845,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	}
 
 	// Check if all appliances are running the same version after upgrade complete
-	newStats, _, err := a.Stats(ctx, orderBy, descending)
+	newStats, _, err := a.Stats(ctx, nil, orderBy, descending)
 	if err != nil {
 		return err
 	}

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -278,7 +278,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 		return err
 	}
 
-	initialStats, _, err := a.Stats(ctx, orderBy, descending)
+	initialStats, _, err := a.Stats(ctx, nil, orderBy, descending)
 	if err != nil {
 		return err
 	}

--- a/cmd/appliance/upgrade/status.go
+++ b/cmd/appliance/upgrade/status.go
@@ -65,7 +65,7 @@ func upgradeStatusRun(cmd *cobra.Command, args []string, opts *upgradeStatusOpti
 	if err != nil {
 		return err
 	}
-	initialStats, _, err := a.Stats(ctx, orderBy, descending)
+	initialStats, _, err := a.Stats(ctx, nil, orderBy, descending)
 	if err != nil {
 		return err
 	}

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -141,12 +141,16 @@ func (a *Appliance) UpgradeCancel(ctx context.Context, applianceID string) error
 	return nil
 }
 
-func (a *Appliance) Stats(ctx context.Context, orderBy []string, descending bool) (*openapi.StatsAppliancesList, *http.Response, error) {
+func (a *Appliance) Stats(ctx context.Context, filter map[string]map[string]string, orderBy []string, descending bool) (*openapi.StatsAppliancesList, *http.Response, error) {
 	status, response, err := a.APIClient.ApplianceStatsApi.StatsAppliancesGet(ctx).Authorization(a.Token).Execute()
 	if err != nil {
 		return status, response, api.HTTPErrorResponse(response, err)
 	}
-	stats, err := orderApplianceStats(status.GetData(), orderBy, descending)
+	stats, _, err := FilterApplianceStats(status.GetData(), filter, orderBy, descending)
+	if err != nil {
+		return status, response, err
+	}
+	stats, err = orderApplianceStats(stats, orderBy, descending)
 	if err != nil {
 		return status, response, err
 	}

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -185,7 +185,7 @@ NO_ENABLE_CHECK:
 	}
 
 	// Filter offline appliances
-	initialStats, _, err := app.Stats(ctx, opts.OrderBy, opts.Descending)
+	initialStats, _, err := app.Stats(ctx, nil, opts.OrderBy, opts.Descending)
 	if err != nil {
 		return backupIDs, err
 	}

--- a/pkg/appliance/prompt.go
+++ b/pkg/appliance/prompt.go
@@ -16,7 +16,7 @@ func PromptSelect(ctx context.Context, a *Appliance, filter map[string]map[strin
 	if err != nil {
 		return "", err
 	}
-	stats, _, err := a.Stats(ctx, orderBy, descending)
+	stats, _, err := a.Stats(ctx, nil, orderBy, descending)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/appliance/status.go
+++ b/pkg/appliance/status.go
@@ -28,7 +28,7 @@ func (u *ApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance 
 	})
 	logEntry.WithField("want", want).Info("Polling for the appliance status")
 	return backoff.Retry(func() error {
-		stats, _, err := u.Appliance.Stats(ctx, nil, false)
+		stats, _, err := u.Appliance.Stats(ctx, nil, nil, false)
 		if err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ func (u *ApplianceStatus) WaitForApplianceState(ctx context.Context, appliance o
 	return backoff.Retry(func() error {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		stats, _, err := u.Appliance.Stats(ctx, nil, false)
+		stats, _, err := u.Appliance.Stats(ctx, nil, nil, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -126,6 +126,8 @@ func ParseFilteringFlags(flags *pflag.FlagSet, defaultFilter map[string]map[stri
 					result[v][f] = value
 				}
 			}
+		} else if err != nil {
+			log.WithError(err).Error("failed to parse filter")
 		}
 	}
 


### PR DESCRIPTION
This PR implements filtering for the `appliance stats` command, making it easier to see stats for particular appliances.

The filter works the same as the general appliance filter, but uses different keywords for filtering. These include the ability to filter by name, id, status, state and function. More keywords may be added in the future.