### PR TITLE
finish upgrade batch before returning error

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -142,7 +142,7 @@ func argValidation(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("'%s' is not a valid argument. Did you mean 'signin'?", arg)
 		}
 		// If arg is missing protocol prefix, temporarily add one to validate the url
-		if !strings.HasPrefix(arg, "https://") || !strings.HasPrefix(arg, "http://") {
+		if !strings.HasPrefix(arg, "https://") && !strings.HasPrefix(arg, "http://") {
 			arg = "https://" + arg
 		}
 		if err := util.IsValidURL(arg); err != nil {


### PR DESCRIPTION
Currently, when an appliance upgrade fails for some reason in a batch, the command exits before the rest of the appliances in the same batch have finished the upgrade process.

This makes the user unaware on when the rest of the appliances have finished running through the upgrade.

This PR fixes the issue by finishing the whole upgrade batch before returning the errors.