### PR TITLE
Filter online appliances without failing if a controller is offline

### DIFF
--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -148,6 +148,25 @@ func FilterAvailable(appliances []openapi.Appliance, stats []openapi.StatsApplia
 	return result, offline, err
 }
 
+func FilterOnline(appliances []openapi.Appliance, stats []openapi.StatsAppliancesListAllOfData) ([]openapi.Appliance, []openapi.Appliance, error) {
+	result := make([]openapi.Appliance, 0)
+	offline := make([]openapi.Appliance, 0)
+	var err error
+	// filter out offline appliances
+	for _, a := range appliances {
+		for _, stat := range stats {
+			if a.GetId() == stat.GetId() {
+				if StatsIsOnline(stat) {
+					result = append(result, a)
+				} else {
+					offline = append(offline, a)
+				}
+			}
+		}
+	}
+	return result, offline, err
+}
+
 func FilterActivated(appliances []openapi.Appliance) (active []openapi.Appliance, inactive []openapi.Appliance) {
 	inactive = []openapi.Appliance{}
 	active = []openapi.Appliance{}

--- a/pkg/appliance/prompt.go
+++ b/pkg/appliance/prompt.go
@@ -20,7 +20,7 @@ func PromptSelect(ctx context.Context, a *Appliance, filter map[string]map[strin
 	if err != nil {
 		return "", err
 	}
-	appliances, _, err = FilterAvailable(appliances, stats.GetData())
+	appliances, _, err = FilterOnline(appliances, stats.GetData())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This is so that `appliance logs` can work even if one of the controllers happens to be offline at the moment.