### PR TITLE
fix: html escape characters in backup password

### DIFF
--- a/cmd/appliance/backup/api_test.go
+++ b/cmd/appliance/backup/api_test.go
@@ -151,6 +151,9 @@ func TestBackupAPICommand(t *testing.T) {
 	f.APIClient = func(c *configuration.Config) (*openapi.APIClient, error) {
 		return registry.Client, nil
 	}
+	f.HTTPClient = func() (*http.Client, error) {
+		return registry.Client.GetConfig().HTTPClient, nil
+	}
 	f.Appliance = func(c *configuration.Config) (*appliance.Appliance, error) {
 		api, _ := f.APIClient(c)
 


### PR DESCRIPTION
When enabling the backup API, the user is prompted to enter a password for encrypting the backup in a prompt.

If the user enters a password containing the characters '<', '>' and '&', those characters would be escaped in the json encoding before sending the request to the appliance.

This would result in the password not being what the user expects it to be, making the backup practically impossible for user to decrypt.

This PR overrides the default behaviour of the json encoder to not escape these characters before sending the request payload.