### PR TITLE
internal: use custom token for homebrew merge permissions

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -16,7 +16,7 @@ jobs:
             --fail-with-body \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.HOMEBREW_MERGE_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/appgate/homebrew-tap/dispatches \
             -d "{\"event_type\": \"sdpctl_release\", \"client_payload\": {\"version\": \"${{ github.event.release.name }}\", \"unit\": false, \"integration\": true}}"


### PR DESCRIPTION
Add a custom secret token for auto-merging the homebrew-tap repository