### PR TITLE
Fix configure not checking protocol

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -54,7 +54,7 @@ func NewCmdConfigure(f *factory.Factory) *cobra.Command {
 			switch len(args) {
 			case 0:
 				if noInteractive || !opts.CanPrompt {
-					return errors.New("Can't prompt, You need to provide all arguments, for example 'sdpctl configure appgate.controller.com'")
+					return errors.New("Can't prompt, You need to provide all arguments, for example 'sdpctl configure company.controller.com'")
 				}
 				q := &survey.Input{
 					Message: "Enter the url for the Controller API (example https://controller.company.com:8443)",

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -142,7 +142,7 @@ func argValidation(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("'%s' is not a valid argument. Did you mean 'signin'?", arg)
 		}
 		// If arg is missing protocol prefix, temporarily add one to validate the url
-		if !strings.HasPrefix(arg, "http") {
+		if !strings.HasPrefix(arg, "https://") || !strings.HasPrefix(arg, "http://") {
 			arg = "https://" + arg
 		}
 		if !util.IsValidURL(arg) {

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/appgate/sdpctl/pkg/configuration"
@@ -139,6 +140,10 @@ func argValidation(cmd *cobra.Command, args []string) error {
 		regex := regexp.MustCompile(`[signin]{3,}`)
 		if regex.MatchString(arg) {
 			return fmt.Errorf("'%s' is not a valid argument. Did you mean 'signin'?", arg)
+		}
+		// If arg is missing protocol prefix, temporarily add one to validate the url
+		if !strings.HasPrefix(arg, "http") {
+			arg = "https://" + arg
 		}
 		if !util.IsValidURL(arg) {
 			return fmt.Errorf("'%s' is not a valid URL", arg)

--- a/docs/sdpctl_configure.html
+++ b/docs/sdpctl_configure.html
@@ -29,7 +29,7 @@ See &lsquo;sdpctl help environment&rsquo; for more information on using environm
   &gt; sdpctl configure
 
   # configuration, no interactive
-  &gt; sdpctl configure appgate.controller.com
+  &gt; sdpctl configure company.controller.com
 
   # configure sdpctl using a custom certificate file
   &gt; sdpctl configure --pem=/path/to/pem

--- a/pkg/docs/configure.go
+++ b/pkg/docs/configure.go
@@ -13,7 +13,7 @@ See 'sdpctl help environment' for more information on using environment variable
 			},
 			{
 				Description: "configuration, no interactive",
-				Command:     "sdpctl configure appgate.controller.com",
+				Command:     "sdpctl configure company.controller.com",
 			},
 			{
 				Description: "configure sdpctl using a custom certificate file",


### PR DESCRIPTION
This PR fixes an issue where the configure command would error if the url provided in the argument does not contain the protocol as a prefix.