### PR TITLE
Bug: index out of range when preparing

### DIFF
--- a/pkg/appliance/mock.go
+++ b/pkg/appliance/mock.go
@@ -14,30 +14,33 @@ import (
 )
 
 const (
-	TestAppliancePrimary               = "primary"
-	TestApplianceUnpreparedPrimary     = "primary-unprepared"
-	TestApplianceSecondary             = "secondary"
-	TestApplianceController3           = "controller3"
-	TestApplianceControllerOffline     = "controller4"
-	TestApplianceControllerNotPrepared = "controller5"
-	TestApplianceControllerMismatch    = "controller6"
-	TestApplianceGatewayA1             = "gatewayA1"
-	TestApplianceGatewayA2             = "gatewayA2"
-	TestApplianceGatewayA3             = "gatewayA3"
-	TestApplianceGatewayB1             = "gatewayB1"
-	TestApplianceGatewayB2             = "gatewayB2"
-	TestApplianceGatewayB3             = "gatewayB3"
-	TestApplianceGatewayC1             = "gatewayC1"
-	TestApplianceGatewayC2             = "gatewayC2"
-	TestApplianceLogForwarderA1        = "logforwarderA1"
-	TestApplianceLogForwarderA2        = "logforwarderA2"
-	TestAppliancePortalA1              = "portalA1"
-	TestApplianceConnectorA1           = "connectorA1"
-	TestApplianceLogServer             = "logserver"
+	TestAppliancePrimary                  = "primary"
+	TestApplianceUnpreparedPrimary        = "primary-unprepared"
+	TestApplianceSecondary                = "secondary"
+	TestApplianceController3              = "controller3"
+	TestApplianceControllerOffline        = "controller4"
+	TestApplianceControllerNotPrepared    = "controller5"
+	TestApplianceControllerMismatch       = "controller6"
+	TestApplianceControllerGatewayPrimary = "controller-gateway-primary"
+	TestApplianceGatewayA1                = "gatewayA1"
+	TestApplianceGatewayA2                = "gatewayA2"
+	TestApplianceGatewayA3                = "gatewayA3"
+	TestApplianceGatewayB1                = "gatewayB1"
+	TestApplianceGatewayB2                = "gatewayB2"
+	TestApplianceGatewayB3                = "gatewayB3"
+	TestApplianceGatewayC1                = "gatewayC1"
+	TestApplianceGatewayC2                = "gatewayC2"
+	TestApplianceLogForwarderA1           = "logforwarderA1"
+	TestApplianceLogForwarderA2           = "logforwarderA2"
+	TestAppliancePortalA1                 = "portalA1"
+	TestApplianceConnectorA1              = "connectorA1"
+	TestApplianceLogServer                = "logserver"
+	TestApplianceControllerGatewayA1      = "controller-gatewayA1"
+	TestApplianceControllerGatewayB1      = "controller-gatewayB1"
 )
 
 var (
-	PreSetApplianceNames                              = []string{TestAppliancePrimary, TestApplianceSecondary, TestApplianceController3, TestApplianceControllerOffline, TestApplianceControllerNotPrepared, TestApplianceControllerMismatch, TestApplianceGatewayA1, TestApplianceGatewayA2, TestApplianceGatewayA3, TestApplianceGatewayB1, TestApplianceGatewayB2, TestApplianceGatewayB3, TestApplianceGatewayC1, TestApplianceGatewayC2, TestApplianceLogForwarderA1, TestApplianceLogForwarderA2, TestAppliancePortalA1, TestApplianceConnectorA1, TestApplianceLogServer}
+	PreSetApplianceNames                              = []string{TestAppliancePrimary, TestApplianceSecondary, TestApplianceController3, TestApplianceControllerOffline, TestApplianceControllerNotPrepared, TestApplianceControllerMismatch, TestApplianceGatewayA1, TestApplianceGatewayA2, TestApplianceGatewayA3, TestApplianceGatewayB1, TestApplianceGatewayB2, TestApplianceGatewayB3, TestApplianceGatewayC1, TestApplianceGatewayC2, TestApplianceLogForwarderA1, TestApplianceLogForwarderA2, TestAppliancePortalA1, TestApplianceConnectorA1, TestApplianceLogServer, TestApplianceControllerGatewayA1, TestApplianceControllerGatewayB1, TestApplianceControllerGatewayPrimary}
 	InitialTestStats     *openapi.StatsAppliancesList = openapi.NewStatsAppliancesListWithDefaults()
 	UpgradedTestStats    *openapi.StatsAppliancesList = openapi.NewStatsAppliancesListWithDefaults()
 )
@@ -83,6 +86,8 @@ func GenerateCollective(t *testing.T, hostname, from, to string, appliances []st
 			res.addAppliance(n, "", siteA, siteNameA, from, from, statusHealthy, UpgradeStatusIdle, true, []string{FunctionController})
 		case TestApplianceControllerMismatch:
 			res.addAppliance(n, "", siteA, siteNameA, "6.1", from, statusHealthy, UpgradeStatusReady, true, []string{FunctionController})
+		case TestApplianceControllerGatewayPrimary:
+			res.addAppliance(n, hostname, siteA, siteNameA, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionController, FunctionGateway})
 		case TestApplianceGatewayA1, TestApplianceGatewayA2, TestApplianceGatewayA3:
 			res.addAppliance(n, "", siteA, siteNameA, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionGateway})
 		case TestApplianceGatewayB1, TestApplianceGatewayB2, TestApplianceGatewayB3:
@@ -97,6 +102,10 @@ func GenerateCollective(t *testing.T, hostname, from, to string, appliances []st
 			res.addAppliance(n, "", siteA, siteNameA, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionPortal})
 		case TestApplianceLogServer:
 			res.addAppliance(n, "", siteA, siteNameA, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionLogServer})
+		case TestApplianceControllerGatewayA1:
+			res.addAppliance(n, "", siteA, siteNameA, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionController, FunctionGateway})
+		case TestApplianceControllerGatewayB1:
+			res.addAppliance(n, "", siteB, siteNameB, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionController, FunctionGateway})
 		default:
 		}
 	}

--- a/pkg/appliance/upgrade.go
+++ b/pkg/appliance/upgrade.go
@@ -177,6 +177,10 @@ func NewUpgradePlan(appliances []openapi.Appliance, stats *openapi.StatsApplianc
 			batchSize = len(lf)
 		}
 	}
+	// batchSize needs to min 1 if there are any other appliances prepared
+	if len(other) > 0 && batchSize == 0 {
+		batchSize = 1
+	}
 
 	// Equally distribute gateways to batches
 	// Each batch should contain only one gateway per site

--- a/pkg/appliance/upgrade_test.go
+++ b/pkg/appliance/upgrade_test.go
@@ -15,6 +15,7 @@ func TestMakeUpgradePlan(t *testing.T) {
 
 	coll := GenerateCollective(t, hostname, v62, v63, PreSetApplianceNames)
 	primary := coll.Appliances["primary"]
+	primaryWithGateway := coll.Appliances["controller-gateway-primary"]
 
 	type args struct {
 		appliances   []openapi.Appliance
@@ -98,6 +99,26 @@ func TestMakeUpgradePlan(t *testing.T) {
 					{coll.Appliances["gatewayA2"], coll.Appliances["gatewayB2"], coll.Appliances["gatewayC2"], coll.Appliances["logforwarderA2"]},
 					{coll.Appliances["connectorA1"], coll.Appliances["gatewayA3"], coll.Appliances["logserver"], coll.Appliances["portalA1"]},
 				},
+			},
+		},
+		{
+			name: "test grouping with no other batches",
+			args: args{
+				appliances: []openapi.Appliance{
+					coll.Appliances["controller-gateway-primary"],
+					coll.Appliances["controller-gatewayB1"],
+					coll.Appliances["logserver"],
+				},
+				stats:        coll.Stats,
+				ctrlHostname: hostname,
+				filter:       DefaultCommandFilter,
+				orderBy:      nil,
+				descending:   false,
+			},
+			want: &UpgradePlan{
+				PrimaryController: &primaryWithGateway,
+				Controllers:       []openapi.Appliance{coll.Appliances["controller-gatewayB1"]},
+				Batches:           [][]openapi.Appliance{{coll.Appliances["logserver"]}},
 			},
 		},
 	}


### PR DESCRIPTION
Fix bug index-out-of-range bug when preparing collectives with no logforwarders or distinct gateways.