### PR TITLE
internal: add docker registry to build

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,7 @@ changelog:
     - title: New Features
       labels:
         - feature
+        - enhancement
     - title: Bugfixes
       labels:
         - bug

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: New Features
+      labels:
+        - feature
+    - title: Bugfixes
+      labels:
+        - bug
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,3 +15,7 @@ changelog:
       exclude:
         labels:
           - dependencies
+  exclude:
+    labels:
+      - documentation
+      - internal

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,25 +9,7 @@ before:
 snapshot:
   name_template: "{{ if .IsSnapshot }}{{ .Env.SNAPSHOT_VERSION }}{{ else }}{{ .Tag }}{{ end }}"
 changelog:
-  use: github
-  sort: desc
-  groups:
-  - title: Features
-    regexp: '^.*feat(\([[:word:]]+\))??!?:.+$'
-    order: 0
-  - title: Bug Fixes
-    regexp: '^.*bug(\([[:word:]]+\))??!?:.+$'
-    order: 1
-  - title: Dependencies
-    regexp: '^.*dependabot(\([[:word:]]+\))??!?:.+$'
-    order: 3
-  - title: Others
-    order: 999
-  filters:
-    exclude:
-      - "^docs:"
-      - "^CI:"
-      - typo
+  use: github-native
 github_urls:
   download: https://github.com/appgate/sdpctl/releases
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ prefix  := /usr/local
 bindir  := ${prefix}/bin
 commit=$$(git rev-parse HEAD)
 commitPath=github.com/appgate/sdpctl/cmd.commit=${commit}
+date=$$(date --iso-8601)
 
 CGO := 0
 ifeq ($(shell uname),Darwin)
@@ -14,7 +15,7 @@ endif
 
 .PHONY: build
 build:
-	CGO_ENABLED=$(CGO) go build -o build/$(BIN_NAME) -ldflags="-X '${commitPath}'"
+	CGO_ENABLED=$(CGO) go build -o build/$(BIN_NAME) -ldflags="-X '${commitPath}' -X 'github.com/appgate/sdpctl/pkg/factory.dockerRegistry=$(DOCKER_REGISTRY_URL)' -X 'github.com/appgate/sdpctl/cmd.buildDate=$(date)'"
 
 .PHONY: deps
 deps:

--- a/docs/sdpctl_appliance_backup.html
+++ b/docs/sdpctl_appliance_backup.html
@@ -51,7 +51,7 @@ will be created there if it doesn&rsquo;t already exist and the backups will be 
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
 <pre class="code-editor margin-bottom"><code>      --all                  backup all appliances in the Collective
       --current              backup the current peer Controller
-  -d, --destination string   backup destination directory (default &quot;$HOME/Downloads/backup&quot;)
+  -d, --destination string   backup destination directory (default &quot;$HOME/Downloads/appgate/backup&quot;)
   -h, --help                 help for backup
       --primary              backup the primary Controller
       --quiet                backup summary will not be printed if setting this flag

--- a/docs/sdpctl_appliance_functions_download.html
+++ b/docs/sdpctl_appliance_functions_download.html
@@ -35,7 +35,7 @@
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
 <pre class="code-editor margin-bottom"><code>      --docker-registry string   docker registry for downloading image bundles
   -h, --help                     help for download
-      --save-path string         path to where the container bundle should be saved (default &quot;$HOME/Downloads&quot;)
+      --save-path string         path to where the container bundle should be saved (default &quot;$HOME/Downloads/appgate&quot;)
       --version string           Override the LogServer version that will be downloaded. Defaults to the same version as the primary controller.
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>


### PR DESCRIPTION
Adds option to add a docker registry as an environment variable, `DOCKER_REGISTRY_URL`, when building with `make build`