### PR TITLE
Fix wrong status on switch-partition

### DIFF
--- a/cmd/appliance/switch_partition.go
+++ b/cmd/appliance/switch_partition.go
@@ -190,6 +190,10 @@ func switchPartitionRunE(opts *options) error {
 		return fmt.Errorf("failed to get appliance stats: %w", err)
 	}
 
+	if err := api.ApplianceStats.WaitForApplianceStatus(ctx, *appliance, appliancepkg.StatusNotBusy, t); err != nil {
+		return err
+	}
+
 	if p != nil {
 		p.Wait()
 	}

--- a/cmd/appliance/switch_partition.go
+++ b/cmd/appliance/switch_partition.go
@@ -166,17 +166,27 @@ func switchPartitionRunE(opts *options) error {
 		go t.Watch(appliancepkg.StatusNotBusy, []string{"error"})
 	}
 
+	log.Info("switching partition")
 	err = backoff.Retry(func() error {
+		log.Debug("calling switch-partition on appliance")
 		return api.ApplianceSwitchPartition(ctx, opts.id.String())
 	}, backoff.NewExponentialBackOff())
 	if err != nil {
+		if t != nil {
+			t.Update("error")
+			t.Fail(err.Error())
+		}
+		log.WithError(err).Error("partition switch failed")
 		return fmt.Errorf("partition switch failed on appliance %s: %v", opts.id, err)
 	}
 
+	log.Info("polling for appliance state")
 	if err := api.ApplianceStats.WaitForApplianceState(ctx, *appliance, appliancepkg.StatReady, t); err != nil {
 		if t != nil {
+			t.Update("error")
 			t.Fail(err.Error())
 		}
+		log.WithError(err).Error("failed to get appliance state")
 		return fmt.Errorf("failed to get appliance stats: %w", err)
 	}
 

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -342,7 +342,7 @@ func (a *Appliance) ApplianceSwitchPartition(ctx context.Context, id string) err
 	if err != nil {
 		return err
 	}
-	if response.StatusCode != http.StatusAccepted {
+	if response.StatusCode >= 400 {
 		return api.HTTPErrorResponse(response, fmt.Errorf("unexpected response: %s", response.Status))
 	}
 	return nil

--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -338,12 +338,9 @@ func (a *Appliance) UpgradeSwitchPartition(ctx context.Context, id string) error
 
 func (a *Appliance) ApplianceSwitchPartition(ctx context.Context, id string) error {
 	req := a.APIClient.ApplianceApi.AppliancesIdSwitchPartitionPost(ctx, id).Authorization(a.Token)
-	response, err := req.Execute()
+	_, err := req.Execute()
 	if err != nil {
 		return err
-	}
-	if response.StatusCode >= 400 {
-		return api.HTTPErrorResponse(response, fmt.Errorf("unexpected response: %s", response.Status))
 	}
 	return nil
 }


### PR DESCRIPTION
The switch-partition command on an appliance would fail even though the api call was successful due to the API specification being wrong and/or the response status check in sdpctl being too strict.

This PR will loosen up the response status check to make the command successful as long as the response status is lower than 400.