### PR TITLE
Feature: show name in resolve-name-status table

### DIFF
--- a/cmd/appliance/resolve_name_status.go
+++ b/cmd/appliance/resolve_name_status.go
@@ -18,13 +18,14 @@ import (
 )
 
 type resolveNameStatusOpts struct {
-	Config      *configuration.Config
-	Out         io.Writer
-	Client      func(c *configuration.Config) (*openapi.APIClient, error)
-	Appliance   func(c *configuration.Config) (*appliancepkg.Appliance, error)
-	debug       bool
-	json        bool
-	applianceID string
+	Config       *configuration.Config
+	Out          io.Writer
+	Client       func(c *configuration.Config) (*openapi.APIClient, error)
+	Appliance    func(c *configuration.Config) (*appliancepkg.Appliance, error)
+	withPartials bool
+	debug        bool
+	json         bool
+	applianceID  string
 }
 
 func NewResolveNameStatusCmd(f *factory.Factory) *cobra.Command {
@@ -82,16 +83,17 @@ func NewResolveNameStatusCmd(f *factory.Factory) *cobra.Command {
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
-			return resolveNameStatusRun(c, args, &opts)
+			return resolveNameStatusRun(&opts)
 		},
 	}
+	cmd.Flags().BoolVar(&opts.withPartials, "with-partials", false, "include all partial resolutions in table")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Display in JSON format")
 	cmd.SetHelpFunc(cmdutil.HideIncludeExcludeFlags)
 
 	return cmd
 }
 
-func resolveNameStatusRun(cmd *cobra.Command, args []string, opts *resolveNameStatusOpts) error {
+func resolveNameStatusRun(opts *resolveNameStatusOpts) error {
 	client, err := opts.Client(opts.Config)
 	if err != nil {
 		return err
@@ -111,9 +113,16 @@ func resolveNameStatusRun(cmd *cobra.Command, args []string, opts *resolveNameSt
 	}
 
 	p := util.NewPrinter(opts.Out, 4)
-	p.AddHeader("Partial", "Finals", "Partials", "Errors")
-	for _, r := range result.GetResolutions() {
-		p.AddLine(r.GetPartial(), r.GetFinals(), r.GetPartials(), r.GetErrors())
+	if opts.withPartials {
+		p.AddHeader("Name", "Partial Resolutions", "Final Resolutions", "Errors", "Partials")
+		for k, r := range result.GetResolutions() {
+			p.AddLine(k, r.GetPartial(), r.GetFinals(), r.GetErrors(), r.GetPartials())
+		}
+	} else {
+		p.AddHeader("Name", "Partial Resolutions", "Final Resolutions", "Errors")
+		for k, r := range result.GetResolutions() {
+			p.AddLine(k, r.GetPartial(), r.GetFinals(), r.GetErrors())
+		}
 	}
 	p.Print()
 	return nil

--- a/cmd/appliance/resolve_name_status.go
+++ b/cmd/appliance/resolve_name_status.go
@@ -86,7 +86,7 @@ func NewResolveNameStatusCmd(f *factory.Factory) *cobra.Command {
 			return resolveNameStatusRun(&opts)
 		},
 	}
-	cmd.Flags().BoolVar(&opts.withPartials, "with-partials", false, "include all partial resolutions in table")
+	cmd.Flags().BoolVar(&opts.withPartials, "partial-resolution", false, "include all partial resolutions in table")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Display in JSON format")
 	cmd.SetHelpFunc(cmdutil.HideIncludeExcludeFlags)
 
@@ -114,14 +114,14 @@ func resolveNameStatusRun(opts *resolveNameStatusOpts) error {
 
 	p := util.NewPrinter(opts.Out, 4)
 	if opts.withPartials {
-		p.AddHeader("Name", "Partial Resolutions", "Final Resolutions", "Errors", "Partials")
+		p.AddHeader("Name", "Final Resolutions", "Partial Resolution", "Errors", "Partials")
 		for k, r := range result.GetResolutions() {
-			p.AddLine(k, r.GetPartial(), r.GetFinals(), r.GetErrors(), r.GetPartials())
+			p.AddLine(k, r.GetFinals(), r.GetPartial(), r.GetErrors(), r.GetPartials())
 		}
 	} else {
-		p.AddHeader("Name", "Partial Resolutions", "Final Resolutions", "Errors")
+		p.AddHeader("Name", "Final Resolutions", "Partial Resolution", "Errors")
 		for k, r := range result.GetResolutions() {
-			p.AddLine(k, r.GetPartial(), r.GetFinals(), r.GetErrors())
+			p.AddLine(k, r.GetFinals(), r.GetPartial(), r.GetErrors())
 		}
 	}
 	p.Print()

--- a/cmd/appliance/resolve_name_status_test.go
+++ b/cmd/appliance/resolve_name_status_test.go
@@ -9,13 +9,107 @@ import (
 	"testing"
 
 	"github.com/appgate/sdp-api-client-go/api/v20/openapi"
-	"github.com/appgate/sdpctl/pkg/appliance"
+	appliancepkg "github.com/appgate/sdpctl/pkg/appliance"
 	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/factory"
 	"github.com/appgate/sdpctl/pkg/httpmock"
 	"github.com/appgate/sdpctl/pkg/util"
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestResolveNameStatusCMD(t *testing.T) {
+	tests := []struct {
+		name, appliance, cli, want string
+		wantErr                    bool
+		wantErrOut                 *regexp.Regexp
+	}{
+		{
+			name:      "basic name resolution status test",
+			appliance: appliancepkg.TestAppliancePrimary,
+			want: `Name                                                          Partial Resolutions    Final Resolutions               Errors
+----                                                          -------------------    -----------------               ------
+aws://lb-tag:kubernetes.io/service-name=opsnonprod/erp-dev    false                  [3.120.51.78 35.156.237.184]    []
+`,
+		},
+		{
+			name:      "name resolution status table with partials",
+			cli:       "--with-partials",
+			appliance: appliancepkg.TestAppliancePrimary,
+			want: `Name                                                          Partial Resolutions    Final Resolutions               Errors    Partials
+----                                                          -------------------    -----------------               ------    --------
+aws://lb-tag:kubernetes.io/service-name=opsnonprod/erp-dev    false                  [3.120.51.78 35.156.237.184]    []        [dns://all.GW-ELB-2001535196.eu-central-1.elb.amazonaws.com dns://all.purple-lb-1785267452.eu-central-1.elb.amazonaws.com]
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := httpmock.NewRegistry(t)
+			hostname := "appgate.test"
+			coll := appliancepkg.GenerateCollective(t, hostname, "6.3", "", []string{tt.appliance})
+			appliance := coll.Appliances[tt.appliance]
+			for _, stub := range coll.GenerateStubs(coll.GetAppliances(), *coll.Stats, *coll.UpgradedStats) {
+				registry.RegisterStub(stub)
+			}
+			defer registry.Teardown()
+			registry.Serve()
+
+			stdout := &bytes.Buffer{}
+			stdin := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			in := io.NopCloser(stdin)
+			f := &factory.Factory{
+				Config: &configuration.Config{
+					Debug: false,
+					URL:   fmt.Sprintf("http://%s:%d/admin", hostname, registry.Port),
+				},
+				IOOutWriter: stdout,
+				Stdin:       in,
+				StdErr:      stderr,
+			}
+			f.APIClient = func(c *configuration.Config) (*openapi.APIClient, error) {
+				return registry.Client, nil
+			}
+			f.Appliance = func(c *configuration.Config) (*appliancepkg.Appliance, error) {
+				api, _ := f.APIClient(c)
+
+				a := &appliancepkg.Appliance{
+					APIClient:  api,
+					HTTPClient: api.GetConfig().HTTPClient,
+					Token:      "",
+				}
+				return a, nil
+			}
+			args := []string{appliance.GetId()}
+			if len(tt.cli) > 0 {
+				args = append(args, tt.cli)
+			}
+			cmd := NewResolveNameStatusCmd(f)
+			cmd.SetArgs(args)
+			cmd.PersistentFlags().Bool("descending", false, "")
+			cmd.PersistentFlags().StringSlice("order-by", []string{"name"}, "")
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			_, err := cmd.ExecuteC()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewResolveNameStatusCmd() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.wantErrOut != nil {
+				if !tt.wantErrOut.MatchString(err.Error()) {
+					t.Errorf("Expected output to match, got:\n%s\n expected: \n%s\n", tt.wantErrOut, err.Error())
+				}
+				return
+			}
+			body, err := io.ReadAll(stdout)
+			if err != nil {
+				t.Fatalf("unable to read stdout %s", err)
+			}
+			got := string(body)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestNewResolveNameStatusCmdJSON(t *testing.T) {
 	tests := []struct {
@@ -83,10 +177,10 @@ func TestNewResolveNameStatusCmdJSON(t *testing.T) {
 			f.APIClient = func(c *configuration.Config) (*openapi.APIClient, error) {
 				return registry.Client, nil
 			}
-			f.Appliance = func(c *configuration.Config) (*appliance.Appliance, error) {
+			f.Appliance = func(c *configuration.Config) (*appliancepkg.Appliance, error) {
 				api, _ := f.APIClient(c)
 
-				a := &appliance.Appliance{
+				a := &appliancepkg.Appliance{
 					APIClient:  api,
 					HTTPClient: api.GetConfig().HTTPClient,
 					Token:      "",
@@ -136,9 +230,7 @@ func TestNewResolveNameStatusCmdJSON(t *testing.T) {
   }
 }
 `
-			if diff := cmp.Diff(want, got, httpmock.TransformJSONFilter); diff != "" {
-				t.Fatalf("JSON Diff (-want +got):\n%s", diff)
-			}
+			assert.Equal(t, want, got)
 		})
 	}
 }

--- a/cmd/appliance/resolve_name_status_test.go
+++ b/cmd/appliance/resolve_name_status_test.go
@@ -26,18 +26,18 @@ func TestResolveNameStatusCMD(t *testing.T) {
 		{
 			name:      "basic name resolution status test",
 			appliance: appliancepkg.TestAppliancePrimary,
-			want: `Name                                                          Partial Resolutions    Final Resolutions               Errors
-----                                                          -------------------    -----------------               ------
-aws://lb-tag:kubernetes.io/service-name=opsnonprod/erp-dev    false                  [3.120.51.78 35.156.237.184]    []
+			want: `Name                                                          Final Resolutions               Partial Resolution    Errors
+----                                                          -----------------               ------------------    ------
+aws://lb-tag:kubernetes.io/service-name=opsnonprod/erp-dev    [3.120.51.78 35.156.237.184]    false                 []
 `,
 		},
 		{
 			name:      "name resolution status table with partials",
-			cli:       "--with-partials",
+			cli:       "--partial-resolution",
 			appliance: appliancepkg.TestAppliancePrimary,
-			want: `Name                                                          Partial Resolutions    Final Resolutions               Errors    Partials
-----                                                          -------------------    -----------------               ------    --------
-aws://lb-tag:kubernetes.io/service-name=opsnonprod/erp-dev    false                  [3.120.51.78 35.156.237.184]    []        [dns://all.GW-ELB-2001535196.eu-central-1.elb.amazonaws.com dns://all.purple-lb-1785267452.eu-central-1.elb.amazonaws.com]
+			want: `Name                                                          Final Resolutions               Partial Resolution    Errors    Partials
+----                                                          -----------------               ------------------    ------    --------
+aws://lb-tag:kubernetes.io/service-name=opsnonprod/erp-dev    [3.120.51.78 35.156.237.184]    false                 []        [dns://all.GW-ELB-2001535196.eu-central-1.elb.amazonaws.com dns://all.purple-lb-1785267452.eu-central-1.elb.amazonaws.com]
 `,
 		},
 	}

--- a/docs/sdpctl_appliance_functions_download.html
+++ b/docs/sdpctl_appliance_functions_download.html
@@ -33,9 +33,10 @@
   &gt; sdpctl appliance functions download LogServer --docker-registry=&lt;path-to-custom-docker-registry&gt;
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
-<pre class="code-editor margin-bottom"><code>      --docker-registry string   docker registry for downloading image bundles
+<pre class="code-editor margin-bottom"><code>      --destination string       path to a directory where the container bundle should be saved. The command will create a directory if it doesn't already exist (default &quot;$HOME/Downloads/appgate&quot;)
+      --docker-registry string   docker registry for downloading image bundles
   -h, --help                     help for download
-      --save-path string         path to where the container bundle should be saved (default &quot;$HOME/Downloads/appgate&quot;)
+      --save-path string         [DEPRECATED, use '--destination' instead] path to a directory where the container bundle should be saved. The command will create a directory if it doesn't already exist
       --version string           Override the LogServer version that will be downloaded. Defaults to the same version as the primary controller.
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>

--- a/docs/sdpctl_appliance_resolve-name-status.html
+++ b/docs/sdpctl_appliance_resolve-name-status.html
@@ -44,8 +44,9 @@ Clients and shows the resolution results</p><pre class="code-editor margin-botto
   }
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
-<pre class="code-editor margin-bottom"><code>  -h, --help   help for resolve-name-status
-      --json   Display in JSON format
+<pre class="code-editor margin-bottom"><code>  -h, --help                 help for resolve-name-status
+      --json                 Display in JSON format
+      --partial-resolution   include all partial resolutions in table
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>
 <pre class="code-editor margin-bottom"><code>      --api-version int          Peer API version override

--- a/pkg/httpmock/http.go
+++ b/pkg/httpmock/http.go
@@ -60,11 +60,6 @@ func NewRegistry(t *testing.T) *Registry {
 	os.Setenv("SDPCTL_BEARER", "header-token-value")
 	t.Cleanup(func() {
 		t.Helper()
-		for _, s := range r.stubs {
-			if !s.matched {
-				t.Logf("URL %s was registered but never used", s.URL)
-			}
-		}
 		for _, notFound := range r.notFound {
 			t.Logf("%s was not registered, but requested", notFound)
 		}


### PR DESCRIPTION
This PR is an update for the resolve-name-status command. The update includes showing the resolved name in the table presented instead of only in the json output.

Partial resolutions are excluded from the table by default to not clutter the output, but can be shown using the `--partial-resolutions`