### PR TITLE
Add version constraint for breaking upgrade path

### DIFF
--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -165,13 +165,11 @@ func CheckVersions(ctx context.Context, stats openapi.StatsAppliancesList, appli
 					continue
 				}
 
-				// Check version 6.0.0 -> 6.2.x upgrade, since it will fail
-				v600, _ := version.NewVersion("6.0.0")
-				v62, _ := version.NewVersion("6.2.0")
-				if statV.Equal(v600) && v.GreaterThanOrEqual(v62) {
+				// Check specific version constraints on upgrades we know will break
+				if err := CheckApplianceVersionsDisallowed(statV, v); err != nil {
 					skip = append(skip, SkipUpgrade{
 						Appliance: appliance,
-						Reason:    ErrSkipReasonUnsupportedUpgradePath,
+						Reason:    fmt.Errorf("%s: %w", ErrSkipReasonUnsupportedUpgradePath, err),
 					})
 					continue
 				}
@@ -475,6 +473,7 @@ func NeedsMultiControllerUpgrade(upgradeStatuses map[string]UpgradeStatusResult,
 }
 
 var disallowedVersionUpgrades map[string][]string = map[string][]string{
+	"6.0.0+estimated":   {"6.2.0+estimated"},
 	">=6.3.5+estimated": {"6.4.0+estimated"},
 }
 

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -720,7 +720,15 @@ func TestCheckApplianceVersionsDisallowed(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "test 6.3.5->6.4.0 test",
+			name: "test 6.0.0->6.2.0",
+			args: args{
+				currentVersion: "6.0.0",
+				targetVersion:  "6.2.0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "test 6.3.5->6.4.0",
 			args: args{
 				currentVersion: "6.3.5",
 				targetVersion:  "6.4.0",

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -708,3 +708,57 @@ func TestCheckNeedsMultiControllerUpgrade(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckApplianceVersionsDisallowed(t *testing.T) {
+	type args struct {
+		currentVersion string
+		targetVersion  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test 6.3.5->6.4.0 test",
+			args: args{
+				currentVersion: "6.3.5",
+				targetVersion:  "6.4.0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "test 6.3.6->6.4.0",
+			args: args{
+				currentVersion: "6.3.6",
+				targetVersion:  "6.4.0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "test 6.3.4->6.4.0",
+			args: args{
+				currentVersion: "6.3.4",
+				targetVersion:  "6.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test 6.3.5->6.4.1",
+			args: args{
+				currentVersion: "6.3.5",
+				targetVersion:  "6.4.1",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			currentVersion, _ := version.NewVersion(tt.args.currentVersion)
+			targetVersion, _ := version.NewVersion(tt.args.targetVersion)
+			if err := CheckApplianceVersionsDisallowed(currentVersion, targetVersion); (err != nil) != tt.wantErr {
+				t.Errorf("CheckApplianceVersionsDisallowed() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/appliance/upgrade.go
+++ b/pkg/appliance/upgrade.go
@@ -33,7 +33,7 @@ var (
 	ErrSkipReasonInactive               = errors.New("appliance is inactive")
 	ErrSkipReasonFiltered               = errors.New("filtered using the '--include' and/or '--exclude' flag")
 	ErrSkipReasonAlreadyPrepared        = errors.New("appliance is already prepared for upgrade with a higher or equal version")
-	ErrSkipReasonUnsupportedUpgradePath = errors.New("Upgrading from version 6.0.0 to version 6.2.x is unsupported. Version 6.0.1 or later is required.")
+	ErrSkipReasonUnsupportedUpgradePath = errors.New("unsupported upgrade path")
 	ErrSkipReasonAlreadySameVersion     = errors.New("appliance is already running a version higher or equal to the prepare version")
 	ErrNoApplianceStats                 = errors.New("failed to find appliance stats")
 	ErrVersionParse                     = errors.New("failed to parse current appliance version")


### PR DESCRIPTION
Upgrading from appliance version 6.3.5+ to 6.4.0 is known to be breaking.

This PR implements a check to restrict this upgrade. A new function is created that can be used to catch other breaking upgrade paths in the future.