### PR TITLE
[SA-24689] Prevent batch size to be 0 when batch < maxUnavailable

### DIFF
--- a/pkg/appliance/upgrade.go
+++ b/pkg/appliance/upgrade.go
@@ -592,7 +592,7 @@ func calculateBatches(gatewaysBySite, logForwardersBySite map[string][]openapi.A
 		maxUnavailable = 1
 	}
 	if maxUnavailable > 1 {
-		if batches == maxUnavailable {
+		if batches == maxUnavailable || batches < maxUnavailable {
 			return 1
 		}
 		for batches%maxUnavailable != 0 {

--- a/pkg/filesystem/filesystem_test.go
+++ b/pkg/filesystem/filesystem_test.go
@@ -11,6 +11,13 @@ import (
 
 func TestConfigDir(t *testing.T) {
 	tempDir := t.TempDir()
+	noXdgHomePath := func() string {
+		if runtime.GOOS == "darwin" {
+			return filepath.Join(tempDir, "Library", "Application Support", "sdpctl")
+		} else {
+			return filepath.Join(tempDir, ".config", "sdpctl")
+		}
+	}()
 
 	tests := []struct {
 		name        string
@@ -49,7 +56,7 @@ func TestConfigDir(t *testing.T) {
 			env: map[string]string{
 				"HOME": tempDir,
 			},
-			output: filepath.Join(tempDir, ".config", "sdpctl"),
+			output: noXdgHomePath,
 		},
 	}
 


### PR DESCRIPTION
When `--max-unavailable` is larger than the batch size, the batch size could become 0. The batch size should always be greater than or equal to 1. 

Bonus: Fix unit test on Mac