### PR TITLE
Calculate Batches Better and Avoid Empty Batches

### DIFF
--- a/pkg/appliance/mock.go
+++ b/pkg/appliance/mock.go
@@ -26,6 +26,15 @@ const (
 	TestApplianceGatewayA1                = "gatewayA1"
 	TestApplianceGatewayA2                = "gatewayA2"
 	TestApplianceGatewayA3                = "gatewayA3"
+	TestApplianceGatewayA4                = "gatewayA4"
+	TestApplianceGatewayA5                = "gatewayA5"
+	TestApplianceGatewayA6                = "gatewayA6"
+	TestApplianceGatewayA7                = "gatewayA7"
+	TestApplianceGatewayA8                = "gatewayA8"
+	TestApplianceGatewayA9                = "gatewayA9"
+	TestApplianceGatewayA10               = "gatewayA10"
+	TestApplianceGatewayA11               = "gatewayA11"
+	TestApplianceGatewayA12               = "gatewayA12"
 	TestApplianceGatewayB1                = "gatewayB1"
 	TestApplianceGatewayB2                = "gatewayB2"
 	TestApplianceGatewayB3                = "gatewayB3"
@@ -97,7 +106,7 @@ func GenerateCollective(t *testing.T, hostname, from, to string, appliances []st
 			res.addAppliance(n, "", siteA, siteNameA, "6.1", from, statusHealthy, UpgradeStatusReady, []string{FunctionController})
 		case TestApplianceControllerGatewayPrimary:
 			res.addAppliance(n, hostname, siteA, siteNameA, from, to, statusHealthy, UpgradeStatusReady, []string{FunctionController, FunctionGateway})
-		case TestApplianceGatewayA1, TestApplianceGatewayA2, TestApplianceGatewayA3:
+		case TestApplianceGatewayA1, TestApplianceGatewayA2, TestApplianceGatewayA3, TestApplianceGatewayA4, TestApplianceGatewayA5, TestApplianceGatewayA6, TestApplianceGatewayA7, TestApplianceGatewayA8, TestApplianceGatewayA9, TestApplianceGatewayA10, TestApplianceGatewayA11, TestApplianceGatewayA12:
 			res.addAppliance(n, "", siteA, siteNameA, from, to, statusHealthy, UpgradeStatusReady, []string{FunctionGateway})
 		case TestApplianceGatewayB1, TestApplianceGatewayB2, TestApplianceGatewayB3:
 			res.addAppliance(n, "", siteB, siteNameB, from, to, statusHealthy, UpgradeStatusReady, []string{FunctionGateway})

--- a/pkg/appliance/upgrade.go
+++ b/pkg/appliance/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"slices"
 	"strings"
 	"text/template"
@@ -216,6 +217,14 @@ func createBatches(batchCount, maxUnavailable int, gateways, logforwarders map[s
 	for _, o := range other {
 		resultIndex = util.SmallestGroupIndex(result)
 		result[resultIndex] = append(result[resultIndex], o)
+	}
+
+	//remove empty groups
+	for i := 0; i < len(result); i++ {
+		if len(result[i]) == 0 {
+			result = append(result[:i], result[i+1:]...)
+			i--
+		}
 	}
 
 	// sort the resulting groups
@@ -595,9 +604,7 @@ func calculateBatches(gatewaysBySite, logForwardersBySite map[string][]openapi.A
 		if batches == maxUnavailable || batches < maxUnavailable {
 			return 1
 		}
-		for batches%maxUnavailable != 0 {
-			batches--
-		}
+		batches = int(math.Ceil(float64(batches) / float64(maxUnavailable)))
 	}
 
 	return batches

--- a/pkg/appliance/upgrade_test.go
+++ b/pkg/appliance/upgrade_test.go
@@ -52,6 +52,7 @@ func TestMakeUpgradePlan(t *testing.T) {
 
 	type args struct {
 		maxUnavailable int
+		filter         map[string]map[string]string
 	}
 	tests := []struct {
 		name    string
@@ -145,6 +146,44 @@ func TestMakeUpgradePlan(t *testing.T) {
 			},
 		},
 		{
+			name: "test batch creation with high max unavailable",
+			args: args{
+				maxUnavailable: 9,
+			},
+			want: testUpgradePlan{
+				PrimaryController: TestAppliancePrimary,
+				Controllers:       []string{TestApplianceSecondary},
+				Batches: [][]string{
+					{"gatewayA1", "gatewayA10", "gatewayA11", "gatewayA12", "gatewayA2", "gatewayA3", "gatewayA4", "gatewayA5", "gatewayA6", "gatewayB1", "gatewayB2", "logforwarderA1", "logforwarderA2"},
+					{"connectorA1", "gatewayA7", "gatewayA8", "gatewayA9", "gatewayC1", "gatewayC2", "logserver", "portalA1"},
+				},
+				input: []string{
+					"gatewayA1",
+					"gatewayA2",
+					"gatewayA3",
+					"gatewayA4",
+					"gatewayA5",
+					"gatewayA6",
+					"gatewayA7",
+					"gatewayA8",
+					"gatewayA9",
+					"gatewayA10",
+					"gatewayA11",
+					"gatewayA12",
+					"gatewayB1",
+					"gatewayB2",
+					"logserver",
+					"logforwarderA1",
+					"logforwarderA2",
+					"connectorA1",
+					"gatewayC1",
+					"secondary",
+					"gatewayC2",
+					"portalA1",
+				},
+			},
+		},
+		{
 			name: "test grouping with no other batches",
 			args: args{
 				maxUnavailable: 1,
@@ -163,7 +202,7 @@ func TestMakeUpgradePlan(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			hostname := "appgate.test"
 			coll := GenerateCollective(t, hostname, "6.3.5", "6.4.1", tt.want.allApplianceNames())
-			got, err := NewUpgradePlan(coll.GetAppliances(), coll.Stats, coll.GetUpgradeStatusMap(), hostname, nil, nil, false, tt.args.maxUnavailable)
+			got, err := NewUpgradePlan(coll.GetAppliances(), coll.Stats, coll.GetUpgradeStatusMap(), hostname, tt.args.filter, nil, false, tt.args.maxUnavailable)
 			if tt.wantErr {
 				assert.Error(t, err)
 			}
@@ -618,6 +657,30 @@ func Test_calculateBatches(t *testing.T) {
 					TestApplianceGatewayB3,
 				},
 				maxUnavailable: 2,
+			},
+			want: 2,
+		},
+		{
+			name: "12 appliances with max unavailable 9",
+			args: args{
+				appliances: []string{
+					TestApplianceGatewayA1,
+					TestApplianceGatewayA2,
+					TestApplianceGatewayA3,
+					TestApplianceGatewayA4,
+					TestApplianceGatewayA5,
+					TestApplianceGatewayA6,
+					TestApplianceGatewayA7,
+					TestApplianceGatewayA8,
+					TestApplianceGatewayA9,
+					TestApplianceGatewayA10,
+					TestApplianceGatewayA11,
+					TestApplianceGatewayA12,
+					TestApplianceGatewayB1,
+					TestApplianceGatewayB2,
+					TestApplianceGatewayB3,
+				},
+				maxUnavailable: 9,
 			},
 			want: 2,
 		},


### PR DESCRIPTION
Calculate the number of batches needed based on the size of the biggest site divided by maxUnavailable. Remove empty batches if they occur to avoid errors.