### PR TITLE
Apply backup password character restrictions

### DIFF
--- a/cmd/appliance/backup/api.go
+++ b/cmd/appliance/backup/api.go
@@ -91,7 +91,7 @@ func backupAPIrun(cmd *cobra.Command, args []string, opts *apiOptions) error {
 		if err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
 			hasStdin = true
 		}
-		answer, err := prompt.GetPassphrase(opts.In, !opts.NoInteractive, hasStdin, "The passphrase to encrypt the appliance backups when the Backup API is used:")
+		answer, err := prompt.GetBackupPassphrase(opts.In, !opts.NoInteractive, hasStdin, "The passphrase to encrypt the appliance backups when the Backup API is used:")
 		if err != nil {
 			return err
 		}

--- a/pkg/appliance/backup.go
+++ b/pkg/appliance/backup.go
@@ -460,13 +460,13 @@ func backupEnabled(ctx context.Context, client *openapi.APIClient, token string,
 	enabled := settings.GetBackupApiEnabled()
 	if !enabled && !noInteraction {
 		log.Warn("Backup API is disabled on the appliance")
-		shouldEnable, err := prompt.PromptConfirm("Backup API is disabld on the appliance. Do you want to enable it now?", true)
+		shouldEnable, err := prompt.PromptConfirm("Backup API is disabled on the appliance. Do you want to enable it now?", true)
 		if err != nil {
 			return false, err
 		}
 		if shouldEnable {
 			settings.SetBackupApiEnabled(true)
-			password, err := prompt.PasswordConfirmation("The passphrase to encrypt the appliance backups when the Backup API is used:")
+			password, err := prompt.BackupPasswordConfirmation("The passphrase to encrypt the appliance backups when the Backup API is used:")
 			if err != nil {
 				return false, err
 			}

--- a/pkg/prompt/password.go
+++ b/pkg/prompt/password.go
@@ -4,10 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/appgate/sdpctl/pkg/cmdutil"
 )
+
+var allowedSpecialChars = `!@#$%^&*()_+\-=\[\]{}|;':",./<>?~$`
+var PassphraseInvalidMessage = fmt.Sprintf("Passphrase contains invalid characters. Only alphanumeric characters and the folowing special characters are permitted:%v", allowedSpecialChars)
 
 func PasswordConfirmation(message string) (string, error) {
 	firstAnswer, err := PromptPassword(message)
@@ -26,7 +30,7 @@ func PasswordConfirmation(message string) (string, error) {
 
 // GetPassphrase check stdin if we have anything, and use that as passphrase
 // otherwise, if we can prompt, Prompt user input
-func GetPassphrase(stdIn io.Reader, canPrompt, hasStdin bool, message string) (string, error) {
+func GetPassphrase(stdIn io.Reader, canPrompt bool, hasStdin bool, message string) (string, error) {
 	if hasStdin {
 		buf, err := io.ReadAll(stdIn)
 		if err != nil {
@@ -38,4 +42,74 @@ func GetPassphrase(stdIn io.Reader, canPrompt, hasStdin bool, message string) (s
 		return "", cmdutil.ErrMissingTTY
 	}
 	return PasswordConfirmation(message)
+}
+
+// ValidateBackupPassphrase validates that a passphrase contains only allowed characters:
+// alphanumeric characters (a-z, A-Z, 0-9) and common printable special characters.
+// It rejects spaces, tabs, and exotic unicode characters like emojis.
+func ValidateBackupPassphrase(passphrase string) error {
+	if passphrase == "" {
+		return errors.New("passphrase cannot be empty")
+	}
+
+	// Allow alphanumeric characters and common printable special characters
+	// Explicitly exclude spaces, tabs, and unicode characters outside basic ASCII printable range
+	allowedPattern := "^[a-zA-Z0-9" + allowedSpecialChars + "]+$"
+	matched, err := regexp.MatchString(allowedPattern, passphrase)
+	if err != nil {
+		return fmt.Errorf("failed to validate passphrase: %w", err)
+	}
+
+	if !matched {
+		return errors.New(PassphraseInvalidMessage)
+	}
+
+	return nil
+}
+
+// GetBackupPassphrase checks stdin if we have anything, and use that as passphrase
+// otherwise, if we can prompt, prompt user input with validation for backup passphrases
+func GetBackupPassphrase(stdIn io.Reader, canPrompt bool, hasStdin bool, message string) (string, error) {
+	if hasStdin {
+		buf, err := io.ReadAll(stdIn)
+		if err != nil {
+			return "", fmt.Errorf("could not read input from stdin %s", err)
+		}
+		passphrase := strings.TrimSuffix(string(buf), "\n")
+		if err := ValidateBackupPassphrase(passphrase); err != nil {
+			return "", err
+		}
+		return passphrase, nil
+	}
+	if !canPrompt {
+		return "", cmdutil.ErrMissingTTY
+	}
+	return BackupPasswordConfirmation(message)
+}
+
+// BackupPasswordConfirmation prompts for a backup passphrase with validation
+func BackupPasswordConfirmation(message string) (string, error) {
+	for {
+		firstAnswer, err := PromptPassword(message)
+		if err != nil {
+			return "", err
+		}
+
+		if err := ValidateBackupPassphrase(firstAnswer); err != nil {
+			fmt.Printf("Error: %s\n", err.Error())
+			continue
+		}
+
+		secondAnswer, err := PromptPassword("Confirm your passphrase:")
+		if err != nil {
+			return "", err
+		}
+
+		if firstAnswer != secondAnswer {
+			fmt.Println("Error: The passphrase did not match")
+			continue
+		}
+
+		return firstAnswer, nil
+	}
 }


### PR DESCRIPTION
Previously we allowed any unicode input for the backup password phrase. This resulted in some weird corners cases when you used certain exotic characters. For simplicity this PR restricts allowed phrases to alphanumeric characters and the following special characters: !@#$%^&*()_+\-=\[\]{}|;':",./<>?~$