### PR TITLE
fix headers for backup api enable request

### DIFF
--- a/cmd/appliance/backup/api_test.go
+++ b/cmd/appliance/backup/api_test.go
@@ -151,7 +151,7 @@ func TestBackupAPICommand(t *testing.T) {
 	f.APIClient = func(c *configuration.Config) (*openapi.APIClient, error) {
 		return registry.Client, nil
 	}
-	f.HTTPClient = func() (*http.Client, error) {
+	f.CustomHTTPClient = func() (*http.Client, error) {
 		return registry.Client.GetConfig().HTTPClient, nil
 	}
 	f.Appliance = func(c *configuration.Config) (*appliance.Appliance, error) {


### PR DESCRIPTION
Some headers were missing when enabling the backup API from the fix in #597. Also adding error check for response code on the request.