### PR TITLE
Remote log bundle support

### DIFF
--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -176,7 +176,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 			if len(opts.logServerBundlePath) > 0 {
 				var bundlePath string
 				parsedURL, err := url.ParseRequestURI(opts.logServerBundlePath)
-				if err == nil && (parsedURL.Scheme == "http" || parsedURL.Scheme == "https") {
+				if err == nil && parsedURL.Scheme == "https" {
 					// Download the bundle to a temp file
 					client, err := opts.HTTPClient()
 					if err != nil {
@@ -224,6 +224,10 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 					fmt.Fprint(opts.Out, "LogServer bundle downloaded successfully\n")
 					bundlePath = tmpFile.Name()
 					opts.logServerBundlePath = bundlePath
+				}
+
+				if parsedURL.Scheme == "http"{
+					return fmt.Errorf("Plain HTTP URLs are not supported for LogServer bundle. Please use HTTPS URL instead")
 				}
 
 				opts.logServerBundlePath = filesystem.AbsolutePath(opts.logServerBundlePath)

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -270,7 +270,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 	flags.BoolVar(&opts.forcePrepare, "force", false, "Force prepare of upgrade on appliances even though the version uploaded is the same or lower than the version already running on the appliance")
 	flags.BoolVar(&opts.skipBundle, "skip-container-bundle", false, "skip the bundling of the docker images for functions that need them, e.g. the LogServer")
 	flags.String("docker-registry", "", "Custom docker registry for downloading function docker images. Needs to be accessible by the sdpctl host machine.")
-	flags.StringVar(&opts.logServerBundlePath, "logserver-bundle", "", "Path to a local LogServer image bundle file to upload and use when upgrading a LogServer appliance.")
+	flags.StringVar(&opts.logServerBundlePath, "logserver-bundle", "", "HTTP or local file path to a LogServer image bundle file to upload and use when upgrading a LogServer appliance.")
 
 	return prepareCmd
 }

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -270,7 +270,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 	flags.BoolVar(&opts.forcePrepare, "force", false, "Force prepare of upgrade on appliances even though the version uploaded is the same or lower than the version already running on the appliance")
 	flags.BoolVar(&opts.skipBundle, "skip-container-bundle", false, "skip the bundling of the docker images for functions that need them, e.g. the LogServer")
 	flags.String("docker-registry", "", "Custom docker registry for downloading function docker images. Needs to be accessible by the sdpctl host machine.")
-	flags.StringVar(&opts.logServerBundlePath, "logserver-bundle", "", "HTTP or local file path to a LogServer image bundle file to upload and use when upgrading a LogServer appliance.")
+	flags.StringVar(&opts.logServerBundlePath, "logserver-bundle", "", "URL or local file path to a LogServer image bundle file to upload and use when upgrading a LogServer appliance.")
 
 	return prepareCmd
 }

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -50,7 +50,7 @@ type prepareUpgradeOptions struct {
 	image               string
 	DevKeyring          bool
 	remoteImage         bool
-	remoteBundle    	bool
+	remoteBundle        bool
 	filename            string
 	timeout             time.Duration
 	defaultFilter       map[string]map[string]string
@@ -171,12 +171,12 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 					}
 				}
 			}
-			
+
 			opts.remoteBundle = false
 			if len(opts.logServerBundlePath) > 0 {
 				var bundlePath string
 				parsedURL, err := url.ParseRequestURI(opts.logServerBundlePath)
-				if err == nil && (parsedURL.Scheme == "http" || parsedURL.Scheme == "https") {			
+				if err == nil && (parsedURL.Scheme == "http" || parsedURL.Scheme == "https") {
 					// Download the bundle to a temp file
 					resp, err := http.Get(opts.logServerBundlePath)
 					if err != nil {
@@ -186,9 +186,9 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 					if resp.StatusCode != http.StatusOK {
 						return fmt.Errorf("failed to download LogServer bundle: HTTP %d", resp.StatusCode)
 					}
-					
-					id := uuid.New().String()	 				
-					
+
+					id := uuid.New().String()
+
 					tmpFile, err := os.CreateTemp("", id)
 					opts.remoteBundle = true
 					if err != nil {
@@ -201,8 +201,8 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 					}
 					bundlePath = tmpFile.Name()
 					opts.logServerBundlePath = bundlePath
-				} 
-				
+				}
+
 				opts.logServerBundlePath = filesystem.AbsolutePath(opts.logServerBundlePath)
 				ok, err := util.FileExists(opts.logServerBundlePath)
 				if err != nil {
@@ -578,9 +578,9 @@ func prepareRun(cmd *cobra.Command, opts *prepareUpgradeOptions) error {
 	}
 
 	if opts.remoteBundle && len(opts.logServerBundlePath) > 0 {
-        if err := os.Remove(opts.logServerBundlePath); err != nil && !os.IsNotExist(err) {
-            log.Warnf("Failed to delete temporary LogServer bundle file: %v", err)
-        }
+		if err := os.Remove(opts.logServerBundlePath); err != nil && !os.IsNotExist(err) {
+			log.Warnf("Failed to delete temporary LogServer bundle file: %v", err)
+		}
 	}
 
 	if opts.remoteImage && opts.hostOnController && existingFile.GetStatus() != appliancepkg.FileReady {

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -226,7 +226,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 					opts.logServerBundlePath = bundlePath
 				}
 
-				if parsedURL.Scheme == "http"{
+				if parsedURL.Scheme == "http" {
 					return fmt.Errorf("Plain HTTP URLs are not supported for LogServer bundle. Please use HTTPS URL instead")
 				}
 

--- a/cmd/appliance/upgrade/prepare.go
+++ b/cmd/appliance/upgrade/prepare.go
@@ -221,7 +221,7 @@ func NewPrepareUpgradeCmd(f *factory.Factory) *cobra.Command {
 					}
 
 					progress.Complete()
-					fmt.Fprintf(opts.Out, "LogServer bundle downloaded successfully\n")
+					fmt.Fprint(opts.Out, "LogServer bundle downloaded successfully\n")
 					bundlePath = tmpFile.Name()
 					opts.logServerBundlePath = bundlePath
 				}

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -642,6 +642,10 @@ func TestUpgradePrepareCommand(t *testing.T) {
 			f.APIClient = func(c *configuration.Config) (*openapi.APIClient, error) {
 				return registry.Client, nil
 			}
+			f.HTTPClient = func() (*http.Client, error) {
+				return registry.Client.GetConfig().HTTPClient, nil
+			}
+			f.SetSpinnerOutput(io.Discard) // Disable spinner output in tests
 			f.Appliance = func(c *configuration.Config) (*appliancepkg.Appliance, error) {
 				api, _ := f.APIClient(c)
 

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"html"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/appgate/sdp-api-client-go/api/v22/openapi"
@@ -64,6 +68,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 		cli                 string
 		askStubs            func(*prompt.PromptStubber)
 		httpStubs           []httpmock.Stub
+		tlsStubs            []httpmock.Stub // For HTTPS logserver bundle downloads
 		upgradeStatusWorker appliancepkg.WaitForUpgradeStatus
 		wantOut             *regexp.Regexp
 		wantErr             bool
@@ -500,6 +505,20 @@ func TestUpgradePrepareCommand(t *testing.T) {
 			askStubs: func(s *prompt.PromptStubber) {
 				s.StubOne(true) // upgrade_confirm
 			},
+			tlsStubs: []httpmock.Stub{
+				{
+					URL: "/logserver-6.5.image.zip",
+					Responder: func(rw http.ResponseWriter, r *http.Request) {
+						file, _ := os.Open("./testdata/appgate-6.2.2-9876.img.zip")
+						defer file.Close()
+
+						rw.Header().Set("Content-Type", "application/zip")
+						rw.Header().Set("Content-Disposition", "attachment; filename=logserver-6.5.image.zip")
+						rw.WriteHeader(http.StatusOK)
+						io.Copy(rw, file)
+					},
+				},
+			},
 			httpStubs: []httpmock.Stub{
 				{
 					URL:       "/admin/appliances",
@@ -512,18 +531,6 @@ func TestUpgradePrepareCommand(t *testing.T) {
 				{
 					URL:       "/admin/files/appgate-6.2.2-9876.img.zip",
 					Responder: httpmock.JSONResponse("../../../pkg/appliance/fixtures/upgrade_status_file.json"),
-				},
-				{
-					URL: "/logserver-6.5.image.zip",
-					Responder: func(rw http.ResponseWriter, r *http.Request) {
-						file, _ := os.Open("./testdata/appgate-6.2.2-9876.img.zip")
-						defer file.Close()
-
-						rw.Header().Set("Content-Type", "application/zip")
-						rw.Header().Set("Content-Disposition", "attachment; filename=logserver-6.5.image.zip")
-						rw.WriteHeader(http.StatusOK)
-						io.Copy(rw, file)
-					},
 				},
 				{
 					URL: "/admin/appliances/ee639d70-e075-4f01-596b-930d5f24f569/upgrade/prepare",
@@ -589,9 +596,16 @@ func TestUpgradePrepareCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "remote logserver bundle download failure - 404",
+			name:       "logserver bundle HTTP validation",
+			cli:        "upgrade prepare --image './testdata/appgate-6.2.2-9876.img.zip' --logserver-bundle 'http://example.com/bundle.zip'",
+			httpStubs:  []httpmock.Stub{},
+			wantErr:    true,
+			wantErrOut: regexp.MustCompile(`Plain HTTP URLs are not supported for LogServer bundle`),
+		},
+		{
+			name: "remote logserver bundle download failure - HTTPS 404",
 			cli:  "upgrade prepare --image './testdata/appgate-6.2.2-9876.img.zip' --logserver-bundle '%s/nonexistent-bundle.zip'",
-			httpStubs: []httpmock.Stub{
+			tlsStubs: []httpmock.Stub{
 				{
 					URL: "/nonexistent-bundle.zip",
 					Responder: func(rw http.ResponseWriter, r *http.Request) {
@@ -604,7 +618,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 		},
 		{
 			name:       "remote logserver bundle download failure - connection error",
-			cli:        "upgrade prepare --image './testdata/appgate-6.2.2-9876.img.zip' --logserver-bundle 'http://nonexistent.invalid.domain/bundle.zip'",
+			cli:        "upgrade prepare --image './testdata/appgate-6.2.2-9876.img.zip' --logserver-bundle 'https://nonexistent.invalid.domain.test/bundle.zip'",
 			httpStubs:  []httpmock.Stub{},
 			wantErr:    true,
 			wantErrOut: regexp.MustCompile(`failed to download LogServer bundle from URL`),
@@ -625,6 +639,17 @@ func TestUpgradePrepareCommand(t *testing.T) {
 
 			defer registry.Teardown()
 			registry.Serve()
+
+			// Set up TLS registry for HTTPS LogServer bundle downloads if needed
+			var tlsRegistry *TLSRegistry
+			if len(tt.tlsStubs) > 0 {
+				tlsRegistry = newTLSRegistry(t)
+				for _, v := range tt.tlsStubs {
+					tlsRegistry.Register(v.URL, v.Responder)
+				}
+				defer tlsRegistry.Teardown()
+				tlsRegistry.Serve()
+			}
 			stdout := &bytes.Buffer{}
 			stdin := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}
@@ -643,6 +668,10 @@ func TestUpgradePrepareCommand(t *testing.T) {
 				return registry.Client, nil
 			}
 			f.HTTPClient = func() (*http.Client, error) {
+				// Use TLS client if we have a TLS registry, otherwise use the regular client
+				if tlsRegistry != nil {
+					return tlsRegistry.server.Client(), nil
+				}
 				return registry.Client.GetConfig().HTTPClient, nil
 			}
 			f.SetSpinnerOutput(io.Discard) // Disable spinner output in tests
@@ -675,7 +704,12 @@ func TestUpgradePrepareCommand(t *testing.T) {
 
 			cli := tt.cli
 			if strings.Contains(tt.cli, "%s") {
-				cli = fmt.Sprintf(tt.cli, fmt.Sprintf("http://appgate.test:%d", registry.Port))
+				// Use TLS registry URL for HTTPS tests, otherwise use HTTP registry URL
+				if tlsRegistry != nil {
+					cli = fmt.Sprintf(tt.cli, tlsRegistry.URL())
+				} else {
+					cli = fmt.Sprintf(tt.cli, fmt.Sprintf("http://appgate.test:%d", registry.Port))
+				}
 			}
 
 			argv, err := shlex.Split(cli)
@@ -1060,4 +1094,77 @@ controllers are prepared for upgrade when running 'upgrade complete'.
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TLSRegistry wraps an HTTP test server with HTTPS capabilities for testing LogServer bundle downloads
+type TLSRegistry struct {
+	Client   *openapi.APIClient
+	cfg      *openapi.Configuration
+	Mux      *http.ServeMux
+	server   *httptest.Server
+	Port     int
+	Teardown func()
+	stubs    []*httpmock.Stub
+	mu       sync.Mutex
+	notFound []string
+}
+
+// newTLSRegistry creates a new TLS-enabled registry for HTTPS testing
+func newTLSRegistry(t *testing.T) *TLSRegistry {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	clientCfg := openapi.NewConfiguration()
+	clientCfg.HTTPClient = server.Client()
+	c := openapi.NewAPIClient(clientCfg)
+
+	port := server.Listener.Addr().(*net.TCPAddr).Port
+
+	r := &TLSRegistry{
+		Client:   c,
+		cfg:      clientCfg,
+		Mux:      mux,
+		server:   server,
+		Port:     port,
+		Teardown: server.Close,
+	}
+
+	return r
+}
+
+// Register adds a stub to the TLS registry
+func (r *TLSRegistry) Register(url string, resp http.HandlerFunc) {
+	r.stubs = append(r.stubs, &httpmock.Stub{
+		URL:       url,
+		Responder: resp,
+	})
+}
+
+// stubMiddleware tracks which stubs were matched (similar to httpmock.Registry)
+func (r *TLSRegistry) stubMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, request *http.Request) {
+		r.mu.Lock()
+		next.ServeHTTP(rw, request)
+		r.mu.Unlock()
+	})
+}
+
+// Serve sets up the TLS server handlers
+func (r *TLSRegistry) Serve() {
+	for _, stub := range r.stubs {
+		r.Mux.Handle(stub.URL, r.stubMiddleware(stub.Responder))
+	}
+	r.Mux.HandleFunc("/", func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/" {
+			rw.WriteHeader(http.StatusNotFound)
+			r.notFound = append(r.notFound, req.Method+" "+html.EscapeString(req.URL.Path))
+			return
+		}
+	})
+}
+
+// URL returns the HTTPS URL of the TLS server
+func (r *TLSRegistry) URL() string {
+	return r.server.URL
 }

--- a/cmd/appliance/upgrade/prepare_test.go
+++ b/cmd/appliance/upgrade/prepare_test.go
@@ -518,7 +518,7 @@ func TestUpgradePrepareCommand(t *testing.T) {
 					Responder: func(rw http.ResponseWriter, r *http.Request) {
 						file, _ := os.Open("./testdata/appgate-6.2.2-9876.img.zip")
 						defer file.Close()
-						
+
 						rw.Header().Set("Content-Type", "application/zip")
 						rw.Header().Set("Content-Disposition", "attachment; filename=logserver-6.5.image.zip")
 						rw.WriteHeader(http.StatusOK)
@@ -589,8 +589,8 @@ func TestUpgradePrepareCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:       "remote logserver bundle download failure - 404",
-			cli:        "upgrade prepare --image './testdata/appgate-6.2.2-9876.img.zip' --logserver-bundle 'http://127.0.0.1:8080/nonexistent-bundle.zip'",
+			name: "remote logserver bundle download failure - 404",
+			cli:  "upgrade prepare --image './testdata/appgate-6.2.2-9876.img.zip' --logserver-bundle 'http://127.0.0.1:8080/nonexistent-bundle.zip'",
 			httpStubs: []httpmock.Stub{
 				{
 					URL: "/nonexistent-bundle.zip",

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -181,8 +181,8 @@ func (f *FileManager) Upload(ctx context.Context, q QueueItem) error {
 		return err
 	}
 	return func(ctx context.Context, api *appliancepkg.Appliance) error {
-		return backoff.Retry(func() error {
-			v, err := api.FileStatus(ctx, name)
+		return backoff.Retry(func() error {		
+			v, err := api.FileStatus(ctx, uploadName)
 			if err != nil {
 				if t != nil {
 					t.Fail(err.Error())

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -181,7 +181,7 @@ func (f *FileManager) Upload(ctx context.Context, q QueueItem) error {
 		return err
 	}
 	return func(ctx context.Context, api *appliancepkg.Appliance) error {
-		return backoff.Retry(func() error {		
+		return backoff.Retry(func() error {
 			v, err := api.FileStatus(ctx, uploadName)
 			if err != nil {
 				if t != nil {


### PR DESCRIPTION
Adds remote log bundle support. 

When the user specifies a log bundle as an http path the file is downloaded to a local temp file and that local temp file is used to complete the upgrade prepare. 

Example use:

`./sdpctl appliance upgrade prepare --image=~/Downloads/appgate/Appgate-SDP-6.5.0.img.zip --logserver-bundle=http://127.0.0.1:8080/logserver-6.5.image.zip`