### PR TITLE
[SA-24869] Allow upgrade-complete to continue even if unprepared controllers exist 

### DIFF
--- a/cmd/appliance/upgrade/complete_test.go
+++ b/cmd/appliance/upgrade/complete_test.go
@@ -172,13 +172,14 @@ func TestUpgradeCompleteCommand(t *testing.T) {
 			wantErrOut: regexp.MustCompile("never switched partition"),
 		},
 		{
+			// Allow some controllers to be unprepared. Proceed only upgrade-completing the
+			// prepared controllers
 			name:       "controller major-minor guard unprepared controller",
 			cli:        "upgrade complete --backup=false --no-interactive",
 			appliances: []string{appliancepkg.TestAppliancePrimary, appliancepkg.TestApplianceControllerNotPrepared},
 			from:       "6.2.0",
 			to:         "6.3.0",
-			wantErr:    true,
-			wantErrOut: regexp.MustCompile(appliancepkg.ErrNeedsAllControllerUpgrade.Error()),
+			wantErr:    false,
 		},
 		{
 			name:       "controller major-minor guard mismatch version",

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -436,7 +436,7 @@ func CheckNeedsMultiControllerUpgrade(stats *openapi.StatsAppliancesList, upgrad
 		return mismatchControllers, ErrControllerVersionMismatch
 	}
 
-	// we return a list of the controllers that need to be prapared along with an error
+	// we return a list of the controllers that need to be prepared along with an error
 	if isMajorOrMinor && len(unpreparedControllers) > 0 {
 		return unpreparedControllers, ErrNeedsAllControllerUpgrade
 	}

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -436,9 +436,10 @@ func CheckNeedsMultiControllerUpgrade(stats *openapi.StatsAppliancesList, upgrad
 		return mismatchControllers, ErrControllerVersionMismatch
 	}
 
-	// we return a list of the controllers that need to be prepared along with an error
+	// we will only upgrade-complete the prepared controllers
+	// return the unprepared controllers without error
 	if isMajorOrMinor && len(unpreparedControllers) > 0 {
-		return unpreparedControllers, ErrNeedsAllControllerUpgrade
+		return unpreparedControllers, nil
 	}
 
 	return nil, nil

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -642,9 +642,8 @@ func TestCheckNeedsMultiControllerUpgrade(t *testing.T) {
 				{c4, s4},
 				{c5, s5},
 			},
-			wantErr:   true,
-			want:      []openapi.Appliance{c1, c2},
-			wantError: ErrNeedsAllControllerUpgrade,
+			wantErr: false,
+			want:    []openapi.Appliance{c1, c2},
 		},
 		{
 			name: "mix with unprepared max version",
@@ -653,9 +652,8 @@ func TestCheckNeedsMultiControllerUpgrade(t *testing.T) {
 				{c4, s4},
 				{c7, s7},
 			},
-			wantErr:   true,
-			want:      []openapi.Appliance{c1},
-			wantError: ErrNeedsAllControllerUpgrade,
+			wantErr: false,
+			want:    []openapi.Appliance{c1},
 		},
 		{
 			name: "offline controller",


### PR DESCRIPTION
Below is snippet from sdpctl where controller1 is not prepared, but the rest are. 
```
 2. Additional appliances will be upgraded in parallel batches. The additional appliances will be split into
    batches to keep the Collective as available as possible during the upgrade process
    Some of the additional appliances may need to be rebooted for the upgrade to take effect
    Batch #1:
    Appliance                                              Site            Current version    Prepared version    Backup
    ---------                                              ----            ---------------    ----------------    ------
    gateway1-a53f9b2e-d067-4d78-888c-56d252975681-site1    Default Site    6.2.9+37208        6.3.7+39574         ⨯
    gateway2-a53f9b2e-d067-4d78-888c-56d252975681-site1    Default Site    6.2.9+37208        6.3.7+39574         ⨯
    Batch #2:
    Appliance                                              Site            Current version    Prepared version    Backup
    ---------                                              ----            ---------------    ----------------    ------
    gateway3-a53f9b2e-d067-4d78-888c-56d252975681-site1    Default Site    6.2.9+37208        6.3.7+39574         ⨯
Appliances that will be skipped:
  - controller-a53f9b2e-d067-4d78-888c-56d252975681-site1: appliance is not prepared for upgrade
  - ```