### PR TITLE
Various improvements to sdpctl goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,9 @@ builds:
   - <<: &build_defaults
       binary: "{{ .ProjectName }}"
       main: ./main.go
+      buildmode: pie
+      flags:
+        - -trimpath
       ldflags:
         - -s -w -X "github.com/appgate/sdpctl/cmd.version={{ if .IsSnapshot }}{{ .Env.SNAPSHOT_VERSION }}-dev{{ else }}{{ .Version }}{{ end }}"
         - -X "github.com/appgate/sdpctl/cmd.commit={{ .FullCommit }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,3 +97,44 @@ nfpms:
         - no-manual-page
     rpm:
       compression: gzip
+brews:
+  - name: sdpctl
+    commit_author:
+      name: aitorbot
+      email: aitorbot@appgate.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    folder: Formula
+    homepage: "https://github.com/appgate/sdpctl/releases"
+    description: "Official CLI tool for managing Appgate SDP Collectives"
+    license: "MIT"
+    install: |
+      bin.install "sdpctl"
+      generate_completions_from_executable("#{bin}/sdpctl", "completion", shells: [:bash, :zsh, :fish])
+    test: |
+      version_output = shell_output("#{bin}/sdpctl --version")
+      assert_match "sdpctl version #{version}", version_output.split("\n")[0]
+
+      profile_add = shell_output("#{bin}/sdpctl profile add test")
+      expected = "Created profile test, run 'sdpctl profile list' to see all available profiles\n" \
+                 "run 'sdpctl profile set test' to select the new profile"
+      assert_match expected, profile_add
+
+      profile_set = shell_output("#{bin}/sdpctl profile set test")
+      expected = "test is selected as current sdp profile\n" \
+                 "test is not configured yet, run 'sdpctl configure'"
+      assert_match expected, profile_set
+
+      configure = shell_output("#{bin}/sdpctl configure https://example.com:8443")
+      expected = "Configuration updated successfully"
+      assert_match expected, configure
+    repository:
+      owner: appgate
+      name: homebrew-tap
+      branch: main
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: appgate
+          name: homebrew-tap
+          branch: main

--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ gpg --output - --verify checksums.txt.asc | sha256sum --check --ignore-missing
 ```
 
 ## macOS
-Download the latest [macOS build](https://github.com/appgate/sdpctl/releases/latest) from the releases page. Then install using the command line:
+Download our latest macOS release from [Appgate Homebrew Tap](https://github.com/appgate/homebrew-tap)
+```bash
+$ brew tap appgate/tap
+$ brew install sdpctl
+```
+
+You can can manually download the latest [macOS build](https://github.com/appgate/sdpctl/releases/latest) from the releases page. Then install using the command line:
 ```bash
 # Unpack the downloaded package in the current directory
 $ gunzip -c <path-to-downloaded-tar> | tar xopf -


### PR DESCRIPTION
Security Improvements:
- Set `-trimpath` to remove appgate/sdp module path from build
- Set `buildmode: pie` to enable address space layout randomization 

Homebrew
- Add `brew` configuration to make goreleaser automatically publish PRs to Homebrew formula for sdpctl
- Update sdpctl installation doc for macOS to use brew

I tested this new config with `goreleaser --skip publish` 