### PR TITLE
ZTP-3932 - Exclude multiple autoscaling gateways from upgrade

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -322,11 +322,15 @@ func prepareRun(cmd *cobra.Command, opts *prepareUpgradeOptions) error {
 		// Remove auto-scaled gateways from appliances to be upgraded
 		log.Info("excluding autoscaling gateways")
 		appliancesForUpgrade := make([]openapi.Appliance, 0)
+		// Build a map of autoscaling gateway ids
+		autoscalingGatewayIds := make(map[*string]bool)
+		for _, gw := range gws {
+			autoscalingGatewayIds[gw.Id] = true
+		}
+		// Select appliances that do not match the id of an autoscaling gateway
 		for _, appliance := range appliances {
-			for _, gw := range gws {
-				if appliance.Id != gw.Id {
-					appliancesForUpgrade = append(appliancesForUpgrade, appliance)
-				}
+			if !autoscalingGatewayIds[appliance.Id] {
+				appliancesForUpgrade = append(appliancesForUpgrade, appliance)
 			}
 		}
 		appliances = appliancesForUpgrade

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -322,14 +322,14 @@ func prepareRun(cmd *cobra.Command, opts *prepareUpgradeOptions) error {
 		// Remove auto-scaled gateways from appliances to be upgraded
 		log.Info("excluding autoscaling gateways")
 		appliancesForUpgrade := make([]openapi.Appliance, 0)
-		// Build a map of autoscaling gateway ids
-		autoscalingGatewayIds := make(map[*string]bool)
-		for _, gw := range gws {
-			autoscalingGatewayIds[gw.Id] = true
-		}
-		// Select appliances that do not match the id of an autoscaling gateway
 		for _, appliance := range appliances {
-			if !autoscalingGatewayIds[appliance.Id] {
+			isAutoscaling := false
+			for _, gw := range gws {
+				if appliance.Id == gw.Id {
+					isAutoscaling = true
+				}
+			}
+			if !isAutoscaling {
 				appliancesForUpgrade = append(appliancesForUpgrade, appliance)
 			}
 		}


### PR DESCRIPTION
A previous attempt to exclude autoscaling gateways from upgrades failed when there were multiple autoscaling gateways. Now, whether one or multiple, autoscaling gateways will be excluded from upgrades.