### PR TITLE
ZTP-3816 Upgrade should exclude Autoscaling Gateways

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -319,6 +319,7 @@ func prepareRun(cmd *cobra.Command, opts *prepareUpgradeOptions) error {
 			}
 		}
 		// Remove auto-scaled gateways from appliances to be upgraded
+		log.Info("excluding autoscaling gateways")
 		appliancesForUpgrade := make([]openapi.Appliance, 0)
 		for _, appliance := range appliances {
 			for _, gw := range gws {

--- a/pkg/appliance/checks.go
+++ b/pkg/appliance/checks.go
@@ -95,13 +95,10 @@ const autoScalingWarning = `
 There is an auto-scale template configured: {{ .Template.Name }}
 {{end}}
 
-Found {{ .Count }} auto-scaled gateway running version < 16:
+Found {{ .Count }} auto-scaled gateway(s):
 {{range .Appliances}}
   - {{.Name -}}
 {{end}}
-
-Make sure that the health check for those auto-scaled gateways is disabled.
-Not disabling the health checks in those auto-scaled gateways could cause them to be deleted, breaking all the connections established with them.
 `
 
 func ShowAutoscalingWarningMessage(templateAppliance *openapi.Appliance, gateways []openapi.Appliance) (string, error) {

--- a/pkg/appliance/checks_test.go
+++ b/pkg/appliance/checks_test.go
@@ -239,12 +239,9 @@ func TestShowAutoscalingWarningMessage(t *testing.T) {
 There is an auto-scale template configured: gateway template
 
 
-Found 1 auto-scaled gateway running version < 16:
+Found 1 auto-scaled gateway(s):
 
   - Autoscaling Instance gateway abc
-
-Make sure that the health check for those auto-scaled gateways is disabled.
-Not disabling the health checks in those auto-scaled gateways could cause them to be deleted, breaking all the connections established with them.
 `,
 			wantErr: false,
 		},

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -299,7 +299,7 @@ func AutoscalingGateways(appliances []openapi.Appliance) (*openapi.Appliance, []
 		if util.InSlice("template", a.GetTags()) && !a.GetActivated() {
 			template = &a
 		}
-		if v, ok := a.GetGatewayOk(); ok && v.GetEnabled() && strings.HasPrefix(a.GetName(), autoscalePrefix) {
+		if v, ok := a.GetGatewayOk(); ok && v.GetEnabled() && strings.Contains(a.GetName(), autoscalePrefix) {
 			r = append(r, a)
 		}
 	}


### PR DESCRIPTION
Autoscaling gateways are now excluded from appliances selected for upgrade. 