### PR TITLE
Fix filtering for switch-partion and status

### DIFF
--- a/cmd/appliance/stats.go
+++ b/cmd/appliance/stats.go
@@ -59,7 +59,6 @@ func statsRun(cmd *cobra.Command, args []string, opts *statsOptions) error {
 	}
 	filter, orderBy, descending := util.ParseFilteringFlags(cmd.Flags(), appliancepkg.DefaultCommandFilter)
 	ctx := util.BaseAuthContext(a.Token)
-
 	stats, _, err := a.ApplianceStatus(ctx, filter, orderBy, descending)
 	if err != nil {
 		return err

--- a/cmd/appliance/switch_partition.go
+++ b/cmd/appliance/switch_partition.go
@@ -77,10 +77,10 @@ func NewSwitchPartitionCmd(f *factory.Factory) *cobra.Command {
 				return err
 			}
 			opts.api = api
-
+			filter, orderBy, descending := util.ParseFilteringFlags(cmd.Flags(), appliancepkg.DefaultCommandFilter)
 			ctx := util.BaseAuthContext(api.Token)
 			if opts.ids == nil {
-				ids, err := appliancepkg.PromptMultiSelect(ctx, api, nil, nil, false)
+				ids, err := appliancepkg.PromptMultiSelect(ctx, api, filter, orderBy, descending)
 				if err != nil {
 					return err
 				}

--- a/pkg/appliance/functions.go
+++ b/pkg/appliance/functions.go
@@ -651,7 +651,7 @@ func applyApplianceStatsFilter(stats []openapi.ApplianceWithStatus, filter map[s
 				functionList := strings.Split(v, FilterDelimiter)
 				for _, function := range functionList {
 					active := strings.Split(ApplianceActiveFunctions(s), ",")
-					if util.InSlice(function, active) {
+					if results := util.SearchSlice(function, active, true); len(results) > 0 {
 						filtered = append(filtered, s)
 					}
 				}

--- a/pkg/util/generics.go
+++ b/pkg/util/generics.go
@@ -1,6 +1,8 @@
 package util
 
-import "errors"
+import (
+	"errors"
+)
 
 func Find[A any](s []A, f func(A) bool) (A, error) {
 	var r A


### PR DESCRIPTION
Pass the filtering args when doing switch-partion
Fix a problem with stats filtering.  Filtering on function=controller didn't work, but other functions did. All functions should now be filterable and case insensitive.