### PR TITLE
Disable auto-merge of Homebrew Tap PRs

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -1,8 +1,6 @@
 name: Announce
 
-on:
-  release:
-    types: [published]
+on: workflow_dispatch
 
 jobs:
   homebrew:


### PR DESCRIPTION
Homebrew Tap PRs created by goreleaser will be merged manually post-release