### PR TITLE
use Config.BearerToken when Token is empty

### DIFF
--- a/cmd/serviceusers/create.go
+++ b/cmd/serviceusers/create.go
@@ -51,7 +51,11 @@ func serviceUserCreateRun(cmd *cobra.Command, args []string, opts ServiceUsersOp
 		return err
 	}
 
-	ctx := util.BaseAuthContext(opts.Token)
+	token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
+	if err != nil {
+		return fmt.Errorf("Failed to get token: %w", err)
+	}
+	ctx := util.BaseAuthContext(token)
 
 	fromFile, err := cmd.Flags().GetString("from-file")
 	if err != nil {

--- a/cmd/serviceusers/create.go
+++ b/cmd/serviceusers/create.go
@@ -51,11 +51,7 @@ func serviceUserCreateRun(cmd *cobra.Command, args []string, opts ServiceUsersOp
 		return err
 	}
 
-	token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
-	if err != nil {
-		return fmt.Errorf("Failed to get token: %w", err)
-	}
-	ctx := util.BaseAuthContext(token)
+	ctx := util.BaseAuthContext(api.Token)
 
 	fromFile, err := cmd.Flags().GetString("from-file")
 	if err != nil {

--- a/cmd/serviceusers/delete.go
+++ b/cmd/serviceusers/delete.go
@@ -35,15 +35,11 @@ func NewServiceUsersDeleteCMD(f *factory.Factory) *cobra.Command {
 			return errs.ErrorOrNil()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
-			if err != nil {
-				return fmt.Errorf("Failed to get token: %w", err)
-			}
-			ctx := util.BaseAuthContext(token)
 			api, err := opts.API(opts.Config)
 			if err != nil {
 				return err
 			}
+			ctx := util.BaseAuthContext(api.Token)
 
 			ids := []string{}
 			if len(args) > 0 {

--- a/cmd/serviceusers/delete.go
+++ b/cmd/serviceusers/delete.go
@@ -35,7 +35,11 @@ func NewServiceUsersDeleteCMD(f *factory.Factory) *cobra.Command {
 			return errs.ErrorOrNil()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := util.BaseAuthContext(opts.Token)
+			token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
+			if err != nil {
+				return fmt.Errorf("Failed to get token: %w", err)
+			}
+			ctx := util.BaseAuthContext(token)
 			api, err := opts.API(opts.Config)
 			if err != nil {
 				return err

--- a/cmd/serviceusers/get.go
+++ b/cmd/serviceusers/get.go
@@ -31,15 +31,11 @@ func NewServiceUsersGetCMD(f *factory.Factory) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
-			if err != nil {
-				return fmt.Errorf("Failed to get token: %w", err)
-			}
-			ctx := util.BaseAuthContext(token)
 			api, err := opts.API(opts.Config)
 			if err != nil {
 				return err
 			}
+			ctx := util.BaseAuthContext(api.Token)
 
 			id := args[0]
 			user, err := api.Read(ctx, id)

--- a/cmd/serviceusers/get.go
+++ b/cmd/serviceusers/get.go
@@ -31,7 +31,11 @@ func NewServiceUsersGetCMD(f *factory.Factory) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := util.BaseAuthContext(opts.Token)
+			token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
+			if err != nil {
+				return fmt.Errorf("Failed to get token: %w", err)
+			}
+			ctx := util.BaseAuthContext(token)
 			api, err := opts.API(opts.Config)
 			if err != nil {
 				return err

--- a/cmd/serviceusers/list.go
+++ b/cmd/serviceusers/list.go
@@ -1,7 +1,6 @@
 package serviceusers
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/appgate/sdpctl/pkg/docs"
@@ -29,11 +28,8 @@ func NewServiceUsersListCMD(f *factory.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
-			if err != nil {
-				return fmt.Errorf("Failed to get token: %w", err)
-			}
-			ctx := util.BaseAuthContext(token)
+
+			ctx := util.BaseAuthContext(api.Token)
 
 			users, err := api.List(ctx)
 			if err != nil {

--- a/cmd/serviceusers/list.go
+++ b/cmd/serviceusers/list.go
@@ -1,6 +1,7 @@
 package serviceusers
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/appgate/sdpctl/pkg/docs"
@@ -28,7 +29,11 @@ func NewServiceUsersListCMD(f *factory.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ctx := util.BaseAuthContext(opts.Token)
+			token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
+			if err != nil {
+				return fmt.Errorf("Failed to get token: %w", err)
+			}
+			ctx := util.BaseAuthContext(token)
 
 			users, err := api.List(ctx)
 			if err != nil {

--- a/cmd/serviceusers/update.go
+++ b/cmd/serviceusers/update.go
@@ -49,15 +49,11 @@ func NewServiceUsersUpdateCMD(f *factory.Factory) *cobra.Command {
 }
 
 func serviceUserUpdateRun(cmd *cobra.Command, args []string, opts ServiceUsersOptions) error {
-	token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
-	if err != nil {
-		return fmt.Errorf("Failed to get token: %w", err)
-	}
-	ctx := util.BaseAuthContext(token)
 	api, err := opts.API(opts.Config)
 	if err != nil {
 		return err
 	}
+	ctx := util.BaseAuthContext(api.Token)
 
 	id := args[0]
 	toUpdate, err := api.Read(ctx, id)

--- a/cmd/serviceusers/update.go
+++ b/cmd/serviceusers/update.go
@@ -1,7 +1,6 @@
 package serviceusers
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,7 +16,9 @@ import (
 )
 
 func NewServiceUsersUpdateCMD(f *factory.Factory) *cobra.Command {
+	token, _ := f.Config.GetBearTokenHeaderValue()
 	opts := ServiceUsersOptions{
+		Token:  token,
 		Config: f.Config,
 		API:    f.ServiceUsers,
 		Out:    f.IOOutWriter,
@@ -48,7 +49,11 @@ func NewServiceUsersUpdateCMD(f *factory.Factory) *cobra.Command {
 }
 
 func serviceUserUpdateRun(cmd *cobra.Command, args []string, opts ServiceUsersOptions) error {
-	ctx := context.Background()
+	token, err := util.TokenFromConfig(opts.Token, opts.Config.BearerToken)
+	if err != nil {
+		return fmt.Errorf("Failed to get token: %w", err)
+	}
+	ctx := util.BaseAuthContext(token)
 	api, err := opts.API(opts.Config)
 	if err != nil {
 		return err

--- a/pkg/serviceusers/api.go
+++ b/pkg/serviceusers/api.go
@@ -9,13 +9,13 @@ import (
 
 type ServiceUsersAPI struct {
 	client *openapi.ServiceUsersApiService
-	token  string
+	Token  string
 }
 
 func NewServiceUsersAPI(client *openapi.ServiceUsersApiService, token string) *ServiceUsersAPI {
 	return &ServiceUsersAPI{
 		client: client,
-		token:  token,
+		Token:  token,
 	}
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -212,3 +212,13 @@ func BaseAuthContext(token string) context.Context {
 	ctx := context.Background()
 	return context.WithValue(ctx, openapi.ContextAccessToken, token)
 }
+
+func TokenFromConfig(token string, bearerToken *string) (string, error) {
+	if token != "" {
+		return token, nil
+	}
+	if bearerToken != nil {
+		return *bearerToken, nil
+	}
+	return "", fmt.Errorf("Credentials are not set, please use the 'login' command to authenticate first")
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -212,13 +212,3 @@ func BaseAuthContext(token string) context.Context {
 	ctx := context.Background()
 	return context.WithValue(ctx, openapi.ContextAccessToken, token)
 }
-
-func TokenFromConfig(token string, bearerToken *string) (string, error) {
-	if token != "" {
-		return token, nil
-	}
-	if bearerToken != nil {
-		return *bearerToken, nil
-	}
-	return "", fmt.Errorf("Credentials are not set, please use the 'login' command to authenticate first")
-}


### PR DESCRIPTION
Depending on how the auth token is provided (system keyring, environment variables, username/password prompt) Token may not be populated. Add a check to use Token or Confg.BearerToken depending on which one is defined.