### PR TITLE
fix: force-disable-controller selecting extra controllers

### DIFF
--- a/pkg/appliance/fixtures/appliance_list_similar.json
+++ b/pkg/appliance/fixtures/appliance_list_similar.json
@@ -1,0 +1,814 @@
+{
+    "data": [
+        {
+            "id": "4c07bc67-57ea-42dd-b702-c2d6c45419fc",
+            "name": "primary",
+            "notes": "",
+            "created": "2021-11-02T14:09:46.904196Z",
+            "updated": "2021-11-02T14:58:46.820505Z",
+            "tags": [],
+            "activated": true,
+            "pendingCertificateRenewal": false,
+            "version": 14,
+            "hostname": "appgate.test",
+            "site": "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4",
+            "siteName": "Default Site",
+            "connectToPeersUsingClientPortWithSpa": true,
+            "clientInterface": {
+                "proxyProtocol": false,
+                "hostname": "appgate.test",
+                "httpsPort": 443,
+                "dtlsPort": 443,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "adminInterface": {
+                "hostname": "appgate.test",
+                "httpsPort": 8443,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "networking": {
+                "hosts": [],
+                "nics": [
+                    {
+                        "enabled": true,
+                        "name": "eth0",
+                        "ipv4": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": [
+                                {
+                                    "address": "10.97.158.2",
+                                    "netmask": 26,
+                                    "snat": false
+                                }
+                            ]
+                        },
+                        "ipv6": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": []
+                        }
+                    }
+                ],
+                "dnsServers": [
+                    "1.1.1.1",
+                    "8.8.8.8"
+                ],
+                "dnsDomains": [],
+                "routes": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0,
+                        "gateway": "10.97.158.1"
+                    }
+                ]
+            },
+            "ntp": {
+                "servers": [
+                    {
+                        "hostname": "1.1.1.1"
+                    },
+                    {
+                        "hostname": "8.8.8.8"
+                    }
+                ]
+            },
+            "sshServer": {
+                "enabled": true,
+                "port": 22,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "passwordAuthentication": true
+            },
+            "snmpServer": {
+                "enabled": false,
+                "udpPort": 161,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "snmpd.conf": "rocommunity public default"
+            },
+            "healthcheckServer": {
+                "enabled": false,
+                "port": 5555,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "prometheusExporter": {
+                "enabled": false,
+                "port": 5556,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "ping": {
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "logServer": {
+                "enabled": false,
+                "retentionDays": 30
+            },
+            "controller": {
+                "enabled": true,
+                "database": {
+                    "location": "internal"
+                }
+            },
+            "gateway": {
+                "enabled": false,
+                "vpn": {
+                    "weight": 100,
+                    "allowDestinations": []
+                }
+            },
+            "logForwarder": {
+                "enabled": false,
+                "tcpClients": [],
+                "awsKineses": [],
+                "sites": []
+            },
+            "connector": {
+                "enabled": false,
+                "expressClients": [],
+                "advancedClients": []
+            },
+            "rsyslogDestinations": [],
+            "hostnameAliases": [
+                "10.97.158.2"
+            ]
+        },
+        {
+            "id": "d33838f8-69b6-45b4-ab80-f56423eb0df2",
+            "name": "controller-site1",
+            "notes": "",
+            "created": "2021-11-02T14:09:46.904196Z",
+            "updated": "2021-11-02T14:58:46.820505Z",
+            "tags": [],
+            "activated": true,
+            "pendingCertificateRenewal": false,
+            "version": 14,
+            "hostname": "ctrl.appgate.test",
+            "site": "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4",
+            "siteName": "Default Site",
+            "connectToPeersUsingClientPortWithSpa": true,
+            "clientInterface": {
+                "proxyProtocol": false,
+                "hostname": "ctrl.appgate.test",
+                "httpsPort": 443,
+                "dtlsPort": 443,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "networking": {
+                "hosts": [],
+                "nics": [
+                    {
+                        "enabled": true,
+                        "name": "eth0",
+                        "ipv4": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": [
+                                {
+                                    "address": "10.97.158.2",
+                                    "netmask": 26,
+                                    "snat": false
+                                }
+                            ]
+                        },
+                        "ipv6": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": []
+                        }
+                    }
+                ],
+                "dnsServers": [
+                    "1.1.1.1",
+                    "8.8.8.8"
+                ],
+                "dnsDomains": [],
+                "routes": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0,
+                        "gateway": "10.97.158.1"
+                    }
+                ]
+            },
+            "ntp": {
+                "servers": [
+                    {
+                        "hostname": "1.1.1.1"
+                    },
+                    {
+                        "hostname": "8.8.8.8"
+                    }
+                ]
+            },
+            "sshServer": {
+                "enabled": true,
+                "port": 22,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "passwordAuthentication": true
+            },
+            "snmpServer": {
+                "enabled": false,
+                "udpPort": 161,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "snmpd.conf": "rocommunity public default"
+            },
+            "healthcheckServer": {
+                "enabled": false,
+                "port": 5555,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "prometheusExporter": {
+                "enabled": false,
+                "port": 5556,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "ping": {
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "logServer": {
+                "enabled": false,
+                "retentionDays": 30
+            },
+            "controller": {
+                "enabled": true,
+                "database": {
+                    "location": "internal"
+                }
+            },
+            "gateway": {
+                "enabled": false,
+                "vpn": {
+                    "weight": 100,
+                    "allowDestinations": []
+                }
+            },
+            "logForwarder": {
+                "enabled": false,
+                "tcpClients": [],
+                "awsKineses": [],
+                "sites": []
+            },
+            "connector": {
+                "enabled": false,
+                "expressClients": [],
+                "advancedClients": []
+            },
+            "rsyslogDestinations": [],
+            "hostnameAliases": [
+                "10.97.158.2"
+            ]
+        },
+        {
+            "id": "5975becb-d7c9-4c40-a008-d05ebd1fdaf7",
+            "name": "controller-site1 DR",
+            "notes": "",
+            "created": "2021-11-02T14:09:46.904196Z",
+            "updated": "2021-11-02T14:58:46.820505Z",
+            "tags": [],
+            "activated": true,
+            "pendingCertificateRenewal": false,
+            "version": 14,
+            "hostname": "ctrl.appgate.test",
+            "site": "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4",
+            "siteName": "Default Site",
+            "connectToPeersUsingClientPortWithSpa": true,
+            "clientInterface": {
+                "proxyProtocol": false,
+                "hostname": "ctrl.appgate.test",
+                "httpsPort": 443,
+                "dtlsPort": 443,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "networking": {
+                "hosts": [],
+                "nics": [
+                    {
+                        "enabled": true,
+                        "name": "eth0",
+                        "ipv4": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": [
+                                {
+                                    "address": "10.97.158.2",
+                                    "netmask": 26,
+                                    "snat": false
+                                }
+                            ]
+                        },
+                        "ipv6": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": false,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": []
+                        }
+                    }
+                ],
+                "dnsServers": [
+                    "1.1.1.1",
+                    "8.8.8.8"
+                ],
+                "dnsDomains": [],
+                "routes": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0,
+                        "gateway": "10.97.158.1"
+                    }
+                ]
+            },
+            "ntp": {
+                "servers": [
+                    {
+                        "hostname": "1.1.1.1"
+                    },
+                    {
+                        "hostname": "8.8.8.8"
+                    }
+                ]
+            },
+            "sshServer": {
+                "enabled": true,
+                "port": 22,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "passwordAuthentication": true
+            },
+            "snmpServer": {
+                "enabled": false,
+                "udpPort": 161,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "snmpd.conf": "rocommunity public default"
+            },
+            "healthcheckServer": {
+                "enabled": false,
+                "port": 5555,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "prometheusExporter": {
+                "enabled": false,
+                "port": 5556,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "ping": {
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "logServer": {
+                "enabled": false,
+                "retentionDays": 30
+            },
+            "controller": {
+                "enabled": true,
+                "database": {
+                    "location": "internal"
+                }
+            },
+            "gateway": {
+                "enabled": false,
+                "vpn": {
+                    "weight": 100,
+                    "allowDestinations": []
+                }
+            },
+            "logForwarder": {
+                "enabled": false,
+                "tcpClients": [],
+                "awsKineses": [],
+                "sites": []
+            },
+            "connector": {
+                "enabled": false,
+                "expressClients": [],
+                "advancedClients": []
+            },
+            "rsyslogDestinations": [],
+            "hostnameAliases": [
+                "10.97.158.2"
+            ]
+        },
+        {
+            "id": "ee639d70-e075-4f01-596b-930d5f24f569",
+            "name": "gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1",
+            "notes": "",
+            "created": "2021-11-02T14:11:50.122299Z",
+            "updated": "2021-11-02T14:13:33.591830Z",
+            "tags": [],
+            "activated": true,
+            "pendingCertificateRenewal": false,
+            "version": 14,
+            "hostname": "gateway.devops",
+            "site": "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4",
+            "siteName": "Default Site",
+            "connectToPeersUsingClientPortWithSpa": true,
+            "clientInterface": {
+                "proxyProtocol": false,
+                "hostname": "gateway.devops",
+                "httpsPort": 443,
+                "dtlsPort": 443,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "adminInterface": {
+                "hostname": "gateway.devops",
+                "httpsPort": 8443,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "networking": {
+                "hosts": [],
+                "nics": [
+                    {
+                        "enabled": true,
+                        "name": "eth0",
+                        "ipv4": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": true,
+                                "routers": true,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": [
+                                {
+                                    "address": "10.97.158.3",
+                                    "netmask": 26,
+                                    "snat": false
+                                }
+                            ]
+                        },
+                        "ipv6": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": true,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": []
+                        }
+                    },
+                    {
+                        "enabled": true,
+                        "name": "eth1",
+                        "ipv4": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": true,
+                                "routers": true,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": [
+                                {
+                                    "address": "10.97.219.66",
+                                    "netmask": 26,
+                                    "snat": false
+                                }
+                            ]
+                        },
+                        "ipv6": {
+                            "dhcp": {
+                                "enabled": false,
+                                "dns": true,
+                                "routers": false,
+                                "ntp": false,
+                                "mtu": false
+                            },
+                            "static": []
+                        }
+                    }
+                ],
+                "dnsServers": [
+                    "1.1.1.1",
+                    "8.8.8.8"
+                ],
+                "dnsDomains": [],
+                "routes": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0,
+                        "gateway": "10.97.158.1"
+                    }
+                ]
+            },
+            "ntp": {
+                "servers": [
+                    {
+                        "hostname": "0.ubuntu.pool.ntp.org"
+                    },
+                    {
+                        "hostname": "1.ubuntu.pool.ntp.org"
+                    },
+                    {
+                        "hostname": "2.ubuntu.pool.ntp.org"
+                    },
+                    {
+                        "hostname": "3.ubuntu.pool.ntp.org"
+                    }
+                ]
+            },
+            "sshServer": {
+                "enabled": true,
+                "port": 22,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ],
+                "passwordAuthentication": true
+            },
+            "snmpServer": {
+                "enabled": false,
+                "allowSources": []
+            },
+            "healthcheckServer": {
+                "enabled": false,
+                "port": 5555,
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "prometheusExporter": {
+                "enabled": false,
+                "port": 5556,
+                "allowSources": []
+            },
+            "ping": {
+                "allowSources": [
+                    {
+                        "address": "0.0.0.0",
+                        "netmask": 0
+                    },
+                    {
+                        "address": "::",
+                        "netmask": 0
+                    }
+                ]
+            },
+            "logServer": {
+                "enabled": false,
+                "retentionDays": 30
+            },
+            "controller": {
+                "enabled": false,
+                "database": {
+                    "location": "internal"
+                }
+            },
+            "gateway": {
+                "enabled": true,
+                "vpn": {
+                    "weight": 100,
+                    "allowDestinations": [
+                        {
+                            "nic": "eth1"
+                        }
+                    ]
+                }
+            },
+            "logForwarder": {
+                "enabled": false,
+                "tcpClients": [],
+                "awsKineses": [],
+                "sites": []
+            },
+            "connector": {
+                "enabled": false,
+                "expressClients": [],
+                "advancedClients": []
+            },
+            "rsyslogDestinations": [],
+            "hostnameAliases": []
+        }
+    ],
+    "range": "0-2/2",
+    "orderBy": "name",
+    "descending": false,
+    "filterBy": []
+}

--- a/pkg/appliance/fixtures/stats_appliance_similar.json
+++ b/pkg/appliance/fixtures/stats_appliance_similar.json
@@ -1,0 +1,225 @@
+{
+    "name": "appliances",
+    "creationDate": "2021-11-26T14:27:45.474641Z",
+    "refreshInterval": 1,
+    "data": [
+        {
+            "id": "4c07bc67-57ea-42dd-b702-c2d6c45419fc",
+            "name": "primary",
+            "online": true,
+            "version": "6.2.6-12345",
+            "state": "appliance_ready",
+            "volumeNumber": 2,
+            "status": "healthy",
+            "controller": {
+                "status": "healthy",
+                "details": "Database size is 12 MB"
+            },
+            "logServer": {
+                "status": "n/a"
+            },
+            "logForwarder": {
+                "status": "n/a"
+            },
+            "gateway": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "connector": {
+                "status": "n/a"
+            },
+            "portal": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "appliance": {
+                "status": "healthy"
+            },
+            "cpu": 0.8,
+            "memory": 48.8,
+            "disk": 1.2,
+            "network": {
+                "busiestNic": "eth0",
+                "dropin": 0,
+                "dropout": 0,
+                "rxSpeed": "0.26 Kbps",
+                "txSpeed": "0.26 Kbps",
+                "ips": {
+                    "eth0": [
+                        "10.97.144.2"
+                    ]
+                }
+            },
+            "upgrade": {
+                "status": "idle",
+                "details": ""
+            }
+        },
+        {
+            "id": "d33838f8-69b6-45b4-ab80-f56423eb0df2",
+            "name": "controller-site1",
+            "online": false,
+            "version": "6.2.6-12345",
+            "state": "appliance_ready",
+            "volumeNumber": 2,
+            "status": "error",
+            "controller": {
+                "status": "error",
+                "details": "Database size is 12 MB"
+            },
+            "logServer": {
+                "status": "n/a"
+            },
+            "logForwarder": {
+                "status": "n/a"
+            },
+            "gateway": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "connector": {
+                "status": "n/a"
+            },
+            "portal": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "appliance": {
+                "status": "error"
+            },
+            "cpu": 0.8,
+            "memory": 48.8,
+            "disk": 1.2,
+            "network": {
+                "busiestNic": "eth0",
+                "dropin": 0,
+                "dropout": 0,
+                "rxSpeed": "0.26 Kbps",
+                "txSpeed": "0.26 Kbps",
+                "ips": {
+                    "eth0": [
+                        "10.97.144.2"
+                    ]
+                }
+            },
+            "upgrade": {
+                "status": "idle",
+                "details": ""
+            }
+        },
+        {
+            "id": "5975becb-d7c9-4c40-a008-d05ebd1fdaf7",
+            "name": "controller-site1 DR",
+            "online": true,
+            "version": "6.2.6-12345",
+            "state": "appliance_ready",
+            "volumeNumber": 2,
+            "status": "warning",
+            "controller": {
+                "status": "warning",
+                "details": "Database size is 12 MB"
+            },
+            "logServer": {
+                "status": "n/a"
+            },
+            "logForwarder": {
+                "status": "n/a"
+            },
+            "gateway": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "connector": {
+                "status": "n/a"
+            },
+            "portal": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "appliance": {
+                "status": "warning"
+            },
+            "cpu": 0.8,
+            "memory": 48.8,
+            "disk": 1.2,
+            "network": {
+                "busiestNic": "eth0",
+                "dropin": 0,
+                "dropout": 0,
+                "rxSpeed": "0.26 Kbps",
+                "txSpeed": "0.26 Kbps",
+                "ips": {
+                    "eth0": [
+                        "10.97.144.2"
+                    ]
+                }
+            },
+            "upgrade": {
+                "status": "idle",
+                "details": ""
+            }
+        },
+        {
+            "id": "ee639d70-e075-4f01-596b-930d5f24f569",
+            "name": "gateway-da0375f6-0b28-4248-bd54-a933c4c39008-site1",
+            "online": true,
+            "version": "6.2.6-12345",
+            "state": "appliance_ready",
+            "volumeNumber": 1,
+            "status": "healthy",
+            "controller": {
+                "status": "n/a"
+            },
+            "logServer": {
+                "status": "n/a"
+            },
+            "logForwarder": {
+                "status": "n/a"
+            },
+            "gateway": {
+                "status": "healthy",
+                "numberOfSessions": 0
+            },
+            "connector": {
+                "status": "n/a"
+            },
+            "portal": {
+                "status": "n/a",
+                "numberOfSessions": 0
+            },
+            "appliance": {
+                "status": "healthy",
+                "details": "cz-ffwd: forwarding logs to envy-10-97-144-2.devops:443"
+            },
+            "cpu": 0.7,
+            "memory": 7.8,
+            "disk": 4.9,
+            "network": {
+                "busiestNic": "eth0",
+                "dropin": 27,
+                "dropout": 0,
+                "rxSpeed": "96.0 bps",
+                "txSpeed": "76.8 bps",
+                "ips": {
+                    "eth0": [
+                        "10.97.144.3"
+                    ],
+                    "eth1": [
+                        "10.97.205.66"
+                    ]
+                }
+            },
+            "upgrade": {
+                "status": "ready",
+                "details": "6.2.7"
+            }
+        }
+    ],
+    "controllerCount": 3,
+    "gatewayCount": 1,
+    "applianceCount": 2,
+    "logServerCount": 1,
+    "logForwarderCount": 0,
+    "connectorCount": 0,
+    "portalCount": 0
+}


### PR DESCRIPTION
I some cases, the force-disable-controller command would select more controllers than was selected in the selection prompt. This would happen when two controllers would have the same hostname set, leading to the command selecting all controllers with a matching hostname for disabling.

This PR fixes the issue by matching the controllers on the ID instead of the hostname.