### PR TITLE
Goreleaser-release-improvements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -154,4 +154,10 @@ brews:
     repository:
       owner: appgate
       name: homebrew-tap
-      branch: main
+      branch: "{{.ProjectName}}-{{.Tag}}"
+      pull_request:
+        enabled: true
+        base:
+          owner: appgate
+          name: homebrew-tap
+          branch: main

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,15 +10,23 @@ snapshot:
   name_template: "{{ if .IsSnapshot }}{{ .Env.SNAPSHOT_VERSION }}{{ else }}{{ .Tag }}{{ end }}"
 changelog:
   use: github
+  sort: desc
   groups:
   - title: Features
     regexp: '^.*feat(\([[:word:]]+\))??!?:.+$'
     order: 0
+  - title: Bug Fixes
+    regexp: '^.*bug(\([[:word:]]+\))??!?:.+$'
+    order: 1
   - title: Dependencies
-    regexp: '^Bump.*'
-    order: 10
-  - title: Other
+    regexp: '^.*dependabot(\([[:word:]]+\))??!?:.+$'
+    order: 3
+  - title: Others
     order: 999
+  filters:
+    exclude:
+      - "^docs:"
+      - typo
 github_urls:
   download: https://github.com/appgate/sdpctl/releases
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gomarkdown/markdown v0.0.0-20230322041520-c84983bdbf2a
 	github.com/google/go-cmp v0.6.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/google/uuid v1.5.0
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
-github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
-github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
Makes internal release publishing easier.

- Tries to group different commits into categories in the changelog generated for the release
- Creates a PR request for the Homebrew Tap instead of pushing to main