### PR TITLE
Fix profile path

### DIFF
--- a/cmd/profile/set_test.go
+++ b/cmd/profile/set_test.go
@@ -3,6 +3,8 @@ package profile
 import (
 	"bytes"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -63,6 +65,38 @@ staging is not configured yet, run 'sdpctl configure'
 
 	if diff := cmp.Diff(want, gotStr); diff != "" {
 		t.Errorf("List output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNewSetCmdSetConfiguredProfile(t *testing.T) {
+	dir, _ := setupExistingProfiles(t)
+	configPath := filepath.Join(dir, "profiles", "staging", "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"url":"https://controller.example.com:8443/admin"}`), 0600); err != nil {
+		t.Fatalf("failed to create profile config %s", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	opts := &commandOpts{
+		Out: stdout,
+	}
+	cmd := NewSetCmd(opts)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"staging"})
+	if _, err := cmd.ExecuteC(); err != nil {
+		t.Fatalf("executeC %s", err)
+	}
+
+	got, err := io.ReadAll(stdout)
+	if err != nil {
+		t.Fatalf("unable to read stdout %s", err)
+	}
+	gotStr := string(got)
+	want := `staging is selected as current sdp profile
+`
+
+	if diff := cmp.Diff(want, gotStr); diff != "" {
+		t.Errorf("Set output mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/profiles/profile.go
+++ b/pkg/profiles/profile.go
@@ -89,7 +89,7 @@ type Profile struct {
 }
 
 func (p *Profile) GetConfigurationPath() string {
-	return filepath.Join(p.Directory, p.Name, "config.json")
+	return filepath.Join(p.Directory, "config.json")
 }
 
 func (p *Profile) GetLogPath() string {


### PR DESCRIPTION
## Fix false "not configured yet" warning when switching profiles

 ### Summary
 `sdpctl profile set <name>` printed `<name> is not configured yet, run 'sdpctl configure'`
 for profiles that were already fully configured.

 ### Root cause
 A profile's `Directory` already ends in the profile name (e.g. `…/profiles/staging`),
 but `Profile.GetConfigurationPath()` appended the name a second time:

     filepath.Join(p.Directory, p.Name, "config.json")
     -> …/profiles/staging/staging/config.json   (never exists)

 `CurrentConfigExists()` checks that path, so it always reported the profile as
 unconfigured and `profile set` emitted the bogus warning.

 ### Fix
 Drop the redundant name segment so the lookup matches where `configure` actually
 writes the file (and stays consistent with `GetConfigPath()`):

     filepath.Join(p.Directory, "config.json")

 ### Testing
 - New regression test `TestNewSetCmdSetConfiguredProfile` (cmd/profile/set_test.go):
   writes a real config at the correct path and asserts `profile set` prints only the
   "selected" line with no false warning. Fails before the fix, passes after.
 - `go test ./cmd/profile ./pkg/profiles` passes.
 - Verified end-to-end against a live SDP collective: configured a profile against a real
   controller, confirmed `appliance list` works, and confirmed `profile set` no longer
   prints the false warning (while the pre-fix build still does).
