### PR TITLE
New command to process .journal files and create .log text files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 cover.out
 .idea/
 .release-env
+.kdev4/
+sdpctl.kdev4

--- a/cmd/appliance/appliance.go
+++ b/cmd/appliance/appliance.go
@@ -41,6 +41,7 @@ func NewApplianceCmd(f *factory.Factory) *cobra.Command {
 		NewResolveNameCmd(f),
 		NewResolveNameStatusCmd(f),
 		NewLogsCmd(f),
+		NewExtractLogsCmd(f),
 		files.NewFilesCmd(f),
 		maintenance.NewMaintenanceCmd(f),
 		NewSeedCmd(f),

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -28,7 +28,7 @@ func NewExtractLogsCmd(f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "extract-logs",
 		Short:   docs.ApplianceExtractLogsDoc.Short,
-		Long:    docs.ApplianceExtractLogsDoc.Short,
+		Long:    docs.ApplianceExtractLogsDoc.Long,
 		Example: docs.ApplianceExtractLogsDoc.ExampleString(),
 		RunE: func(c *cobra.Command, args []string) error {
 			return logsExtractRun(c, args, &opts)

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -52,7 +52,7 @@ func NewExtractLogsCmd(f *factory.Factory) *cobra.Command {
 
 func logsExtractRun(cmd *cobra.Command, args []string, opts *logextractOpts) error {
 	for i := 0; i < len(args); i++ {
-		fmt.Println("Starting processing %s", args[i])
+		log.Infof("Starting processing %s", args[i])
 		err := process_journal_file(args[i], opts.Path)
 		if err != nil {
 			return err
@@ -74,7 +74,7 @@ func process_journal_file(file string, path string) error {
 	// printing some of their contents.
 	for _, f := range r.File {
 		if strings.HasSuffix(f.Name, ".journal") {
-			fmt.Println("Extracting journal file %s", f.Name)
+			log.Infof("Extracting journal file %s", f.Name)
 
 			rc, err := f.Open()
 			if err != nil {
@@ -102,7 +102,7 @@ func process_journal_file(file string, path string) error {
 	// Sort the extracted journald files
 	sort.Strings(extracted_files)
 
-	fmt.Println("Extracting journal files complete. Processing...")
+	log.Infof("Extracting journal files complete. Processing...")
 
 	textlogs := make(map[string]*os.File)
 
@@ -110,7 +110,7 @@ func process_journal_file(file string, path string) error {
 	for _, journalfile := range extracted_files {
 		j := journaldreader.SdjournalReader{}
 
-		fmt.Println("Processing %s...", journalfile)
+		log.Infof("Processing %s...", journalfile)
 
 		err := j.Open(journalfile)
 		if err != nil {

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -20,7 +20,7 @@ import (
 
 type logextractOpts struct {
 	cmdappliance.AppliancCmdOpts
-	Path       string
+	Path string
 }
 
 func NewExtractLogsCmd(f *factory.Factory) *cobra.Command {
@@ -123,18 +123,18 @@ func process_journal_file(file string, path string) error {
 				// We just move to the next log file in case of error
 				break
 			}
-			if ! hasnext {
+			if !hasnext {
 				break
 			}
 
 			identifier, exists := entry["SYSLOG_IDENTIFIER"]
-			if ! exists {
+			if !exists {
 				identifier = "uncategorised_entries"
 			}
 
 			logfile, exists := textlogs[identifier]
-			if ! exists {
-				logfile, err := os.Create(filepath.Join(path, identifier + ".log"))
+			if !exists {
+				logfile, err := os.Create(filepath.Join(path, identifier+".log"))
 				if err != nil {
 					return nil
 				}
@@ -159,27 +159,27 @@ func process_journal_file(file string, path string) error {
  */
 func format_entry(entry map[string]string) string {
 	timestamp, exists := entry["SYSLOG_TIMESTAMP"]
-	if ! exists {
+	if !exists {
 		timestamp = ""
 	}
 
 	hostname, exists := entry["_HOSTNAME"]
-	if ! exists {
+	if !exists {
 		hostname = ""
 	}
 
 	identifier, exists := entry["SYSLOG_IDENTIFIER"]
-	if ! exists {
+	if !exists {
 		identifier = ""
 	}
 
 	pid, exists := entry["_PID"]
-	if ! exists {
+	if !exists {
 		pid = ""
 	}
 
 	message, exists := entry["MESSAGE"]
-	if ! exists {
+	if !exists {
 		message = ""
 	}
 	return fmt.Sprintf("%s %s %s[%s]: %s\n", timestamp, hostname, identifier, pid, message)

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -134,7 +134,8 @@ func processJournalFile(file string, path string) error {
 		}
 
 		j.Close()
-		if os.Remove(journalfile) != nil {
+		err = os.Remove(journalfile)
+		if err != nil {
 			return err
 		}
 	}

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -1,0 +1,186 @@
+package appliance
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/appgate/sdpctl/pkg/cmdappliance"
+	"github.com/appgate/sdpctl/pkg/docs"
+	"github.com/appgate/sdpctl/pkg/factory"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/appgate/journaldreader/journaldreader"
+)
+
+type logextractOpts struct {
+	cmdappliance.AppliancCmdOpts
+	Path       string
+}
+
+func NewExtractLogsCmd(f *factory.Factory) *cobra.Command {
+	aopts := cmdappliance.AppliancCmdOpts{
+		Appliance: f.Appliance,
+		Config:    f.Config,
+		CanPrompt: f.CanPrompt(),
+	}
+
+	opts := logextractOpts{
+		aopts,
+		"",
+	}
+	cmd := &cobra.Command{
+		Use:     "extract-logs",
+		Short:   docs.ApplianceLogsDoc.Short,
+		Long:    docs.ApplianceLogsDoc.Short,
+		Example: docs.ApplianceLogsDoc.ExampleString(),
+		// PreRunE: func(cmd *cobra.Command, args []string) error {
+		// 	return cmdappliance.ArgsSelectAppliance(cmd, args, &opts.AppliancCmdOpts)
+		// },
+		RunE: func(c *cobra.Command, args []string) error {
+			return logsExtractRun(c, args, &opts)
+		},
+	}
+	cmd.Flags().StringVarP(&opts.Path, "path", "", "", "Optional path to write to")
+	return cmd
+}
+
+func logsExtractRun(cmd *cobra.Command, args []string, opts *logextractOpts) error {
+	for i := 0; i < len(args); i++ {
+		fmt.Println("Starting processing %s", args[i])
+		err := process_journal_file(args[i], opts.Path)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func process_journal_file(file string, path string) error {
+	r, err := zip.OpenReader(file)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	var extracted_files []string
+
+	// Iterate through the files in the archive,
+	// printing some of their contents.
+	for _, f := range r.File {
+		if strings.HasSuffix(f.Name, ".journal") {
+			fmt.Println("Extracting journal file %s", f.Name)
+
+			rc, err := f.Open()
+			if err != nil {
+				return err
+			}
+
+			extracted, err := os.CreateTemp("", "")
+			if err != nil {
+				return err
+			}
+			extracted_files = append(extracted_files, extracted.Name())
+
+			written, err := io.Copy(extracted, rc)
+			if written+1 == written-1 { // Completely useless statement to get go to compile
+				log.Fatal(written)
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+			rc.Close()
+			extracted.Close()
+		}
+	}
+
+	// Sort the extracted journald files
+	sort.Strings(extracted_files)
+
+	fmt.Println("Extracting journal files complete. Processing...")
+
+	textlogs := make(map[string]*os.File)
+
+	// Parse the extracted files
+	for _, journalfile := range extracted_files {
+		j := journaldreader.SdjournalReader{}
+
+		fmt.Println("Processing %s...", journalfile)
+
+		err := j.Open(journalfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for true {
+			entry, hasnext, err := j.Next()
+			if err != nil {
+				// We just move to the next log file in case of error
+				break
+			}
+			if ! hasnext {
+				break
+			}
+
+			identifier, exists := entry["SYSLOG_IDENTIFIER"]
+			if ! exists {
+				identifier = "uncategorised_entries"
+			}
+
+			logfile, exists := textlogs[identifier]
+			if ! exists {
+				logfile, err := os.Create(filepath.Join(path, identifier + ".log"))
+				if err != nil {
+					return nil
+				}
+				defer logfile.Close()
+				textlogs[identifier] = logfile
+			}
+
+			logfile.WriteString(format_entry(entry))
+		}
+
+		j.Close()
+		if os.Remove(journalfile) != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+/*
+ * Formats a log entry the default way like journalctl
+ */
+func format_entry(entry map[string]string) string {
+	timestamp, exists := entry["SYSLOG_TIMESTAMP"]
+	if ! exists {
+		timestamp = ""
+	}
+
+	hostname, exists := entry["_HOSTNAME"]
+	if ! exists {
+		hostname = ""
+	}
+
+	identifier, exists := entry["SYSLOG_IDENTIFIER"]
+	if ! exists {
+		identifier = ""
+	}
+
+	pid, exists := entry["_PID"]
+	if ! exists {
+		pid = ""
+	}
+
+	message, exists := entry["MESSAGE"]
+	if ! exists {
+		message = ""
+	}
+	return fmt.Sprintf("%s %s %s[%s]: %s\n", timestamp, hostname, identifier, pid, message)
+}

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/appgate/sdpctl/pkg/cmdappliance"
 	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/factory"
 	log "github.com/sirupsen/logrus"
@@ -18,29 +17,19 @@ import (
 )
 
 type logextractOpts struct {
-	cmdappliance.AppliancCmdOpts
 	Path string
 }
 
 func NewExtractLogsCmd(f *factory.Factory) *cobra.Command {
-	aopts := cmdappliance.AppliancCmdOpts{
-		Appliance: f.Appliance,
-		Config:    f.Config,
-		CanPrompt: f.CanPrompt(),
-	}
 
 	opts := logextractOpts{
-		aopts,
-		"",
+		".",
 	}
 	cmd := &cobra.Command{
 		Use:     "extract-logs",
 		Short:   docs.ApplianceExtractLogsDoc.Short,
 		Long:    docs.ApplianceExtractLogsDoc.Short,
 		Example: docs.ApplianceExtractLogsDoc.ExampleString(),
-		// PreRunE: func(cmd *cobra.Command, args []string) error {
-		// 	return cmdappliance.ArgsSelectAppliance(cmd, args, &opts.AppliancCmdOpts)
-		// },
 		RunE: func(c *cobra.Command, args []string) error {
 			return logsExtractRun(c, args, &opts)
 		},

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -86,10 +86,7 @@ func processJournalFile(file string, path string) error {
 			}
 			extractedFiles = append(extractedFiles, extracted.Name())
 
-			written, err := io.Copy(extracted, rc)
-			if written+1 == written-1 { // Completely useless statement to get go to compile
-				log.Fatal(written)
-			}
+			_, err = io.Copy(extracted, rc)
 			if err != nil {
 				return err
 			}

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -91,7 +91,7 @@ func processJournalFile(file string, path string) error {
 				log.Fatal(written)
 			}
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			rc.Close()
 			extracted.Close()

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -23,10 +23,7 @@ type logextractOpts struct {
 }
 
 func NewExtractLogsCmd(f *factory.Factory) *cobra.Command {
-
-	opts := logextractOpts{
-		".",
-	}
+	opts := logextractOpts{}
 	cmd := &cobra.Command{
 		Use:     "extract-logs",
 		Short:   docs.ApplianceExtractLogsDoc.Short,
@@ -39,7 +36,7 @@ func NewExtractLogsCmd(f *factory.Factory) *cobra.Command {
 			configuration.SkipAuthCheck: "true",
 		},
 	}
-	cmd.Flags().StringVarP(&opts.Path, "path", "", "", "Optional path to write to")
+	cmd.Flags().StringVar(&opts.Path, "path", ".", "Optional path to write to")
 	return cmd
 }
 

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -3,15 +3,15 @@ package appliance
 import (
 	"archive/zip"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
-
+	"github.com/appgate/sdpctl/pkg/configuration"
 	"github.com/appgate/sdpctl/pkg/docs"
 	"github.com/appgate/sdpctl/pkg/factory"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/appgate/journaldreader/journaldreader"
 )
@@ -32,6 +32,9 @@ func NewExtractLogsCmd(f *factory.Factory) *cobra.Command {
 		Example: docs.ApplianceExtractLogsDoc.ExampleString(),
 		RunE: func(c *cobra.Command, args []string) error {
 			return logsExtractRun(c, args, &opts)
+		},
+		Annotations: map[string]string{
+			configuration.SkipAuthCheck: "true",
 		},
 	}
 	cmd.Flags().StringVarP(&opts.Path, "path", "", "", "Optional path to write to")

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -35,9 +35,9 @@ func NewExtractLogsCmd(f *factory.Factory) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:     "extract-logs",
-		Short:   docs.ApplianceLogsDoc.Short,
-		Long:    docs.ApplianceLogsDoc.Short,
-		Example: docs.ApplianceLogsDoc.ExampleString(),
+		Short:   docs.ApplianceExtractLogsDoc.Short,
+		Long:    docs.ApplianceExtractLogsDoc.Short,
+		Example: docs.ApplianceExtractLogsDoc.ExampleString(),
 		// PreRunE: func(cmd *cobra.Command, args []string) error {
 		// 	return cmdappliance.ArgsSelectAppliance(cmd, args, &opts.AppliancCmdOpts)
 		// },
@@ -135,7 +135,7 @@ func processJournalFile(file string, path string) error {
 			if !exists {
 				logfile, err := os.Create(filepath.Join(path, identifier+".log"))
 				if err != nil {
-					return nil
+					return err
 				}
 				defer logfile.Close()
 				textlogs[identifier] = logfile

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -60,7 +60,6 @@ func logsExtractRun(cmd *cobra.Command, args []string, opts *logextractOpts) err
 	return nil
 }
 
-
 func processJournalFile(file string, path string) error {
 	r, err := zip.OpenReader(file)
 	if err != nil {

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/appgate/sdpctl/pkg/cmdappliance"
@@ -61,6 +60,7 @@ func logsExtractRun(cmd *cobra.Command, args []string, opts *logextractOpts) err
 	return nil
 }
 
+
 func processJournalFile(file string, path string) error {
 	r, err := zip.OpenReader(file)
 	if err != nil {
@@ -100,7 +100,7 @@ func processJournalFile(file string, path string) error {
 	}
 
 	// Sort the extracted journald files
-	sort.Strings(extractedFiles)
+	extractedFiles = journaldreader.SortJournalFiles(extractedFiles)
 
 	log.Infof("Extracting journal files complete. Processing...")
 
@@ -114,7 +114,7 @@ func processJournalFile(file string, path string) error {
 
 		err := j.Open(journalfile)
 		if err != nil {
-			log.Fatal(err)
+			continue
 		}
 
 		for {

--- a/docs/sdpctl_appliance.html
+++ b/docs/sdpctl_appliance.html
@@ -42,6 +42,7 @@ used together with one of the available sub-commands listed below.</p><hr class=
 <li><p><a href="sdpctl.html">sdpctl</a>	 - sdpctl is a command line tool to manage Appgate SDP Collectives</p></li>
 <li><p><a href="sdpctl_appliance_backup.html">sdpctl appliance backup</a>	 - Perform backup of the appliances</p></li>
 <li><p><a href="sdpctl_appliance_export-seed.html">sdpctl appliance export-seed</a>	 - Export seed for an inactive Appliance</p></li>
+<li><p><a href="sdpctl_appliance_extract-logs.html">sdpctl appliance extract-logs</a>	 - Unpacks binary log files from a log bundle</p></li>
 <li><p><a href="sdpctl_appliance_files.html">sdpctl appliance files</a>	 - The files command lets you manage the file repository on the connected Controller</p></li>
 <li><p><a href="sdpctl_appliance_force-disable-controller.html">sdpctl appliance force-disable-controller</a>	 - Force disable misbehaving Controllers using this command. USE WITH CAUTION!</p></li>
 <li><p><a href="sdpctl_appliance_functions.html">sdpctl appliance functions</a>	 -</p></li>

--- a/docs/sdpctl_appliance_extract-logs.html
+++ b/docs/sdpctl_appliance_extract-logs.html
@@ -1,0 +1,59 @@
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="Description" content="Appgate sdpctl Quick Start Guide">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="expires" content="0">
+  <title>sdpctl Reference Guide</title>
+  <link rel="stylesheet" href="./assets/guide.css">
+  <script type="text/javascript" src="./assets/guide.js"></script>
+  <script>document.addEventListener("DOMContentLoaded", () => initManPage());</script>
+</head>
+<body>
+  <main class="page text-center">
+    <div class="box">
+			<object class="appgate-logo" data="assets/appgate.svg" aria-label="appgate inc logo"></object>
+			<h1 class="margin-top-small">sdpctl Reference Guide</h1>
+      <hr />
+			<div id="breadcrumb" class="breadcrumb">
+				<a href="index.html">Quick Start Guide</a>
+				<span class="breadcrumb-seperator">/</span>
+			</div>
+			<hr />
+      <div class="content text-left">
+      <h2 class="text-left margin-bottom">sdpctl appliance extract-logs</h2><p>Unpacks binary log files from a log bundle</p><hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Synopsis</h3><p>Unpacks journald binary log files from a log bundle .zip file, creating log files grouped by daemon</p><pre class="code-editor margin-bottom"><code>sdpctl appliance extract-logs [flags]
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Examples</h3>
+<pre class="code-editor margin-bottom"><code>  # Extract logs command
+  &gt; sdpctl extract-logs controller.zip
+
+  # Extract logs to specific path
+  &gt; sdpctl extract-logs controller.zip --path /tmp
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
+<pre class="code-editor margin-bottom"><code>  -h, --help          help for extract-logs
+      --path string   Optional path to write to
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>
+<pre class="code-editor margin-bottom"><code>      --api-version int          Peer API version override
+      --ci-mode                  Log to stderr instead of file and disable progress-bars
+      --debug                    Enable debug logging
+      --descending               Change the direction of sort order when using the '--order-by' flag. Using this will reverse the sort order for all keywords specified in the '--order-by' flag.
+      --events-path string       send logs to unix domain socket path
+  -e, --exclude stringToString   Filter appliances using a comma separated list of key-value pairs. Regex syntax is used for matching strings. Example: '--exclude name=controller,site=&lt;site-id&gt; etc.'.
+                                 Available keywords to filter on are: name, id, tags|tag, version, hostname|host, active|activated, site|site-id, function (default [])
+  -i, --include stringToString   Include appliances. Adheres to the same syntax and key-value pairs as '--exclude' (default [])
+      --no-interactive           Suppress interactive prompt with auto accept
+      --no-verify                Don't verify TLS on for the given command, overriding settings from config file
+      --order-by strings         Order appliance lists by keywords, i.e. 'name', 'id' etc. Accepts a comma seperated list of keywords, where first mentioned has priority. Applies to the 'appliance list' and 'appliance stats' commands. (default [name])
+  -p, --profile string           Profile configuration to use
+</code></pre>
+<hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">SEE ALSO</h3>
+<ul>
+<li><p><a href="sdpctl_appliance.html">sdpctl appliance</a>	 - Manage the appliances and perform tasks such as backups, upgrades, metrics etc</p></li>
+</ul>
+
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/docs/sdpctl_appliance_extract-logs.html
+++ b/docs/sdpctl_appliance_extract-logs.html
@@ -31,7 +31,7 @@
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options</h3>
 <pre class="code-editor margin-bottom"><code>  -h, --help          help for extract-logs
-      --path string   Optional path to write to
+      --path string   Optional path to write to (default &quot;.&quot;)
 </code></pre>
 <hr class="margin-bottom"><h3 class="emphasize text-left margin-bottom-small">Options inherited from parent commands</h3>
 <pre class="code-editor margin-bottom"><code>      --api-version int          Peer API version override

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/adrg/xdg v0.5.3
-	github.com/appgate/journaldreader/journaldreader v0.0.0-20241107084131-61a82a70d839
+	github.com/appgate/journaldreader/journaldreader v0.0.0-20241108101643-e0a19052e175
 	github.com/appgate/sdp-api-client-go v1.2.8
 	github.com/billgraziano/dpapi v0.5.0
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -44,14 +44,14 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/edsrzf/mmap-go v1.1.0 // indirect
+	github.com/edsrzf/mmap-go v1.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect

--- a/go.mod
+++ b/go.mod
@@ -40,15 +40,18 @@ require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
+	github.com/appgate/journaldreader/journaldreader v0.0.0-20241107084131-61a82a70d839 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/appgate/sdpctl
 
 go 1.22.6
 
-toolchain go1.23.2
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,14 @@
 module github.com/appgate/sdpctl
 
-go 1.22
+go 1.22.6
+
+toolchain go1.23.2
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/adrg/xdg v0.5.3
+	github.com/appgate/journaldreader/journaldreader v0.0.0-20241107084131-61a82a70d839
 	github.com/appgate/sdp-api-client-go v1.2.8
 	github.com/billgraziano/dpapi v0.5.0
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -40,7 +43,6 @@ require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
-	github.com/appgate/journaldreader/journaldreader v0.0.0-20241107084131-61a82a70d839 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
+github.com/appgate/journaldreader/journaldreader v0.0.0-20241107084131-61a82a70d839 h1:frw9kT2PxKgd18Nr6cnJubEwtyVMY2HDSrZEEiKGOPg=
+github.com/appgate/journaldreader/journaldreader v0.0.0-20241107084131-61a82a70d839/go.mod h1:k7mPUhRhOtFBAjNsdDHEHw3Ljvn0nN762B4nUF0FsCc=
 github.com/appgate/sdp-api-client-go v1.2.8 h1:bx+qFl9G4DEARkceOciXEa0bvCDk6cy5TIi2zMa20R0=
 github.com/appgate/sdp-api-client-go v1.2.8/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/billgraziano/dpapi v0.5.0 h1:pcxA17vyjbDqYuxCFZbgL9tYIk2xgbRZjRaIbATwh+8=
@@ -73,6 +75,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
 github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/enriquebris/goconcurrentqueue v0.7.0 h1:JYrDa45N3xo3Sr9mjvlRaWiBHvBEJIhAdLXO3VGVghA=
 github.com/enriquebris/goconcurrentqueue v0.7.0/go.mod h1:OZ+KC2BcRYzjg0vgoUs1GFqdAjkD9mz2Ots7Jbm1yS4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -167,6 +171,8 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:C
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6 h1:IsMZxCuZqKuao2vNdfD82fjjgPLfyHLpR41Z88viRWs=
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6/go.mod h1:3VeWNIJaW+O5xpRQbPp0Ybqu1vJd/pm7s2F473HRrkw=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/appgate/journaldreader/journaldreader v0.0.0-20241107084131-61a82a70d839 h1:frw9kT2PxKgd18Nr6cnJubEwtyVMY2HDSrZEEiKGOPg=
 github.com/appgate/journaldreader/journaldreader v0.0.0-20241107084131-61a82a70d839/go.mod h1:k7mPUhRhOtFBAjNsdDHEHw3Ljvn0nN762B4nUF0FsCc=
+github.com/appgate/journaldreader/journaldreader v0.0.0-20241108101643-e0a19052e175 h1:V249ZVL+FRUP9QeMMD8TRpFaAr3iJRPhHhVwNdlRPJw=
+github.com/appgate/journaldreader/journaldreader v0.0.0-20241108101643-e0a19052e175/go.mod h1:k7mPUhRhOtFBAjNsdDHEHw3Ljvn0nN762B4nUF0FsCc=
 github.com/appgate/sdp-api-client-go v1.2.8 h1:bx+qFl9G4DEARkceOciXEa0bvCDk6cy5TIi2zMa20R0=
 github.com/appgate/sdp-api-client-go v1.2.8/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/billgraziano/dpapi v0.5.0 h1:pcxA17vyjbDqYuxCFZbgL9tYIk2xgbRZjRaIbATwh+8=
@@ -77,6 +79,8 @@ github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbj
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
+github.com/edsrzf/mmap-go v1.2.0 h1:hXLYlkbaPzt1SaQk+anYwKSRNhufIDCchSPkUD6dD84=
+github.com/edsrzf/mmap-go v1.2.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/enriquebris/goconcurrentqueue v0.7.0 h1:JYrDa45N3xo3Sr9mjvlRaWiBHvBEJIhAdLXO3VGVghA=
 github.com/enriquebris/goconcurrentqueue v0.7.0/go.mod h1:OZ+KC2BcRYzjg0vgoUs1GFqdAjkD9mz2Ots7Jbm1yS4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -173,6 +177,8 @@ github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6/go.mod h1:3VeW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/docs/appliance.go
+++ b/pkg/docs/appliance.go
@@ -301,6 +301,21 @@ NOTE: Although the '--include' and '--exclude' flags are provided as options her
 		},
 	}
 
+	ApplianceExtractLogsDoc = CommandDoc{
+		Short: "Unpacks binary log files from a log bundle",
+		Long:  `Unpacks journald binary log files from a log bundle .zip file, creating log files grouped by daemon`,
+		Examples: []ExampleDoc{
+			{
+				Description: "Extract logs command",
+				Command:     "sdpctl extract-logs controller.zip",
+			},
+			{
+				Description: "Extract logs to specific path",
+				Command:     "sdpctl extract-logs controller.zip --path /tmp",
+			},
+		},
+	}
+
 	ApplianceSeedDocs = CommandDoc{
 		Short: "Export seed for an inactive Appliance",
 		Long: `Generate a seed file in JSON (or iso format)


### PR DESCRIPTION
This will extract all the .journal files from the .zip file and will do the grouping by syslog identifier like we currently do server-side.

`sdpctl  appliance extract-logs controller-0421a864-f171-46f2-b059-f8c35acef9ff-site1-logs.zip  --path iaffieddu/`