### PR TITLE
Extra upgrade status checks

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -431,10 +431,6 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 			g.Go(func() error {
 				ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 				defer cancel()
-				logger := log.WithFields(log.Fields{
-					"appliance": i.GetName(),
-					"id":        i.GetId(),
-				})
 				var t *tui.Tracker
 				if !opts.ciMode {
 					t = p.AddTracker(i.GetName(), "waiting", "upgraded")

--- a/pkg/appliance/status.go
+++ b/pkg/appliance/status.go
@@ -44,7 +44,7 @@ func (u *ApplianceStatus) WaitForApplianceStatus(ctx context.Context, appliance 
 				if !util.InSlice(current, want) {
 					return fmt.Errorf("Want status %s, got %s", want, current)
 				}
-				logEntry.Info("Reached the wanted appliance status")
+				logEntry.WithField("status", current).Info("Reached the wanted appliance status")
 			}
 		}
 		return nil


### PR DESCRIPTION
This adds an extra check for upgrade status of the appliances just before performing the upgrade just in case the appliance goes offline or any other error occurs after the upgrade is initialized.