### PR TITLE
Always have the same name for logserver bundle on appliance

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -530,6 +530,10 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				"Content-Type":        writer.FormDataContentType(),
 				"Content-Disposition": fmt.Sprintf("attachment; filename=%q", zipInfo.Name()),
 			}
+			log.WithFields(log.Fields{
+				"local-name":  localLogServerBundleName,
+				"remote-name": logServerZipName,
+			}).Info("uploading local logserver bundle")
 			if !opts.ciMode {
 				err = uploadWithProgress(ctx, pr, "uploading "+localLogServerBundleName, zipInfo.Size(), headers)
 			} else {

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -451,8 +451,9 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 			return err
 		}
 		logServerZipName := fmt.Sprintf("logserver-%s.zip", tagVersion)
+		var localLogServerBundleName string
 		if len(opts.logServerBundlePath) > 0 {
-			logServerZipName = filepath.Base(opts.logServerBundlePath)
+			localLogServerBundleName = filepath.Base(opts.logServerBundlePath)
 		}
 
 		// check if already exists
@@ -530,7 +531,7 @@ func prepareRun(cmd *cobra.Command, args []string, opts *prepareUpgradeOptions) 
 				"Content-Disposition": fmt.Sprintf("attachment; filename=%q", zipInfo.Name()),
 			}
 			if !opts.ciMode {
-				err = uploadWithProgress(ctx, pr, "uploading "+logServerZipName, zipInfo.Size(), headers)
+				err = uploadWithProgress(ctx, pr, "uploading "+localLogServerBundleName, zipInfo.Size(), headers)
 			} else {
 				err = a.UploadFile(ctx, pr, headers)
 			}


### PR DESCRIPTION
This PR will change the behaviour when uploading a local logserver bundle. Instead of uploading the bundle with the same name as the local file, the bundle will have a consistent `logserver-X.X.zip` name once uploaded to the appliance.

This will prevent the upgrade hook misidentifying the bundle when preparing an upgrade.