### PR TITLE
feature: max-unavailable option for upgrade complete

### DIFF
--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -47,7 +47,7 @@ type upgradeCompleteOptions struct {
 	actualHostname    string
 	defaultFilter     map[string]map[string]string
 	ciMode            bool
-	batchSize         int
+	maxUnavailable    int
 }
 
 // NewUpgradeCompleteCmd return a new upgrade status command
@@ -112,7 +112,7 @@ func NewUpgradeCompleteCmd(f *factory.Factory) *cobra.Command {
 	flags.BoolVarP(&opts.backup, "backup", "b", opts.backup, "Backup primary Controller before completing the upgrade")
 	flags.StringVar(&opts.backupDestination, "backup-destination", "$HOME/Downloads/appgate/backup", "Specify path to download backup")
 	flags.StringVar(&opts.actualHostname, "actual-hostname", "", "If the actual hostname is different from that which you are connecting to the appliance admin API, this flag can be used for setting the actual hostname")
-	flags.IntVar(&opts.batchSize, "batch-size", 2, "Number of batch groups")
+	flags.IntVar(&opts.maxUnavailable, "max-unavailable", 1, "Defines how many gateways that are allowed to be upgraded per site at once. Setting this to a higher number will make batches upgrade in parallel according to what is set with this flag.")
 	return upgradeCompleteCmd
 }
 
@@ -208,7 +208,7 @@ func upgradeCompleteRun(cmd *cobra.Command, args []string, opts *upgradeComplete
 	if err != nil {
 		return err
 	}
-	plan, err := appliancepkg.NewUpgradePlan(active, initialStats, upgradeStatusMap, controlHost, filter, orderBy, descending)
+	plan, err := appliancepkg.NewUpgradePlan(active, initialStats, upgradeStatusMap, controlHost, filter, orderBy, descending, opts.maxUnavailable)
 	if err != nil {
 		return err
 	}

--- a/cmd/appliance/upgrade/complete.go
+++ b/cmd/appliance/upgrade/complete.go
@@ -112,7 +112,7 @@ func NewUpgradeCompleteCmd(f *factory.Factory) *cobra.Command {
 	flags.BoolVarP(&opts.backup, "backup", "b", opts.backup, "Backup primary Controller before completing the upgrade")
 	flags.StringVar(&opts.backupDestination, "backup-destination", "$HOME/Downloads/appgate/backup", "Specify path to download backup")
 	flags.StringVar(&opts.actualHostname, "actual-hostname", "", "If the actual hostname is different from that which you are connecting to the appliance admin API, this flag can be used for setting the actual hostname")
-	flags.IntVar(&opts.maxUnavailable, "max-unavailable", 1, "Defines how many gateways that are allowed to be upgraded per site at once. Setting this to a higher number will make batches upgrade in parallel according to what is set with this flag.")
+	flags.IntVar(&opts.maxUnavailable, "max-unavailable", 1, "Defines how many gateways and logforwarders that are allowed to be upgraded per site at once. Setting this to a higher number will calculate batches according to the value set in this flag. Setting this to a higher value would make the upgrade process shorter at the cost of collective performance for users.")
 	return upgradeCompleteCmd
 }
 

--- a/docs/sdpctl_appliance_resolve-name-status.html
+++ b/docs/sdpctl_appliance_resolve-name-status.html
@@ -44,9 +44,8 @@ Clients and shows the resolution results</p><pre class="code-editor margin-botto
   }
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
-<pre class="code-editor margin-bottom"><code>  -h, --help                 help for resolve-name-status
-      --json                 Display in JSON format
-      --partial-resolution   include all partial resolutions in table
+<pre class="code-editor margin-bottom"><code>  -h, --help   help for resolve-name-status
+      --json   Display in JSON format
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>
 <pre class="code-editor margin-bottom"><code>      --api-version int          Peer API version override

--- a/docs/sdpctl_appliance_upgrade_complete.html
+++ b/docs/sdpctl_appliance_upgrade_complete.html
@@ -38,8 +38,8 @@ and perform a reboot to make the second partition the primary.</p><pre class="co
 <pre class="code-editor margin-bottom"><code>      --actual-hostname string      If the actual hostname is different from that which you are connecting to the appliance admin API, this flag can be used for setting the actual hostname
   -b, --backup                      Backup primary Controller before completing the upgrade (default true)
       --backup-destination string   Specify path to download backup (default &quot;$HOME/Downloads/appgate/backup&quot;)
-      --batch-size int              Number of batch groups (default 2)
   -h, --help                        help for complete
+      --max-unavailable int         Defines how many gateways and logforwarders that are allowed to be upgraded per site at once. Setting this to a higher number will calculate batches according to the value set in this flag. Setting this to a higher value would make the upgrade process shorter at the cost of collective performance for users. (default 1)
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>
 <pre class="code-editor margin-bottom"><code>      --api-version int          Peer API version override

--- a/pkg/appliance/mock.go
+++ b/pkg/appliance/mock.go
@@ -186,12 +186,39 @@ var (
 	}
 )
 
+func (cts *CollectiveTestStruct) GetAppliance(name string) *openapi.Appliance {
+	for _, a := range cts.Appliances {
+		if a.GetName() == name {
+			return &a
+		}
+	}
+	return nil
+}
+
 func (cts *CollectiveTestStruct) GetAppliances() []openapi.Appliance {
 	a := make([]openapi.Appliance, 0, len(cts.Appliances))
 	for _, app := range cts.Appliances {
 		a = append(a, app)
 	}
 	return a
+}
+
+func (cts *CollectiveTestStruct) GetUpgradeStatusMap() map[string]UpgradeStatusResult {
+	upgradeStatusMap := map[string]UpgradeStatusResult{}
+	for _, a := range cts.GetAppliances() {
+		for _, s := range cts.Stats.GetData() {
+			if a.GetId() != s.GetId() {
+				continue
+			}
+			us := s.GetUpgrade()
+			upgradeStatusMap[a.GetId()] = UpgradeStatusResult{
+				Name:    a.GetName(),
+				Status:  us.GetStatus(),
+				Details: us.GetDetails(),
+			}
+		}
+	}
+	return upgradeStatusMap
 }
 
 func (cts *CollectiveTestStruct) GenerateStubs(appliances []openapi.Appliance, stats, upgradedStats openapi.StatsAppliancesList) []httpmock.Stub {

--- a/pkg/appliance/mock.go
+++ b/pkg/appliance/mock.go
@@ -33,11 +33,19 @@ const (
 	TestApplianceGatewayC2                = "gatewayC2"
 	TestApplianceLogForwarderA1           = "logforwarderA1"
 	TestApplianceLogForwarderA2           = "logforwarderA2"
+	TestApplianceLogForwarderB1           = "logforwarderB1"
+	TestApplianceLogForwarderB2           = "logforwarderB2"
+	TestApplianceLogForwarderC1           = "logforwarderC1"
+	TestApplianceLogForwarderC2           = "logforwarderC2"
 	TestAppliancePortalA1                 = "portalA1"
 	TestApplianceConnectorA1              = "connectorA1"
 	TestApplianceLogServer                = "logserver"
 	TestApplianceControllerGatewayA1      = "controller-gatewayA1"
 	TestApplianceControllerGatewayB1      = "controller-gatewayB1"
+
+	TestSiteA = "SiteA"
+	TestSiteB = "SiteB"
+	TestSiteC = "SiteC"
 )
 
 var (
@@ -65,11 +73,11 @@ func GenerateCollective(t *testing.T, hostname, from, to string, appliances []st
 	}
 
 	siteA := uuid.NewString()
-	siteNameA := "SiteA"
+	siteNameA := TestSiteA
 	siteB := uuid.NewString()
-	siteNameB := "SiteB"
+	siteNameB := TestSiteB
 	siteC := uuid.NewString()
-	siteNameC := "SiteC"
+	siteNameC := TestSiteC
 
 	for _, n := range appliances {
 		switch n {
@@ -95,7 +103,7 @@ func GenerateCollective(t *testing.T, hostname, from, to string, appliances []st
 			res.addAppliance(n, "", siteB, siteNameB, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionGateway})
 		case TestApplianceGatewayC1, TestApplianceGatewayC2:
 			res.addAppliance(n, "", siteC, siteNameC, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionGateway})
-		case TestApplianceLogForwarderA1, TestApplianceLogForwarderA2:
+		case TestApplianceLogForwarderA1, TestApplianceLogForwarderA2, TestApplianceLogForwarderB1, TestApplianceLogForwarderB2, TestApplianceLogForwarderC1, TestApplianceLogForwarderC2:
 			res.addAppliance(n, "", siteA, siteNameA, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionLogForwarder})
 		case TestAppliancePortalA1:
 			res.addAppliance(n, "", siteA, siteNameA, from, to, statusHealthy, UpgradeStatusReady, true, []string{FunctionPortal})

--- a/pkg/appliance/upgrade.go
+++ b/pkg/appliance/upgrade.go
@@ -213,6 +213,10 @@ func createBatches(batchCount, maxUnavailable int, gateways, logforwarders map[s
 		resultIndex++
 	}
 
+	sort.SliceStable(other, func(i, j int) bool {
+		return other[i].GetName() < other[j].GetName()
+	})
+
 	// distribute other appliances and even out the groups
 	for _, o := range other {
 		resultIndex = util.SmallestGroupIndex(result)

--- a/pkg/util/generics.go
+++ b/pkg/util/generics.go
@@ -39,3 +39,38 @@ func InSliceFunc[A any](n A, h []A, f func(i, p A) bool) bool {
 	}
 	return false
 }
+
+func SlicePop[T any](s []T, i int) ([]T, T) {
+	elem := s[i]
+	s = append(s[:i], s[i+1:]...)
+	return s, elem
+}
+
+func SliceTake[T any](s []T, amount int) (picked, remaining []T) {
+	if amount > len(s) {
+		amount = len(s)
+	}
+	res := make([]T, 0, amount)
+	remaining = s
+	for i := 0; i < amount; i++ {
+		var elem T
+		remaining, elem = SlicePop(remaining, 0)
+		res = append(res, elem)
+	}
+	return res, remaining
+}
+
+func SmallestGroupIndex[T any](groups [][]T) int {
+	var res, smallest int
+	for i, g := range groups {
+		count := len(g)
+		if smallest == 0 {
+			smallest = count
+		}
+		if count < smallest {
+			smallest = i
+			res = i
+		}
+	}
+	return res
+}

--- a/pkg/util/generics_test.go
+++ b/pkg/util/generics_test.go
@@ -1,0 +1,46 @@
+package util
+
+import "testing"
+
+func TestSmallestGroupIndex(t *testing.T) {
+	tests := []struct {
+		name   string
+		groups [][]string
+		want   int
+	}{
+		{
+			name: "should be 0",
+			groups: [][]string{
+				{"value"},
+				{"value", "value"},
+				{"value", "value", "value"},
+			},
+			want: 0,
+		},
+		{
+			name: "should be 1",
+			groups: [][]string{
+				{"value", "value"},
+				{"value"},
+				{"value", "value", "value"},
+			},
+			want: 1,
+		},
+		{
+			name: "should be 2",
+			groups: [][]string{
+				{"value", "value"},
+				{"value", "value", "value"},
+				{"value"},
+			},
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SmallestGroupIndex(tt.groups); got != tt.want {
+				t.Errorf("SmallestGroupIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When completing an upgrade with `sdpctl appliance upgrade complete`, appliances are upgraded in batches based on keeping the collective as available as possible during the upgrade process. Gateways and LogForwarders belonging to the same site are each placed in seperate upgrade batches.

This PR makes it possible to have more control over how this batching is done with a new `--max-unavailable` flag. The flag makes it possible to specify how many Gateways or LogForwarders that are allowed to be upgraded simultanously. The default setting is 1, will create batches in a similar way as before the implementation of the flag, while setting it to a higher value will allow more gateways and logforwarders belonging to the same site to be upgraded in the same batch.

Note that setting the flag higher than the default value will make the upgrade process a bit quicker, it may also affect the performance of the collective negatively while the upgrade process is running.