### PR TITLE
Translate additional information from old status endpoint

### DIFF
--- a/pkg/appliance/api.go
+++ b/pkg/appliance/api.go
@@ -211,9 +211,18 @@ func translateDeprecatedStatus(toTranslate *openapi.StatsAppliancesList) *openap
 			Memory:    status.Memory,
 			Disk:      status.Disk,
 			Details: &openapi.ApplianceWithStatusAllOfDetails{
+				Version:      status.Version,
+				VolumeNumber: openapi.PtrInt32(int32(*status.VolumeNumber)),
 				Cpu: &openapi.SystemInfo{
 					Percent: status.Cpu,
 				},
+				Memory: &openapi.SystemInfo{
+					Percent: status.Memory,
+				},
+				Disk: &openapi.SystemInfo{
+					Percent: status.Disk,
+				},
+				Status: status.Status,
 				Roles: &openapi.Roles{
 					Controller: &openapi.ControllerRole{
 						Status:          status.Controller.Status,
@@ -264,6 +273,16 @@ func translateDeprecatedStatus(toTranslate *openapi.StatsAppliancesList) *openap
 						RxSpeed: status.Network.RxSpeed,
 					},
 				},
+			}
+			newStatus.Details.Disk = &openapi.SystemInfo{
+				Total:   openapi.PtrInt64(int64(*status.DiskInfo.Total)),
+				Used:    openapi.PtrInt64(int64(*status.DiskInfo.Used)),
+				Free:    openapi.PtrInt64(int64(*status.DiskInfo.Free)),
+				Percent: status.Disk,
+			}
+			newStatus.Details.Upgrade = &openapi.ApplianceWithStatusAllOfDetailsUpgrade{
+				Status:  status.Upgrade.Status,
+				Details: status.Upgrade.Details,
 			}
 		}
 


### PR DESCRIPTION
We found another null pointer on upgrade-complete
```
[2025-05-29T14:56:25+09:00] Initializing upgrade:
 [COMPLETE] verifying states: ready
[2025-05-29T14:56:25+09:00] Upgrading the primary Controller:
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x1687d7c]
goroutine 1 [running]:
github.com/appgate/sdpctl/cmd/appliance/upgrade.upgradeCompleteRun.func3({_, _}, {0xc00034a140, {0xc0000a22a0, 0x11}, 0xc00034a150, 0xc000216648, 0xc000216660, {0x22498e0, 0x0, ...}, ...})
        github.com/appgate/sdpctl/cmd/appliance/upgrade/complete.go:330 +0x2fc
github.com/appgate/sdpctl/cmd/appliance/upgrade.upgradeCompleteRun(0xc000155808, {0x22498e0, 0x0, 0x0}, 0xc000226500)
        github.com/appgate/sdpctl/cmd/appliance/upgrade/complete.go:393 +0x2063
github.com/appgate/sdpctl/cmd/appliance/upgrade.NewUpgradeCompleteCmd.func2(0xc000155808, {0x22498e0, 0x0, 0x0})
        github.com/appgate/sdpctl/cmd/appliance/upgrade/complete.go:105 +0xa9
github.com/spf13/cobra.(*Command).execute(0xc000155808, {0x22498e0, 0x0, 0x0})
        github.com/spf13/cobra@v1.9.1/command.go:1015 +0xa94
github.com/spf13/cobra.(*Command).ExecuteC(0xc000154008)
        github.com/spf13/cobra@v1.9.1/command.go:1148 +0x40c
github.com/appgate/sdpctl/pkg/cmdutil.ExecuteCommand(0xc00020a380?)
        github.com/appgate/sdpctl/pkg/cmdutil/execute.go:44 +0x1f
github.com/appgate/sdpctl/cmd.Execute()
        github.com/appgate/sdpctl/cmd/root.go:255 +0x1a7
main.main()
        ./main.go:10 +0x13
```

We were not translating the following parameters from old status to new status endpoint:
- status.Details.Version
- status.Details.VolumeNumber
- status.Details.Memory
- status.Details.Disk
- status.Details.Status
- status.Details.Upgrade

The stacktrace shows that we were trying to get the status.Details.VolumeNumber 