### PR TITLE
Handle Ctrl-Z and Ctrl-C When in Prompts

### DIFF
--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -62,7 +62,9 @@ func (m textInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			fmt.Println(m.textinput.Value())
-			return m, tea.Quit
+			return m, tea.Interrupt
+		case tea.KeyCtrlZ:
+			return m, tea.Suspend
 		case tea.KeyEnter:
 			m.quitting = true
 			return m, tea.Quit

--- a/pkg/prompt/selector.go
+++ b/pkg/prompt/selector.go
@@ -82,7 +82,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
-		case "q", "ctrl+c":
+		case "ctrl+c":
+			return m, tea.Interrupt
+		case "ctrl+z":
+			return m, tea.Suspend
+		case "q":
 			m.quitting = true
 			return m, tea.Quit
 


### PR DESCRIPTION
Use proper bubbletea commands to handle ctrl-z and ctrl-c inputs.