### PR TITLE
Make message less error-like

### DIFF
--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -37,4 +37,6 @@ var (
 	ErrUnsupportedOperation = errors.New("Operation not supported on your appliance version")
 	// ErrControllerMaintenanceMode is used when trying to connect to appliance where maintenance mode is enabled
 	ErrControllerMaintenanceMode = errors.New("controller seem to be in maintenance mode")
+	// ErrNoUpgradeAvailable is used when there are no upgrades available for the appliance
+	ErrNoUpgradeAvailable = errors.New("Could not perform upgrade.\nAppliances are already running a version higher or equal to the version provided")
 )

--- a/pkg/cmdutil/execute.go
+++ b/pkg/cmdutil/execute.go
@@ -82,7 +82,7 @@ func ExecuteCommand(cmd *cobra.Command) ExitCode {
 
 		// if error is ErrNothingToUpgrade, exit with zero code
 		if errors.Is(err, ErrNothingToPrepare) {
-			fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+			fmt.Fprintln(cmd.ErrOrStderr(), ErrNoUpgradeAvailable)
 			return ExitOK
 		}
 


### PR DESCRIPTION
Make the message less error-like when the version provided is greater than or equal to the provided version.