### PR TITLE
Fix upgrades failing when there are offline/inactive appliances

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ^1.22
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get dependencies
         run: |
@@ -37,14 +37,14 @@ jobs:
     name: "Static analysis"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.22.x"
       - run: "GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@2023.1"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/staticcheck
           key: staticcheck-${{ github.sha }}

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -202,7 +202,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	if err != nil {
 		return err
 	}
-	active, _ := appliancepkg.FilterActivated(postOnlineInclude)
+	active, inactive := appliancepkg.FilterActivated(postOnlineInclude)
 
 	upgradeStatusMap, err := a.UpgradeStatusMap(ctx, active)
 	if err != nil {
@@ -214,6 +214,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	}
 	primaryController := plan.GetPrimaryController()
 	plan.AddOfflineAppliances(offline)
+	plan.AddInactiveAppliances(inactive)
 	if err := plan.Validate(); err != nil {
 		return err
 	}

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -198,18 +198,20 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	if err != nil {
 		return err
 	}
+	postOnlineInclude, offline, err := appliancepkg.FilterAvailable(rawAppliances, initialStats.GetData())
+	if err != nil {
+		return err
+	}
 	upgradeStatusMap, err := a.UpgradeStatusMap(ctx, rawAppliances)
 	if err != nil {
 		return err
 	}
-	plan, err := appliancepkg.NewUpgradePlan(rawAppliances, initialStats, upgradeStatusMap, controlHost, filter, orderBy, descending)
+	plan, err := appliancepkg.NewUpgradePlan(postOnlineInclude, initialStats, upgradeStatusMap, controlHost, filter, orderBy, descending)
 	if err != nil {
 		return err
 	}
-	primaryController, err := appliancepkg.FindPrimaryController(rawAppliances, controlHost, true)
-	if err != nil {
-		return err
-	}
+	primaryController := plan.GetPrimaryController()
+	plan.AddOfflineAppliances(offline)
 	bOpts := appliancepkg.BackupOpts{
 		Config:        opts.Config,
 		Appliance:     opts.Appliance,

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -202,11 +202,13 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	if err != nil {
 		return err
 	}
-	upgradeStatusMap, err := a.UpgradeStatusMap(ctx, rawAppliances)
+	active, _ := appliancepkg.FilterActivated(postOnlineInclude)
+
+	upgradeStatusMap, err := a.UpgradeStatusMap(ctx, active)
 	if err != nil {
 		return err
 	}
-	plan, err := appliancepkg.NewUpgradePlan(postOnlineInclude, initialStats, upgradeStatusMap, controlHost, filter, orderBy, descending)
+	plan, err := appliancepkg.NewUpgradePlan(active, initialStats, upgradeStatusMap, controlHost, filter, orderBy, descending)
 	if err != nil {
 		return err
 	}

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -212,6 +212,9 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	}
 	primaryController := plan.GetPrimaryController()
 	plan.AddOfflineAppliances(offline)
+	if err := plan.Validate(); err != nil {
+		return err
+	}
 	bOpts := appliancepkg.BackupOpts{
 		Config:        opts.Config,
 		Appliance:     opts.Appliance,

--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -103,7 +103,7 @@ func TestUpgradeCompleteCommand(t *testing.T) {
 		},
 		{
 			name:       "test complete with filter function gateway",
-			cli:        "upgrade complete --backup=false --filter function=gateway --no-interactive",
+			cli:        "upgrade complete --backup=false --include function=gateway --no-interactive",
 			appliances: []string{appliancepkg.TestAppliancePrimary, appliancepkg.TestApplianceGatewayA1, appliancepkg.TestApplianceGatewayA2},
 			from:       "6.2.0",
 			to:         "6.2.1",
@@ -262,8 +262,9 @@ func TestUpgradeCompleteCommand(t *testing.T) {
 			cmd.AddCommand(upgradeCmd)
 
 			// cobra hack
-			cmd.Flags().BoolP("help", "x", false, "")
-			cmd.Flags().Bool("no-interactive", false, "usage")
+			cmd.PersistentFlags().BoolP("help", "x", false, "")
+			cmd.PersistentFlags().Bool("ci-mode", false, "")
+			cmd.PersistentFlags().Bool("no-interactive", false, "usage")
 			cmd.PersistentFlags().String("actual-hostname", "", "")
 
 			argv, err := shlex.Split(tt.cli)

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -148,6 +148,19 @@ func FilterAvailable(appliances []openapi.Appliance, stats []openapi.StatsApplia
 	return result, offline, err
 }
 
+func FilterActivated(appliances []openapi.Appliance) (active []openapi.Appliance, inactive []openapi.Appliance) {
+	inactive = []openapi.Appliance{}
+	active = []openapi.Appliance{}
+	for _, a := range appliances {
+		if a.GetActivated() {
+			active = append(active, a)
+			continue
+		}
+		inactive = append(inactive, a)
+	}
+	return
+}
+
 func GetApplianceVersion(appliance openapi.Appliance, stats openapi.StatsAppliancesList) (*version.Version, error) {
 	for _, s := range stats.GetData() {
 		if s.GetId() == appliance.GetId() {

--- a/pkg/appliance/upgrade_test.go
+++ b/pkg/appliance/upgrade_test.go
@@ -63,8 +63,6 @@ func TestMakeUpgradePlan(t *testing.T) {
 					{coll.Appliances["gatewayA2"], coll.Appliances["gatewayB2"], coll.Appliances["gatewayC2"], coll.Appliances["logforwarderA2"]},
 					{coll.Appliances["connectorA1"], coll.Appliances["gatewayA3"], coll.Appliances["logserver"], coll.Appliances["portalA1"]},
 				},
-				adminHostname: hostname,
-				stats:         coll.Stats,
 			},
 		},
 		{
@@ -100,65 +98,7 @@ func TestMakeUpgradePlan(t *testing.T) {
 					{coll.Appliances["gatewayA2"], coll.Appliances["gatewayB2"], coll.Appliances["gatewayC2"], coll.Appliances["logforwarderA2"]},
 					{coll.Appliances["connectorA1"], coll.Appliances["gatewayA3"], coll.Appliances["logserver"], coll.Appliances["portalA1"]},
 				},
-				adminHostname: hostname,
-				stats:         coll.Stats,
 			},
-		},
-		{
-			name: "test multi controller upgrade error",
-			args: args{
-				appliances: []openapi.Appliance{
-					coll.Appliances["primary"],
-					coll.Appliances["controller3"],
-					coll.Appliances["gatewayA1"],
-					coll.Appliances["gatewayB2"],
-					coll.Appliances["gatewayA2"],
-					coll.Appliances["logserver"],
-					coll.Appliances["logforwarderA2"],
-					coll.Appliances["gatewayB1"],
-					coll.Appliances["connectorA1"],
-					coll.Appliances["gatewayC1"],
-					coll.Appliances["secondary"],
-					coll.Appliances["gatewayA3"],
-					coll.Appliances["gatewayC2"],
-					coll.Appliances["portalA1"],
-					coll.Appliances["logforwarderA1"],
-				},
-				stats:        coll.Stats,
-				ctrlHostname: hostname,
-				filter:       DefaultCommandFilter,
-				orderBy:      nil,
-				descending:   false,
-			},
-			wantErr: true,
-		},
-		{
-			name: "test offline controller",
-			args: args{
-				appliances: []openapi.Appliance{
-					coll.Appliances["primary"],
-					coll.Appliances["controller4"],
-					coll.Appliances["gatewayA1"],
-					coll.Appliances["gatewayB2"],
-					coll.Appliances["gatewayA2"],
-					coll.Appliances["logserver"],
-					coll.Appliances["logforwarderA2"],
-					coll.Appliances["gatewayB1"],
-					coll.Appliances["connectorA1"],
-					coll.Appliances["gatewayC1"],
-					coll.Appliances["secondary"],
-					coll.Appliances["gatewayA3"],
-					coll.Appliances["gatewayC2"],
-					coll.Appliances["portalA1"],
-					coll.Appliances["logforwarderA1"],
-				},
-				stats:        coll.Stats,
-				ctrlHostname: hostname,
-				filter:       DefaultCommandFilter,
-				orderBy:      nil,
-				descending:   false,
-			},
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -181,7 +121,7 @@ func TestMakeUpgradePlan(t *testing.T) {
 			if tt.wantErr {
 				assert.Error(t, err)
 			}
-			assert.Equal(t, tt.want, got)
+			assert.EqualExportedValues(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Upgrades would fail in sdpctl when there are offline/inactive appliances in the collective.

Upgrade would try to be fetched before filtering of the offline/inactive appliances, resulting in an error.