### PR TITLE
internal: disregard pre-release strings in version

### DIFF
--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -196,6 +196,19 @@ func CompareVersionsAndBuildNumber(x, y *version.Version) (int, error) {
 	if x == nil || y == nil {
 		return 0, fmt.Errorf("Failed to compare versions, got nil version - x=%v, y=%v", x, y)
 	}
+	var err error
+	if len(x.Prerelease()) > 0 {
+		x, err = ParseVersionString(x.String())
+		if err != nil {
+			return 0, err
+		}
+	}
+	if len(y.Prerelease()) > 0 {
+		y, err = ParseVersionString(y.String())
+		if err != nil {
+			return 0, err
+		}
+	}
 	res := y.Compare(x)
 
 	// if res is 0, we also compare build number

--- a/pkg/appliance/helpers.go
+++ b/pkg/appliance/helpers.go
@@ -22,24 +22,14 @@ var (
 // where 5.4.4 is the semver of the appliance.
 func ParseVersionString(input string) (*version.Version, error) {
 	m := versionRegex.FindStringSubmatch(input)
-	var pre string
 	var meta string
 	if len(m) > 0 {
 		input = m[1]
 		if _, err := strconv.ParseInt(m[3], 10, 64); err == nil {
 			meta = m[3]
-			if len(m[4]) > 0 {
-				pre = m[4]
-			}
 		}
 		if _, err := strconv.ParseInt(m[4], 10, 64); err == nil {
 			meta = m[4]
-			if len(m[3]) > 0 {
-				pre = m[3]
-			}
-		}
-		if len(pre) > 0 && pre != "release" {
-			input = fmt.Sprintf("%s-%s", input, pre)
 		}
 		if len(meta) > 0 {
 			input = fmt.Sprintf("%s+%s", input, meta)


### PR DESCRIPTION
Only build number will be considered when semvers are the same.