### PR TITLE
CI: auto-label-job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,16 @@
+feature:
+  - head-branch: ['feat', 'feature']
+
+bug:
+  - head-branch: ['bug', 'fix']
+
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file: ['go.mod', 'go.sum']
+
+documentation:
+  - changed-files:
+    - any-glob-to-any-file: 'docs/**/*'
+
+internal:
+  - head-branch: ['internal', 'CI']

--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -11,17 +11,12 @@ jobs:
     steps:
       - name: Send announce event
         run: |
-          # Set required variables
-          repo_owner="appgate"
-          repo_name="homebrew-tap"
-          event_type="sdpctl_release"
-          version="${{ github.event.release.name }}"
-
           # Trigger event
           curl -L \
+            --fail-with-body \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
-            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"unit\": false, \"integration\": true}}"
+            https://api.github.com/repos/appgate/homebrew-tap/dispatches \
+            -d "{\"event_type\": \"sdpctl_release\", \"client_payload\": {\"version\": \"${{ github.event.release.name }}\", \"unit\": false, \"integration\": true}}"

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,14 @@
+name: Auto Label
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  auto-label:
+    name: Auto Label Pull Requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Labeler
+        uses: actions/labeler@v5.0.0
+

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -366,10 +366,9 @@ func (c *Config) CheckForUpdate(out io.Writer, client *http.Client, current stri
 	if !r.Draft && !r.PreRelease && n.GreaterThan(v) {
 		latest = n
 	}
-	if latest == nil {
-		return c, errors.New("already at latest version")
+	if latest != nil {
+		fmt.Fprintf(out, "NOTICE: A new version of sdpctl is available for download: %s\nDownload it here: https://github.com/appgate/sdpctl/releases/tag/%s\n\n", latest.Original(), latest.Original())
 	}
-	fmt.Fprintf(out, "NOTICE: A new version of sdpctl is available for download: %s\nDownload it here: https://github.com/appgate/sdpctl/releases/tag/%s\n\n", latest.Original(), latest.Original())
 	return c, nil
 }
 


### PR DESCRIPTION
Implements auto labeling when creating a pull request. This makes the release note generation a bit simpler.

Also includes some small fixes in the announce job and also does not treat an updated sdpctl version as an error.