### PR TITLE
Fix: panic on `upgrade complete`

### DIFF
--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -596,9 +596,13 @@ func TestCheckNeedsMultiControllerUpgrade(t *testing.T) {
 	c4, s4, _ := GenerateApplianceWithStats([]string{FunctionController}, "controller4", "", "6.2.0", "6.3.0", statusHealthy, UpgradeStatusReady, true, "default", "default")
 	c5, s5, _ := GenerateApplianceWithStats([]string{FunctionController}, "controller5", "", "6.2.0", "6.3.0", statusHealthy, UpgradeStatusReady, true, "default", "default")
 	c6, s6, _ := GenerateApplianceWithStats([]string{FunctionController}, "controller6", "", "6.2.0", "6.3.0", statusHealthy, UpgradeStatusReady, true, "default", "default")
+	c12, s12, _ := GenerateApplianceWithStats([]string{FunctionController}, "controller12", "", "6.3.0", "6.3.1", statusHealthy, UpgradeStatusReady, true, "default", "default")
 
 	// unprepared max version
 	c7, s7, _ := GenerateApplianceWithStats([]string{FunctionController}, "controller7", "", "6.3.0", "", statusHealthy, UpgradeStatusIdle, true, "default", "default")
+	c9, s9, _ := GenerateApplianceWithStats([]string{FunctionController}, "controller9", "", "6.3.1", "", statusHealthy, UpgradeStatusIdle, true, "default", "default")
+	c10, s10, _ := GenerateApplianceWithStats([]string{FunctionController}, "controller10", "", "6.3.1", "", statusHealthy, UpgradeStatusIdle, true, "default", "default")
+	c11, s11, _ := GenerateApplianceWithStats([]string{FunctionController}, "controller11", "", "6.3.1", "", statusHealthy, UpgradeStatusIdle, true, "default", "default")
 
 	// offline
 	c8, s8, _ := GenerateApplianceWithStats([]string{FunctionController}, "controller8", "", "6.2.0", "", statusHealthy, UpgradeStatusIdle, false, "default", "default")
@@ -658,6 +662,15 @@ func TestCheckNeedsMultiControllerUpgrade(t *testing.T) {
 			in: []inData{
 				{c4, s4},
 				{c8, s8},
+			},
+		},
+		{
+			name: "only one left to upgrade",
+			in: []inData{
+				{c12, s12},
+				{c9, s9},
+				{c10, s10},
+				{c11, s11},
 			},
 		},
 	}

--- a/pkg/util/generics.go
+++ b/pkg/util/generics.go
@@ -1,0 +1,41 @@
+package util
+
+import "errors"
+
+func Find[A any](s []A, f func(A) bool) (A, error) {
+	var r A
+	for _, v := range s {
+		if f(v) {
+			return v, nil
+		}
+	}
+	return r, errors.New("no match in slice")
+}
+
+func Filter[A any](s []A, f func(A) bool) []A {
+	filtered := []A{}
+	for _, i := range s {
+		if f(i) {
+			filtered = append(filtered, i)
+		}
+	}
+	return filtered
+}
+
+func InSlice[C comparable](n C, h []C) bool {
+	for _, i := range h {
+		if i == n {
+			return true
+		}
+	}
+	return false
+}
+
+func InSliceFunc[C comparable](n C, h []C, f func(i, p C) bool) bool {
+	for _, item := range h {
+		if f(item, n) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/generics.go
+++ b/pkg/util/generics.go
@@ -31,7 +31,7 @@ func InSlice[C comparable](n C, h []C) bool {
 	return false
 }
 
-func InSliceFunc[C comparable](n C, h []C, f func(i, p C) bool) bool {
+func InSliceFunc[A any](n A, h []A, f func(i, p A) bool) bool {
 	for _, item := range h {
 		if f(item, n) {
 			return true

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -33,20 +32,6 @@ func AppendIfMissing[V comparable](slice []V, i V) []V {
 		}
 	}
 	return append(slice, i)
-}
-
-func InSlice(needle string, haystack []string) bool {
-	stack := make([]string, len(haystack))
-	copy(stack, haystack)
-	sort.Strings(stack)
-	i := sort.Search(
-		len(stack),
-		func(i int) bool { return stack[i] >= needle },
-	)
-	if i < len(stack) && stack[i] == needle {
-		return true
-	}
-	return false
 }
 
 // SearchSlice will search a slice of strings and return all matching results.
@@ -203,14 +188,4 @@ func AddSocketLogHook(path string) error {
 	}
 	log.AddHook(hook)
 	return nil
-}
-
-func Find[T any](s []T, f func(T) bool) (T, error) {
-	var r T
-	for _, v := range s {
-		if f(v) {
-			return v, nil
-		}
-	}
-	return r, errors.New("no match in slice")
 }


### PR DESCRIPTION
If there are multiple controllers in the collective, but only one is left to upgrade, the `upgrade complete` command would panic with an "index out of range" issue.

This fixes the issue.