### PR TITLE
Fix-complete-panic

### DIFF
--- a/pkg/appliance/mock.go
+++ b/pkg/appliance/mock.go
@@ -20,6 +20,7 @@ const (
 	TestApplianceController3              = "controller3"
 	TestApplianceControllerOffline        = "controller4"
 	TestApplianceControllerNotPrepared    = "controller5"
+	TestApplianceController2NotPrepared   = "controller7"
 	TestApplianceControllerMismatch       = "controller6"
 	TestApplianceControllerGatewayPrimary = "controller-gateway-primary"
 	TestApplianceGatewayA1                = "gatewayA1"
@@ -40,7 +41,7 @@ const (
 )
 
 var (
-	PreSetApplianceNames                              = []string{TestAppliancePrimary, TestApplianceSecondary, TestApplianceController3, TestApplianceControllerOffline, TestApplianceControllerNotPrepared, TestApplianceControllerMismatch, TestApplianceGatewayA1, TestApplianceGatewayA2, TestApplianceGatewayA3, TestApplianceGatewayB1, TestApplianceGatewayB2, TestApplianceGatewayB3, TestApplianceGatewayC1, TestApplianceGatewayC2, TestApplianceLogForwarderA1, TestApplianceLogForwarderA2, TestAppliancePortalA1, TestApplianceConnectorA1, TestApplianceLogServer, TestApplianceControllerGatewayA1, TestApplianceControllerGatewayB1, TestApplianceControllerGatewayPrimary}
+	PreSetApplianceNames                              = []string{TestAppliancePrimary, TestApplianceSecondary, TestApplianceController3, TestApplianceControllerOffline, TestApplianceControllerNotPrepared, TestApplianceController2NotPrepared, TestApplianceControllerMismatch, TestApplianceGatewayA1, TestApplianceGatewayA2, TestApplianceGatewayA3, TestApplianceGatewayB1, TestApplianceGatewayB2, TestApplianceGatewayB3, TestApplianceGatewayC1, TestApplianceGatewayC2, TestApplianceLogForwarderA1, TestApplianceLogForwarderA2, TestAppliancePortalA1, TestApplianceConnectorA1, TestApplianceLogServer, TestApplianceControllerGatewayA1, TestApplianceControllerGatewayB1, TestApplianceControllerGatewayPrimary}
 	InitialTestStats     *openapi.StatsAppliancesList = openapi.NewStatsAppliancesListWithDefaults()
 	UpgradedTestStats    *openapi.StatsAppliancesList = openapi.NewStatsAppliancesListWithDefaults()
 )
@@ -82,7 +83,7 @@ func GenerateCollective(t *testing.T, hostname, from, to string, appliances []st
 			res.addAppliance(n, "", siteA, siteNameA, from, to, statusHealthy, UpgradeStatusIdle, true, []string{FunctionController})
 		case TestApplianceControllerOffline:
 			res.addAppliance(n, "", siteA, siteNameA, from, to, statusOffline, UpgradeStatusIdle, false, []string{FunctionController})
-		case TestApplianceControllerNotPrepared:
+		case TestApplianceControllerNotPrepared, TestApplianceController2NotPrepared:
 			res.addAppliance(n, "", siteA, siteNameA, from, from, statusHealthy, UpgradeStatusIdle, true, []string{FunctionController})
 		case TestApplianceControllerMismatch:
 			res.addAppliance(n, "", siteA, siteNameA, "6.1", from, statusHealthy, UpgradeStatusReady, true, []string{FunctionController})

--- a/pkg/appliance/upgrade.go
+++ b/pkg/appliance/upgrade.go
@@ -270,7 +270,7 @@ func (up *UpgradePlan) addSkip(appliance openapi.Appliance, reason error) {
 		Appliance: appliance,
 		Reason:    reason,
 	})
-	up.allAppliances = append(up.allAppliances, appliance)
+	up.allAppliances = AppendUniqueAppliance(up.allAppliances, appliance)
 }
 
 func (up *UpgradePlan) AddOfflineAppliances(appliances []openapi.Appliance) {

--- a/pkg/appliance/upgrade.go
+++ b/pkg/appliance/upgrade.go
@@ -496,7 +496,8 @@ Upgrade will be completed in steps:
 
 {{- if .Skipped -}}
 Appliances that will be skipped:
-  {{ range .Skipped }}- {{ .Appliance.Name }}: {{ .Reason -}}{{- end }}
+{{ range .Skipped }}  - {{ .Appliance.Name }}: {{ .Reason }}
+{{ end -}}
 {{ end }}`
 
 var (

--- a/pkg/appliance/upgrade_test.go
+++ b/pkg/appliance/upgrade_test.go
@@ -260,6 +260,7 @@ Upgrade will be completed in steps:
 					TestAppliancePrimary,
 					TestApplianceSecondary,
 					TestApplianceControllerNotPrepared,
+					TestApplianceController2NotPrepared,
 					TestApplianceGatewayA1,
 					TestApplianceGatewayA2,
 				},
@@ -307,6 +308,7 @@ Upgrade will be completed in steps:
 
 Appliances that will be skipped:
   - controller5: appliance is not prepared for upgrade
+  - controller7: appliance is not prepared for upgrade
 `,
 		},
 	}


### PR DESCRIPTION
Fix an issue where the complete command would sometimes panic when upgrading to a minor version if there are already controllers that have been upgraded.

Also fixes a missing line break in the complete summary when multiple appliances are skipped.