### PR TITLE
Improvements on extract-logs   

### DIFF
--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -105,7 +105,7 @@ func processJournalFile(file string, path string, unzipOnly bool) error {
 				parts = parts[:len(parts)-1]
 				prevpath := path
 
-				for i, part := range parts {
+				for _, part := range parts {
 					dirpath := filepath.Join(prevpath, part)
 
 					err = os.Mkdir(dirpath, os.ModePerm)

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -90,6 +90,24 @@ func processJournalFile(file string, path string) error {
 			}
 			rc.Close()
 			extracted.Close()
+		} else {
+			log.Infof("Extracting file %s", f.Name)
+			rc, err := f.Open()
+			if err != nil {
+				return err
+			}
+
+			extracted, err := os.Create(filepath.Join(path, f.Name))
+			if err != nil {
+				return err
+			}
+
+			_, err = io.Copy(extracted, rc)
+			if err != nil {
+				return err
+			}
+			rc.Close()
+			extracted.Close()
 		}
 	}
 

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -97,6 +97,22 @@ func processJournalFile(file string, path string) error {
 				return err
 			}
 
+			// Create the subdirectory tree
+			if strings.Contains(f.Name, "/") {
+				parts := strings.Split(f.Name, "/")
+				parts = parts[:len(parts)-1]
+				prevpath := path
+
+				for i, part := range parts {
+					fmt.Printf("Part %d: %s\n", i, part)
+					dirpath := filepath.Join(prevpath, part)
+
+					err = os.Mkdir(dirpath, os.ModePerm)
+					if err != nil && !os.IsExist(err) {
+						return err
+					}
+				}
+			}
 			extracted, err := os.Create(filepath.Join(path, f.Name))
 			if err != nil {
 				return err

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -106,7 +106,6 @@ func processJournalFile(file string, path string, unzipOnly bool) error {
 				prevpath := path
 
 				for i, part := range parts {
-					fmt.Printf("Part %d: %s\n", i, part)
 					dirpath := filepath.Join(prevpath, part)
 
 					err = os.Mkdir(dirpath, os.ModePerm)

--- a/cmd/appliance/extract_logs.go
+++ b/cmd/appliance/extract_logs.go
@@ -131,7 +131,7 @@ func processJournalFile(file string, path string, unzipOnly bool) error {
 	// Sort the extracted journald files
 	extractedFiles = journaldreader.SortJournalFiles(extractedFiles)
 
-	log.Infof("Extracting journal files complete. Processing...")
+	log.Infof("Decompressing complete. Processing...")
 
 	textlogs := make(map[string]*os.File)
 


### PR DESCRIPTION
Since the standard unzip command does not support the zstd compression algorithm that the current appliances are using, this pull request lets sdpctl with the appropriate flags to be used instead.

The main changes here are:

* All files are extracted, not only .journal files
* Files located inside a directory in the zip are placed in a directory when extracted
* A new flag is introduced to extract the .journal files without processing them. This is to be used by linux users who already have journalctl installed and want to read the logs with ease.