### PR TITLE
Only show disk space warning when files are actually being uploaded

### DIFF
--- a/cmd/appliance/files/upload.go
+++ b/cmd/appliance/files/upload.go
@@ -81,7 +81,7 @@ func NewFilesUploadCmd(f *factory.Factory) *cobra.Command {
 			}
 
 			ctx := context.Background()
-			filesAPI := files.FilesAPI{API: api}
+			filesAPI := files.FileManager{API: api}
 			if !opts.ciMode {
 				filesAPI.Progress = tui.New(ctx, f.SpinnerOut)
 			}
@@ -138,12 +138,12 @@ func NewFilesUploadCmd(f *factory.Factory) *cobra.Command {
 					continue
 				}
 				wg.Add(1)
-				go func(ctx context.Context, wg *sync.WaitGroup, err chan<- error, f *os.File, filesAPI *files.FilesAPI, rename string) {
+				go func(ctx context.Context, wg *sync.WaitGroup, err chan<- error, f *os.File, filesAPI *files.FileManager, rename string) {
 					defer func() {
 						wg.Done()
 						f.Close()
 					}()
-					err <- filesAPI.Upload(ctx, f, rename)
+					err <- filesAPI.Upload(ctx, files.QueueItem{File: f, RemoteName: rename})
 				}(ctx, &wg, errChan, file, &filesAPI, rename)
 			}
 

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -13,7 +13,6 @@ import (
 	"github.com/appgate/sdpctl/pkg/tui"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-multierror"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -91,7 +90,7 @@ func (f *FileManager) WorkQueue(ctx context.Context) error {
 	if f.Progress != nil {
 		f.Progress.WriteLine(msg, "\n")
 	}
-	logrus.WithFields(log.Fields{
+	log.WithFields(log.Fields{
 		"files": strings.Join(f.FileNames(), ","),
 	}).Info(msg)
 	for _, q := range f.queue {

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -146,4 +147,9 @@ func (p *Progress) Wait() {
 		p.Abort()
 	case <-done:
 	}
+}
+
+func (p *Progress) WriteLine(s, prepend string) {
+	t := fmt.Sprintf("[%s] ", time.Now().Format(time.RFC3339))
+	p.pc.Write([]byte(prepend + t + s + "\n"))
 }


### PR DESCRIPTION
This PR contains changes for handling the preparation of upgrades.

Currently, there's is a disk space warning that is triggered if sdpctl detects that an appliance has low disk space. This is to make sure that the appliances has enough disk space to handle the uploads.

The disk space warning, however, does not take into consideration that uploads may be skipped if the file already exists on the appliance, making it obsolete if no files are actually being uploaded.

This PR fixes this by moving the disk space warning check until after we know that files need to be uploaded.