### PR TITLE
Fix panic when using `logserver-bundle` flag

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -473,6 +473,11 @@ func prepareRun(cmd *cobra.Command, opts *prepareUpgradeOptions) error {
 					bundleProgress.WriteLine("Bundle prepared successfully", "")
 					bundleProgress.Wait()
 				}
+			} else {
+				zip, err = os.Open(opts.logServerBundlePath)
+				if err != nil {
+					return err
+				}
 			}
 
 			if err := fm.AddToQueue(zip, logServerZipName); err != nil {


### PR DESCRIPTION
Uploading a logserver-bundle using the `--logserver-bundle` flag results in panic during prepare.

This fixes the issue by assigning the file used in the `--logserver-bundle` flag to the correct variable before trying to upload.