### PR TITLE
fix controller upgrade status on complete

### DIFF
--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -673,7 +673,16 @@ func TestCheckNeedsMultiControllerUpgrade(t *testing.T) {
 				stats.Data = append(stats.Data, d.stat)
 				argAppliances = append(argAppliances, d.appliance)
 			}
-			got, err := CheckNeedsMultiControllerUpgrade(&stats, argAppliances)
+			upgradeStatusMap := map[string]UpgradeStatusResult{}
+			for _, s := range stats.GetData() {
+				us := s.GetUpgrade()
+				upgradeStatusMap[s.GetId()] = UpgradeStatusResult{
+					Status:  us.GetStatus(),
+					Details: us.GetDetails(),
+					Name:    s.GetName(),
+				}
+			}
+			got, err := CheckNeedsMultiControllerUpgrade(&stats, upgradeStatusMap, argAppliances)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CheckNeedsMultiControllerUpgrade() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/appliance/mock.go
+++ b/pkg/appliance/mock.go
@@ -228,7 +228,7 @@ func (cts *CollectiveTestStruct) GenerateStubs(appliances []openapi.Appliance, s
 					continue
 				}
 				us := s.GetUpgrade()
-				if count <= 0 {
+				if us.GetStatus() != UpgradeStatusIdle && count <= 0 {
 					us.SetStatus(UpgradeStatusReady)
 				} else if count == 1 {
 					us.SetStatus(UpgradeStatusIdle)
@@ -406,7 +406,7 @@ func GenerateApplianceWithStats(activeFunctions []string, name, hostname, curren
 	currentStatsData.SetOnline(online)
 	currentStatsData.SetVolumeNumber(0)
 	currentStatsData.SetUpgrade(openapi.StatsAppliancesListAllOfUpgrade{
-		Status:  &upgradeStatus,
+		Status:  openapi.PtrString(upgradeStatus),
 		Details: openapi.PtrString(targetVersion),
 	})
 

--- a/pkg/appliance/upgrade.go
+++ b/pkg/appliance/upgrade.go
@@ -48,6 +48,7 @@ type UpgradePlan struct {
 	Skipping                []SkipUpgrade
 	BackupIds               []string
 	stats                   *openapi.StatsAppliancesList
+	upgradeStatusMap        map[string]UpgradeStatusResult
 	adminHostname           string
 	primary                 *openapi.Appliance
 	allAppliances           []openapi.Appliance
@@ -55,9 +56,10 @@ type UpgradePlan struct {
 
 func NewUpgradePlan(appliances []openapi.Appliance, stats *openapi.StatsAppliancesList, upgradeStatusMap map[string]UpgradeStatusResult, adminHostname string, filter map[string]map[string]string, orderBy []string, descending bool) (*UpgradePlan, error) {
 	plan := UpgradePlan{
-		adminHostname: adminHostname,
-		stats:         stats,
-		allAppliances: appliances,
+		adminHostname:    adminHostname,
+		stats:            stats,
+		upgradeStatusMap: upgradeStatusMap,
+		allAppliances:    appliances,
 	}
 
 	primary, err := FindPrimaryController(appliances, plan.adminHostname, false)
@@ -289,7 +291,7 @@ func (up *UpgradePlan) GetPrimaryController() *openapi.Appliance {
 
 func (up *UpgradePlan) Validate() error {
 	// we check if all controllers need upgrade very early
-	if _, err := CheckNeedsMultiControllerUpgrade(up.stats, up.allAppliances); err != nil {
+	if _, err := CheckNeedsMultiControllerUpgrade(up.stats, up.upgradeStatusMap, up.allAppliances); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
When running complete, controller upgrade status would sometimes be wrong due to lagging upgrade status identification. This could result in the complete command erronously throwing the version mismatch error when executing an upgrade complete command.

This fix will instead use the dedicated upgrade status endpoint when determining if all controllers are ready when necessary.